### PR TITLE
feat: trigger primary actions with enter key

### DIFF
--- a/apps/react-ui/client/src/hooks/useEnterKeyAction.ts
+++ b/apps/react-ui/client/src/hooks/useEnterKeyAction.ts
@@ -1,0 +1,46 @@
+import { useEffect } from "react";
+
+type UseEnterKeyActionOptions = {
+  enabled?: boolean;
+  preventDefault?: boolean;
+  target?: Document | HTMLElement | null;
+};
+
+const isClient = typeof window !== "undefined";
+
+export function useEnterKeyAction(
+  callback: () => void,
+  options: UseEnterKeyActionOptions = {},
+) {
+  const { enabled = true, preventDefault = false, target } = options;
+
+  useEffect(() => {
+    if (!enabled || !isClient) {
+      return;
+    }
+
+    const eventTarget = target ?? document;
+
+    if (!eventTarget) {
+      return;
+    }
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== "Enter" || event.isComposing) {
+        return;
+      }
+
+      if (preventDefault) {
+        event.preventDefault();
+      }
+
+      callback();
+    };
+
+    eventTarget.addEventListener("keydown", handleKeyDown);
+
+    return () => {
+      eventTarget.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [callback, enabled, preventDefault, target]);
+}

--- a/apps/react-ui/client/src/pages/model/index.tsx
+++ b/apps/react-ui/client/src/pages/model/index.tsx
@@ -20,6 +20,7 @@ import { modelService } from "@src/api/services/modelService";
 import type { ModelParameters } from "@src/types";
 import { modelOptionsConfig } from "@src/config/optionsConfig";
 import { hasStudyIdColumn } from "@src/utils/dataUtils";
+import { useEnterKeyAction } from "@src/hooks/useEnterKeyAction";
 
 export default function ModelPage() {
   const searchParams = useSearchParams();
@@ -34,7 +35,16 @@ export default function ModelPage() {
   const abortControllerRef = useRef<AbortController | null>(null);
   const isMountedRef = useRef(true);
   const searchParamsAppliedRef = useRef(false);
+  const runModelButtonRef = useRef<HTMLButtonElement>(null);
   const { showAlert } = useGlobalAlert();
+
+  useEnterKeyAction(() => {
+    const button = runModelButtonRef.current;
+
+    if (button && !button.disabled) {
+      button.click();
+    }
+  });
 
   const loadDataFromStore = () => {
     try {
@@ -266,6 +276,7 @@ export default function ModelPage() {
                       />
 
                       <ActionButton
+                        ref={runModelButtonRef}
                         onClick={handleRunModel}
                         variant="primary"
                         className="w-full"

--- a/apps/react-ui/client/src/pages/upload/index.tsx
+++ b/apps/react-ui/client/src/pages/upload/index.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useCallback } from "react";
+import { useState, useCallback, useRef } from "react";
 import Head from "next/head";
 import { useRouter } from "next/navigation";
 import type { FileRejection } from "react-dropzone";
@@ -15,6 +15,7 @@ import MDXContent from "@src/context/MDXContent";
 import CONFIG from "@src/CONFIG";
 import { getRandomMockCsvFile } from "@src/utils/mockCsvFiles";
 import { generateMockCSVFile } from "@src/utils/mockData";
+import { useEnterKeyAction } from "@src/hooks/useEnterKeyAction";
 
 export default function UploadPage() {
   const [selectedFile, setSelectedFile] = useState<File | null>(null);
@@ -86,6 +87,16 @@ export default function UploadPage() {
       handleGenerateMockData();
     }
   };
+
+  const uploadButtonRef = useRef<HTMLButtonElement>(null);
+
+  useEnterKeyAction(() => {
+    const button = uploadButtonRef.current;
+
+    if (button && !button.disabled) {
+      button.click();
+    }
+  });
 
   const handleSubmit = useCallback(
     (event: React.FormEvent<HTMLFormElement>) => {
@@ -232,6 +243,7 @@ export default function UploadPage() {
               )}
 
               <ActionButton
+                ref={uploadButtonRef}
                 onClick={(event) => {
                   void handleSubmit(event as React.FormEvent<HTMLFormElement>);
                 }}

--- a/apps/react-ui/client/src/pages/validation/index.tsx
+++ b/apps/react-ui/client/src/pages/validation/index.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { useSearchParams } from "next/navigation";
 import Head from "next/head";
 import { useRouter } from "next/navigation";
@@ -14,6 +14,7 @@ import { GoBackButton } from "@src/components/Buttons";
 import RowInfoComponent from "@src/components/RowInfoComponent";
 import CONFIG from "@src/CONFIG";
 import type { AlertType, DataArray } from "@src/types";
+import { useEnterKeyAction } from "@src/hooks/useEnterKeyAction";
 
 type ValidationMessage = {
   type: AlertType;
@@ -38,6 +39,16 @@ export default function ValidationPage() {
   const [uploadedData, setUploadedData] = useState<UploadedData | null>(null);
   const router = useRouter();
   const { showAlert } = useGlobalAlert();
+
+  const continueButtonRef = useRef<HTMLButtonElement>(null);
+
+  useEnterKeyAction(() => {
+    const button = continueButtonRef.current;
+
+    if (button && !button.disabled) {
+      button.click();
+    }
+  });
 
   const validateData = (
     previewData: string[][],
@@ -472,6 +483,7 @@ export default function ValidationPage() {
                 </ActionButton>
               )}
               <ActionButton
+                ref={continueButtonRef}
                 onClick={handleContinue}
                 disabled={!validationResult.isValid}
                 variant="primary"


### PR DESCRIPTION
## Summary
- add a reusable `useEnterKeyAction` hook to centralize enter key handling
- wire the upload, validation, and model parameter pages to activate their primary action buttons when enter is pressed

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ca75456808832a9ce5995330bda8ae