### PR TITLE
Add MAIVE modal footer with app version

### DIFF
--- a/apps/react-ui/client/src/components/Modals/MAIVEInfoModal.tsx
+++ b/apps/react-ui/client/src/components/Modals/MAIVEInfoModal.tsx
@@ -4,6 +4,7 @@ import TEXT from "@lib/text";
 import CONST from "@src/CONST";
 import Link from "next/link";
 import BaseModal from "./BaseModal";
+import { version } from "../../../package.json";
 
 type MAIVEInfoModalProps = {
   isOpen: boolean;
@@ -30,143 +31,146 @@ export default function MAIVEInfoModal({
         </h2>
       </div>
 
-      <div className="p-6 space-y-6">
-        <section>
-          <h3 className="text-xl font-semibold text-primary mb-3">
-            {TEXT.maiveModal.overview.title}
-          </h3>
-          <div className="text-secondary leading-relaxed">
-            <MDXContent source={TEXT.maiveModal.overview.text} lineMargin={4} />
-          </div>
-        </section>
-
-        <section>
-          <h3 className="text-xl font-semibold text-primary mb-3">
-            {TEXT.maiveModal.howItWorks.title}
-          </h3>
-          <div className="space-y-3 text-secondary">
-            {TEXT.maiveModal.howItWorks.text.map((step, index) => (
-              <div key={index} className="leading-relaxed">
-                <MDXContent source={step} />
-              </div>
-            ))}
-          </div>
-        </section>
-
-        <section>
-          <h3 className="text-xl font-semibold text-primary mb-3">
-            {TEXT.maiveModal.keyFeatures.title}
-          </h3>
-          <ul className="list-disc list-inside space-y-2 text-secondary">
-            {TEXT.maiveModal.keyFeatures.text.map((feature) => (
-              <li key={feature.head}>
-                <strong>{feature.head}:</strong> {feature.text}
-              </li>
-            ))}
-          </ul>
-        </section>
-
-        <section>
-          <h3 className="text-xl font-semibold text-primary mb-3">
-            {TEXT.maiveModal.applications.title}
-          </h3>
-          <div className="grid md:grid-cols-2 gap-4">
-            {TEXT.maiveModal.applications.text.map((application) => (
-              <div
-                key={application.head}
-                className="bg-surface-secondary p-4 rounded-lg"
-              >
-                <h4 className="font-semibold text-primary mb-2">
-                  {application.head}
-                </h4>
-                <p className="text-sm text-muted">{application.text}</p>
-              </div>
-            ))}
-          </div>
-        </section>
-
-        <section>
-          <h3 className="text-xl font-semibold text-primary mb-3">
-            {TEXT.maiveModal.papersAndResources.title}
-          </h3>
-          <div className="space-y-3">
-            <div className="border-l-4 border-primary-500 pl-4">
-              <h4 className="font-semibold text-primary">
-                {TEXT.maiveModal.papersAndResources.maiveWebsite.head}
-              </h4>
-              <p className="text-sm text-muted mb-2">
-                {TEXT.maiveModal.papersAndResources.maiveWebsite.text}
-              </p>
-              <Link
-                href={CONST.LINKS.MAIVE.WEBSITE}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-primary-600 hover:underline text-sm interactive"
-              >
-                {TEXT.maiveModal.papersAndResources.maiveWebsite.linkText}
-              </Link>
-            </div>
-            <div className="border-l-4 border-green-500 pl-4">
-              <h4 className="font-semibold text-primary">
-                {TEXT.maiveModal.papersAndResources.maivePaper.head}
-              </h4>
-              <p className="text-sm text-muted mb-2">
-                {TEXT.maiveModal.papersAndResources.maivePaper.text}
-              </p>
-              <Link
-                href={CONST.LINKS.MAIVE.PAPER}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-green-600 hover:underline text-sm interactive"
-              >
-                {TEXT.maiveModal.papersAndResources.maivePaper.linkText}
-              </Link>
-            </div>
-            <div className="border-l-4 border-purple-500 pl-4">
-              <h4 className="font-semibold text-primary">
-                {TEXT.maiveModal.papersAndResources.maiveCode.head}
-              </h4>
-              <p className="text-sm text-muted mb-2">
-                {TEXT.maiveModal.papersAndResources.maiveCode.text}
-              </p>
-              <Link
-                href={CONST.LINKS.MAIVE.GITHUB}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-purple-600 hover:underline text-sm interactive"
-              >
-                {TEXT.maiveModal.papersAndResources.maiveCode.linkText}
-              </Link>
-            </div>
-          </div>
-        </section>
-
-        {!!shouldShowGettingStarted ? (
+      <div className="p-6 h-full flex flex-col justify-between">
+        <div className="space-y-6 flex-1 overflow-y-auto">
           <section>
             <h3 className="text-xl font-semibold text-primary mb-3">
-              {TEXT.maiveModal.gettingStarted.title}
+              {TEXT.maiveModal.overview.title}
             </h3>
-            <p className="text-secondary leading-relaxed mb-4">
-              {TEXT.maiveModal.gettingStarted.text}
-            </p>
-            <div className="flex gap-3">
-              <ActionButton href="/upload" variant="primary" size="md">
-                {TEXT.maiveModal.uploadYourData}
-              </ActionButton>
-              <ActionButton onClick={onClose} variant="secondary" size="md">
-                {TEXT.common.close}
-              </ActionButton>
+            <div className="text-secondary leading-relaxed">
+              <MDXContent source={TEXT.maiveModal.overview.text} lineMargin={4} />
             </div>
           </section>
-        ) : (
+
           <section>
-            <div className="flex gap-3">
-              <ActionButton onClick={onClose} variant="secondary" size="md">
-                {TEXT.common.close}
-              </ActionButton>
+            <h3 className="text-xl font-semibold text-primary mb-3">
+              {TEXT.maiveModal.howItWorks.title}
+            </h3>
+            <div className="space-y-3 text-secondary">
+              {TEXT.maiveModal.howItWorks.text.map((step, index) => (
+                <div key={index} className="leading-relaxed">
+                  <MDXContent source={step} />
+                </div>
+              ))}
             </div>
           </section>
-        )}
+
+          <section>
+            <h3 className="text-xl font-semibold text-primary mb-3">
+              {TEXT.maiveModal.keyFeatures.title}
+            </h3>
+            <ul className="list-disc list-inside space-y-2 text-secondary">
+              {TEXT.maiveModal.keyFeatures.text.map((feature) => (
+                <li key={feature.head}>
+                  <strong>{feature.head}:</strong> {feature.text}
+                </li>
+              ))}
+            </ul>
+          </section>
+
+          <section>
+            <h3 className="text-xl font-semibold text-primary mb-3">
+              {TEXT.maiveModal.applications.title}
+            </h3>
+            <div className="grid md:grid-cols-2 gap-4">
+              {TEXT.maiveModal.applications.text.map((application) => (
+                <div
+                  key={application.head}
+                  className="bg-surface-secondary p-4 rounded-lg"
+                >
+                  <h4 className="font-semibold text-primary mb-2">
+                    {application.head}
+                  </h4>
+                  <p className="text-sm text-muted">{application.text}</p>
+                </div>
+              ))}
+            </div>
+          </section>
+
+          <section>
+            <h3 className="text-xl font-semibold text-primary mb-3">
+              {TEXT.maiveModal.papersAndResources.title}
+            </h3>
+            <div className="space-y-3">
+              <div className="border-l-4 border-primary-500 pl-4">
+                <h4 className="font-semibold text-primary">
+                  {TEXT.maiveModal.papersAndResources.maiveWebsite.head}
+                </h4>
+                <p className="text-sm text-muted mb-2">
+                  {TEXT.maiveModal.papersAndResources.maiveWebsite.text}
+                </p>
+                <Link
+                  href={CONST.LINKS.MAIVE.WEBSITE}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-primary-600 hover:underline text-sm interactive"
+                >
+                  {TEXT.maiveModal.papersAndResources.maiveWebsite.linkText}
+                </Link>
+              </div>
+              <div className="border-l-4 border-green-500 pl-4">
+                <h4 className="font-semibold text-primary">
+                  {TEXT.maiveModal.papersAndResources.maivePaper.head}
+                </h4>
+                <p className="text-sm text-muted mb-2">
+                  {TEXT.maiveModal.papersAndResources.maivePaper.text}
+                </p>
+                <Link
+                  href={CONST.LINKS.MAIVE.PAPER}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-green-600 hover:underline text-sm interactive"
+                >
+                  {TEXT.maiveModal.papersAndResources.maivePaper.linkText}
+                </Link>
+              </div>
+              <div className="border-l-4 border-purple-500 pl-4">
+                <h4 className="font-semibold text-primary">
+                  {TEXT.maiveModal.papersAndResources.maiveCode.head}
+                </h4>
+                <p className="text-sm text-muted mb-2">
+                  {TEXT.maiveModal.papersAndResources.maiveCode.text}
+                </p>
+                <Link
+                  href={CONST.LINKS.MAIVE.GITHUB}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-purple-600 hover:underline text-sm interactive"
+                >
+                  {TEXT.maiveModal.papersAndResources.maiveCode.linkText}
+                </Link>
+              </div>
+            </div>
+          </section>
+
+          {!!shouldShowGettingStarted ? (
+            <section>
+              <h3 className="text-xl font-semibold text-primary mb-3">
+                {TEXT.maiveModal.gettingStarted.title}
+              </h3>
+              <p className="text-secondary leading-relaxed mb-4">
+                {TEXT.maiveModal.gettingStarted.text}
+              </p>
+              <div className="flex gap-3">
+                <ActionButton href="/upload" variant="primary" size="md">
+                  {TEXT.maiveModal.uploadYourData}
+                </ActionButton>
+                <ActionButton onClick={onClose} variant="secondary" size="md">
+                  {TEXT.common.close}
+                </ActionButton>
+              </div>
+            </section>
+          ) : (
+            <section>
+              <div className="flex gap-3">
+                <ActionButton onClick={onClose} variant="secondary" size="md">
+                  {TEXT.common.close}
+                </ActionButton>
+              </div>
+            </section>
+          )}
+        </div>
+        <div className="text-xs text-muted text-right mt-4">Version {version}</div>
       </div>
     </BaseModal>
   );


### PR DESCRIPTION
## Summary
- import the MAIVE client package version into the MAIVEInfoModal component
- restructure the modal body layout so the content and footer are organized in a flex column
- add a footer display that shows the current client version aligned to the bottom-right of the modal

## Testing
- npm run lint *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ca6443caac832a9ea7dc59dc8b4719