### PR TITLE
fix: hide adjusted weights when instrumenting disabled

### DIFF
--- a/apps/react-ui/client/src/components/Options/OptionRenderer.tsx
+++ b/apps/react-ui/client/src/components/Options/OptionRenderer.tsx
@@ -5,6 +5,7 @@ import Alert from "@src/components/Alert";
 import type { OptionConfig } from "@src/types/options";
 import type { ModelParameters } from "@src/types/api";
 import CONFIG from "@src/CONFIG";
+import CONST from "@src/CONST";
 
 type OptionRendererProps = {
   option: OptionConfig;
@@ -37,17 +38,31 @@ export default function OptionRenderer({
             disabled={option.disabled}
           />
         );
-      case "dropdown":
+      case "dropdown": {
+        const dropdownOptions =
+          option.key === "weight"
+            ? option.options.filter((dropdownOption) => {
+                if (
+                  !parameters.shouldUseInstrumenting &&
+                  dropdownOption.value ===
+                    CONST.WEIGHT_OPTIONS.ADJUSTED_WEIGHTS.VALUE
+                ) {
+                  return false;
+                }
+                return true;
+              })
+            : option.options;
         return (
           <DropdownSelect
             label={option.label}
             value={value as string}
             onChange={handleChange as (value: string) => void}
-            options={option.options}
+            options={dropdownOptions}
             className={option.className}
             disabled={option.disabled}
           />
         );
+      }
       default:
         return null;
     }

--- a/apps/react-ui/client/src/pages/model/index.tsx
+++ b/apps/react-ui/client/src/pages/model/index.tsx
@@ -203,6 +203,20 @@ export default function ModelPage() {
     );
   }, [parameters.standardErrorTreatment, uploadedData]);
 
+  useEffect(() => {
+    if (
+      parameters.shouldUseInstrumenting ||
+      parameters.weight !== CONST.WEIGHT_OPTIONS.ADJUSTED_WEIGHTS.VALUE
+    ) {
+      return;
+    }
+
+    setParameters((prev) => ({
+      ...prev,
+      weight: CONST.WEIGHT_OPTIONS.EQUAL_WEIGHTS.VALUE,
+    }));
+  }, [parameters.shouldUseInstrumenting, parameters.weight]);
+
   return (
     <>
       <Head>


### PR DESCRIPTION
## Summary
- hide the Adjusted Weights choice whenever instrumenting is turned off
- reset the weighting selection to Equal Weights if instrumenting is disabled while Adjusted Weights was selected

## Testing
- npm run ui:lint

------
https://chatgpt.com/codex/tasks/task_e_68ca76ac9694832a9640ca2c530aeef6