### PR TITLE
fix: contain modal scroll chaining

### DIFF
--- a/apps/react-ui/client/src/components/Modals/BaseModal.tsx
+++ b/apps/react-ui/client/src/components/Modals/BaseModal.tsx
@@ -105,7 +105,7 @@ export default function BaseModal({
     >
       <div
         ref={modalRef}
-        className={`modal-content ${maxWidth} w-full ${maxHeight} overflow-y-auto ${className}`}
+        className={`modal-content ${maxWidth} w-full ${maxHeight} overflow-y-auto overscroll-contain ${className}`}
         onClick={handleModalContentClick}
         tabIndex={-1}
         role="dialog"

--- a/apps/react-ui/client/src/components/Modals/MAIVEInfoModal.tsx
+++ b/apps/react-ui/client/src/components/Modals/MAIVEInfoModal.tsx
@@ -32,7 +32,7 @@ export default function MAIVEInfoModal({
       </div>
 
       <div className="p-6 flex flex-col h-full justify-between">
-        <div className="space-y-6 flex-1 overflow-y-auto">
+        <div className="space-y-6 flex-1 overflow-y-auto overscroll-contain">
           <section>
             <h3 className="text-xl font-semibold text-primary mb-3">
               {TEXT.maiveModal.overview.title}

--- a/apps/react-ui/client/src/styles/globals.css
+++ b/apps/react-ui/client/src/styles/globals.css
@@ -433,6 +433,7 @@ body {
 		box-shadow:
 			0 20px 25px -5px var(--color-shadow-heavy),
 			0 10px 10px -5px var(--color-shadow-medium);
+		overscroll-behavior: contain;
 	}
 
 	/* Page container abstractions */


### PR DESCRIPTION
## Summary
- contain scroll chaining on BaseModal and MAIVE info content to avoid scrolling past modal boundaries
- add CSS overscroll containment for modal shells to keep focus on modal content

## Testing
- npm run ui:lint

------
https://chatgpt.com/codex/tasks/task_e_68ca75581784832a8ac35ef75446bc22