### PR TITLE
Adjust funnel plot and copy when instrumenting disabled

### DIFF
--- a/apps/lambda-r-backend/r_scripts/maive_model.R
+++ b/apps/lambda-r-backend/r_scripts/maive_model.R
@@ -213,14 +213,17 @@ run_maive_model <- function(data, parameters) {
   boot_se <- parse_boot_result(maive_res$boot_result, "boot_se") # [a, b]
   boot_ci <- parse_boot_result(maive_res$boot_result, "boot_ci") # [[a, b], [c, d]]
 
+  se_adjusted_for_plot <- if (instrument == 0) NULL else maive_res$SE_instrumented
+
   funnel_plot_data <- get_funnel_plot_data( # nolint: object_usage_linter.
     effect = df$bs,
     se = df$sebs,
-    se_adjusted = maive_res$SE_instrumented,
+    se_adjusted = se_adjusted_for_plot,
     intercept = maive_res$beta,
     intercept_se = maive_res$SE,
     slope_coef = maive_res$slope_coef,
-    is_quaratic_fit = is_quadratic_fit
+    is_quaratic_fit = is_quadratic_fit,
+    instrument = instrument
   )
 
   results <- list(

--- a/apps/react-ui/client/src/components/Modals/RunInfoModal.tsx
+++ b/apps/react-ui/client/src/components/Modals/RunInfoModal.tsx
@@ -9,6 +9,8 @@ import RunDetails from "@src/components/RunDetails";
 import BaseModal from "./BaseModal";
 import { FaDownload } from "react-icons/fa";
 
+type ResultsTextContent = typeof TEXT.results;
+
 type RunInfoModalProps = {
   isOpen: boolean;
   onClose: () => void;
@@ -18,6 +20,7 @@ type RunInfoModalProps = {
   runDuration?: number; // in milliseconds
   runTimestamp?: Date;
   onExportButtonClick: () => void;
+  resultsText: ResultsTextContent;
 };
 
 export default function RunInfoModal({
@@ -29,6 +32,7 @@ export default function RunInfoModal({
   runDuration,
   runTimestamp,
   onExportButtonClick,
+  resultsText,
 }: RunInfoModalProps) {
   const getParameterDisplayName = (key: keyof ModelParameters): string => {
     return TEXT.model[key].label;
@@ -173,6 +177,7 @@ export default function RunInfoModal({
             runDuration={runDuration}
             runTimestamp={runTimestamp}
             dataInfo={dataInfo}
+            resultsText={resultsText}
           />
         </section>
       </div>

--- a/apps/react-ui/client/src/components/ResultsSummary.tsx
+++ b/apps/react-ui/client/src/components/ResultsSummary.tsx
@@ -10,6 +10,8 @@ import Tooltip from "@components/Tooltip";
 import TEXT from "@src/lib/text";
 import CONFIG from "@src/CONFIG";
 
+type ResultsTextContent = typeof TEXT.results;
+
 type ResultsSummaryProps = {
   results: ModelResults;
   parameters?: ModelParameters;
@@ -19,6 +21,7 @@ type ResultsSummaryProps = {
   runTimestamp?: Date;
   dataInfo?: DataInfo;
   showTooltips?: boolean;
+  resultsText?: ResultsTextContent;
 };
 
 export default function ResultsSummary({
@@ -30,6 +33,7 @@ export default function ResultsSummary({
   runTimestamp,
   dataInfo,
   showTooltips = false,
+  resultsText = TEXT.results,
 }: ResultsSummaryProps) {
   const getValueDisplay = (item: ResultItem): string => {
     const baseValue = item.value.toString();
@@ -63,12 +67,9 @@ export default function ResultsSummary({
       label: string;
       tooltip: string;
     };
-    for (const sectionKey of Object.keys(TEXT.results)) {
+    for (const sectionKey of Object.keys(resultsText)) {
       const section = (
-        TEXT.results as unknown as Record<
-          string,
-          Record<string, TooltipContent>
-        >
+        resultsText as unknown as Record<string, Record<string, TooltipContent>>
       )[sectionKey];
       if (section?.metrics) {
         for (const metricKey of Object.keys(section.metrics)) {
@@ -87,9 +88,9 @@ export default function ResultsSummary({
 
   const getSectionTitle = (section: string): string => {
     const sectionTitles: Record<string, string> = {
-      effect: TEXT.results.effectEstimate.title,
-      bias: TEXT.results.publicationBias.title,
-      tests: TEXT.results.diagnosticTests.title,
+      effect: resultsText.effectEstimate.title,
+      bias: resultsText.publicationBias.title,
+      tests: resultsText.diagnosticTests.title,
     };
     return sectionTitles[section] || "";
   };
@@ -101,6 +102,7 @@ export default function ResultsSummary({
     runDuration,
     runTimestamp,
     dataInfo,
+    resultsText,
   );
 
   const allResults = [...resultsData.coreResults];

--- a/apps/react-ui/client/src/lib/text/index.ts
+++ b/apps/react-ui/client/src/lib/text/index.ts
@@ -278,4 +278,59 @@ const TEXT = {
   },
 } as const;
 
+export const getResultsText = (shouldUseInstrumenting: boolean) => {
+  if (shouldUseInstrumenting) {
+    return TEXT.results;
+  }
+
+  const { effectEstimate, publicationBias, funnelPlot } = TEXT.results;
+
+  return {
+    ...TEXT.results,
+    effectEstimate: {
+      ...effectEstimate,
+      metrics: {
+        ...effectEstimate.metrics,
+        estimate: {
+          ...effectEstimate.metrics.estimate,
+          tooltip:
+            "Point estimate of the effect size corrected for publication bias and p-hacking.",
+        },
+      },
+    },
+    publicationBias: {
+      ...publicationBias,
+      metrics: {
+        ...publicationBias.metrics,
+        pValue: {
+          ...publicationBias.metrics.pValue,
+          tooltip:
+            "p-value from the Egger regression that tests for publication bias or p-hacking.",
+        },
+        eggerCoef: {
+          ...publicationBias.metrics.eggerCoef,
+          tooltip:
+            "Coefficient capturing funnel asymmetry in the Egger regression.",
+        },
+        eggerSE: {
+          ...publicationBias.metrics.eggerSE,
+          tooltip:
+            "Robust standard error of the coefficient capturing funnel asymmetry in the Egger regression.",
+        },
+        significance: {
+          ...publicationBias.metrics.significance,
+          tooltip:
+            "Indicates whether publication bias is statistically significant at the 5% level according to the Egger test.",
+        },
+      },
+    },
+    funnelPlot: {
+      ...funnelPlot,
+      title: "Funnel Plot",
+      tooltip:
+        "Scatter of effect sizes against their standard errors. The plot includes 90%, 95%, and 99% confidence interval regions (shaded areas), with the solid line representing the regression fit. The estimate is the intercept of the line with the horizontal axis.",
+    },
+  } as typeof TEXT.results;
+};
+
 export default TEXT;

--- a/apps/react-ui/client/src/pages/results/index.tsx
+++ b/apps/react-ui/client/src/pages/results/index.tsx
@@ -8,7 +8,7 @@ import Tooltip from "@components/Tooltip";
 import DownloadButton from "@components/Buttons/DownloadButton";
 import ActionButton from "@components/Buttons/ActionButton";
 import { GoBackButton } from "@components/Buttons";
-import TEXT from "@src/lib/text";
+import { getResultsText } from "@src/lib/text";
 import { useDataStore, dataCache } from "@store/dataStore";
 import {
   exportComprehensiveResults,
@@ -44,8 +44,16 @@ export default function ResultsPage() {
   // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
   const parsedParameters: ModelParameters = JSON.parse(parameters ?? "{}");
 
+  const shouldUseInstrumenting =
+    parsedParameters?.shouldUseInstrumenting ?? true;
+
   // Memoize dataInfo to prevent expensive recalculations on every render
   const dataInfo = useMemo(() => generateDataInfo(dataId), [dataId]);
+
+  const resultsText = useMemo(
+    () => getResultsText(shouldUseInstrumenting),
+    [shouldUseInstrumenting],
+  );
 
   if (!results) {
     return (
@@ -151,16 +159,17 @@ export default function ResultsPage() {
                 runTimestamp={runTimestamp ? new Date(runTimestamp) : undefined}
                 dataInfo={dataInfo}
                 showTooltips={true}
+                resultsText={resultsText}
               />
 
               {/* Funnel Plot */}
               <div className="p-4 bg-gray-50 dark:bg-gray-700 rounded-lg relative">
                 <Tooltip
-                  content={TEXT.results.funnelPlot.tooltip}
+                  content={resultsText.funnelPlot.tooltip}
                   visible={CONFIG.TOOLTIPS_ENABLED.RESULTS_PAGE}
                 >
                   <h2 className="text-xl font-semibold mb-4">
-                    {TEXT.results.funnelPlot.title}
+                    {resultsText.funnelPlot.title}
                   </h2>
                 </Tooltip>
                 <div className="flex justify-center">
@@ -259,6 +268,7 @@ export default function ResultsPage() {
         runDuration={runDuration ? parseInt(runDuration, 10) : undefined}
         runTimestamp={runTimestamp ? new Date(runTimestamp) : undefined}
         onExportButtonClick={handleExportData}
+        resultsText={resultsText}
       />
     </>
   );

--- a/apps/react-ui/client/src/utils/dataUtils.ts
+++ b/apps/react-ui/client/src/utils/dataUtils.ts
@@ -1,4 +1,4 @@
-import TEXT from "@src/lib/text";
+import TEXT, { getResultsText } from "@src/lib/text";
 import type { DataArray, ModelResults, ModelParameters } from "@src/types";
 import type { DataInfo } from "@src/types/data";
 import {
@@ -249,6 +249,10 @@ export const exportComprehensiveResults = (
 ): void => {
   const workbook = XLSX.utils.book_new();
 
+  const resultsText = getResultsText(
+    parameters?.shouldUseInstrumenting ?? true,
+  );
+
   // Sheet 1: Results Summary
   const resultsSummary = convertToExportFormat(
     generateResultsData(
@@ -257,6 +261,7 @@ export const exportComprehensiveResults = (
       runDuration,
       runTimestamp,
       dataInfo,
+      resultsText,
     ),
   );
 

--- a/apps/react-ui/client/src/utils/resultsDataUtils.ts
+++ b/apps/react-ui/client/src/utils/resultsDataUtils.ts
@@ -24,12 +24,15 @@ export type ResultsData = {
 /**
  * Generate results data for display and export purposes
  */
+type ResultsTextContent = typeof TEXT.results;
+
 export const generateResultsData = (
   results: ModelResults,
   parameters?: ModelParameters,
   runDuration?: number,
   runTimestamp?: Date,
   dataInfo?: DataInfo,
+  resultsText: ResultsTextContent = TEXT.results,
 ): ResultsData => {
   const formatValue = (value: number, decimals = 4): string => {
     return value.toFixed(decimals);
@@ -42,32 +45,32 @@ export const generateResultsData = (
   // Core results
   const coreResults: ResultItem[] = [
     {
-      label: TEXT.results.effectEstimate.metrics.estimate.label,
+      label: resultsText.effectEstimate.metrics.estimate.label,
       value: results.effectEstimate,
       show: true,
       section: "effect",
     },
     {
-      label: TEXT.results.effectEstimate.metrics.standardError.label,
+      label: resultsText.effectEstimate.metrics.standardError.label,
       value: results.standardError,
       show: true,
       section: "effect",
     },
     {
-      label: TEXT.results.effectEstimate.metrics.significance.label,
+      label: resultsText.effectEstimate.metrics.significance.label,
       value: results.isSignificant ? "Yes" : "No",
       show: true,
       highlightColor: results.isSignificant ? "text-green-600" : "text-red-600",
       section: "effect",
     },
     {
-      label: TEXT.results.effectEstimate.metrics.bootCI.label,
+      label: resultsText.effectEstimate.metrics.bootCI.label,
       value: results.bootCI !== "NA" ? formatCI(results.bootCI[0]) : "NA",
       show: results.bootCI !== "NA",
       section: "effect",
     },
     {
-      label: TEXT.results.effectEstimate.metrics.andersonRubinCI.label,
+      label: resultsText.effectEstimate.metrics.andersonRubinCI.label,
       value:
         results.andersonRubinCI !== "NA"
           ? formatCI(results.andersonRubinCI)
@@ -76,25 +79,25 @@ export const generateResultsData = (
       section: "effect",
     },
     {
-      label: TEXT.results.publicationBias.metrics.eggerCoef.label,
+      label: resultsText.publicationBias.metrics.eggerCoef.label,
       value: results.publicationBias.eggerCoef,
       show: true,
       section: "bias",
     },
     {
-      label: TEXT.results.publicationBias.metrics.eggerSE.label,
+      label: resultsText.publicationBias.metrics.eggerSE.label,
       value: results.publicationBias.eggerSE,
       show: true,
       section: "bias",
     },
     {
-      label: TEXT.results.publicationBias.metrics.pValue.label,
+      label: resultsText.publicationBias.metrics.pValue.label,
       value: results.publicationBias.pValue,
       show: true,
       section: "bias",
     },
     {
-      label: TEXT.results.publicationBias.metrics.significance.label,
+      label: resultsText.publicationBias.metrics.significance.label,
       value: results.publicationBias.isSignificant ? "Yes" : "No",
       show: true,
       highlightColor: results.publicationBias.isSignificant
@@ -103,7 +106,7 @@ export const generateResultsData = (
       section: "bias",
     },
     {
-      label: TEXT.results.diagnosticTests.metrics.hausmanTest.label,
+      label: resultsText.diagnosticTests.metrics.hausmanTest.label,
       value: results.hausmanTest.statistic,
       show: parameters?.shouldUseInstrumenting ?? true,
       highlightColor: results.hausmanTest.rejectsNull
@@ -115,13 +118,13 @@ export const generateResultsData = (
       section: "tests",
     },
     {
-      label: TEXT.results.diagnosticTests.metrics.hausmanCriticalValue.label,
+      label: resultsText.diagnosticTests.metrics.hausmanCriticalValue.label,
       value: results.hausmanTest.criticalValue,
       show: parameters?.shouldUseInstrumenting ?? true,
       section: "tests",
     },
     {
-      label: TEXT.results.diagnosticTests.metrics.firstStageFTest.label,
+      label: resultsText.diagnosticTests.metrics.firstStageFTest.label,
       value: results.firstStageFTest !== "NA" ? results.firstStageFTest : "NA",
       show:
         (parameters?.shouldUseInstrumenting ?? true) &&


### PR DESCRIPTION
## Summary
- add an instrument flag to the R funnel plot renderer to skip adjusted-SE points and rename the regression fit when instrumenting is disabled
- plumb the instrument setting through the MAIVE model and tailor the exported results text/tooltip content when the run skips instrumenting
- update the results page, modal, and export helpers to use conditional copy so funnel plot and publication-bias messaging drop MAIVE/instrument references

## Testing
- npm run ui:lint
- npm run r:test-e2e

------
https://chatgpt.com/codex/tasks/task_e_68ca7aa6abb0832a9b046536c65ed81e