### PR TITLE
feat: add dedicated routes for secondary CTAs

### DIFF
--- a/apps/react-ui/client/src/components/Buttons/DemoButton.tsx
+++ b/apps/react-ui/client/src/components/Buttons/DemoButton.tsx
@@ -1,64 +1,24 @@
-import { useRouter } from "next/navigation";
-import { useRef } from "react";
-import { DataProcessingService } from "@src/services/dataProcessingService";
 import ActionButton from "@src/components/Buttons/ActionButton";
-import CONST from "@src/CONST";
 import { FaPlay } from "react-icons/fa";
 
 type DemoButtonProps = {
-  isLoading: boolean;
-  setIsLoading: (isLoading: boolean) => void;
   size?: "sm" | "md" | "lg";
   className?: string;
 };
 
 export default function DemoButton({
-  isLoading,
-  setIsLoading,
   size = "md",
   className,
 }: DemoButtonProps) {
-  const router = useRouter();
-  const buttonRef = useRef<HTMLButtonElement>(null);
-
-  const handleDemoClick = async () => {
-    setIsLoading(true);
-
-    // Wait for the transition animation to complete
-    await new Promise((resolve) => setTimeout(resolve, 700));
-
-    try {
-      const dataId = await DataProcessingService.processAndStoreMockDataByName(
-        CONST.DEMO_MOCK_DATA_NAME,
-      );
-
-      // Wait a bit more to ensure loading state is visible
-      await new Promise((resolve) => setTimeout(resolve, 500));
-
-      // Navigate to model page
-      router.push(`/model?dataId=${dataId}`);
-    } catch (error) {
-      console.error("Error loading demo data:", error);
-      alert("Failed to load demo data. Please try again.");
-      setIsLoading(false);
-    }
-  };
-
   return (
     <ActionButton
-      ref={buttonRef}
-      onClick={() => {
-        void handleDemoClick();
-      }}
+      href="/demo"
       variant="secondary"
       size={size}
-      disabled={isLoading}
-      className={`${className} inline-flex gap-2 transition-all duration-300 ${
-        isLoading ? "scale-95 opacity-75" : "scale-100 opacity-100"
-      }`}
+      className={`${className ?? ""} inline-flex gap-2`}
     >
       <FaPlay className="icon-button" />
-      {`${isLoading ? "Loading..." : "Run a demo"}`}
+      Run a demo
     </ActionButton>
   );
 }

--- a/apps/react-ui/client/src/components/MAIVEInfo/MAIVEInfoContent.tsx
+++ b/apps/react-ui/client/src/components/MAIVEInfo/MAIVEInfoContent.tsx
@@ -1,0 +1,126 @@
+import MDXContent from "@context/MDXContent";
+import TEXT from "@lib/text";
+import CONST from "@src/CONST";
+import Link from "next/link";
+
+type MAIVEInfoContentProps = {
+  className?: string;
+};
+
+export default function MAIVEInfoContent({
+  className = "",
+}: MAIVEInfoContentProps) {
+  return (
+    <div className={`space-y-8 ${className}`}>
+      <section>
+        <h3 className="text-xl font-semibold text-primary mb-3">
+          {TEXT.maiveModal.overview.title}
+        </h3>
+        <div className="text-secondary leading-relaxed">
+          <MDXContent source={TEXT.maiveModal.overview.text} lineMargin={4} />
+        </div>
+      </section>
+
+      <section>
+        <h3 className="text-xl font-semibold text-primary mb-3">
+          {TEXT.maiveModal.howItWorks.title}
+        </h3>
+        <div className="space-y-3 text-secondary">
+          {TEXT.maiveModal.howItWorks.text.map((step, index) => (
+            <div key={index} className="leading-relaxed">
+              <MDXContent source={step} />
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section>
+        <h3 className="text-xl font-semibold text-primary mb-3">
+          {TEXT.maiveModal.keyFeatures.title}
+        </h3>
+        <ul className="list-disc list-inside space-y-2 text-secondary">
+          {TEXT.maiveModal.keyFeatures.text.map((feature) => (
+            <li key={feature.head}>
+              <strong>{feature.head}:</strong> {feature.text}
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      <section>
+        <h3 className="text-xl font-semibold text-primary mb-3">
+          {TEXT.maiveModal.applications.title}
+        </h3>
+        <div className="grid md:grid-cols-2 gap-4">
+          {TEXT.maiveModal.applications.text.map((application) => (
+            <div
+              key={application.head}
+              className="bg-surface-secondary p-4 rounded-lg"
+            >
+              <h4 className="font-semibold text-primary mb-2">
+                {application.head}
+              </h4>
+              <p className="text-sm text-muted">{application.text}</p>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section>
+        <h3 className="text-xl font-semibold text-primary mb-3">
+          {TEXT.maiveModal.papersAndResources.title}
+        </h3>
+        <div className="space-y-3">
+          <div className="border-l-4 border-primary-500 pl-4">
+            <h4 className="font-semibold text-primary">
+              {TEXT.maiveModal.papersAndResources.maiveWebsite.head}
+            </h4>
+            <p className="text-sm text-muted mb-2">
+              {TEXT.maiveModal.papersAndResources.maiveWebsite.text}
+            </p>
+            <Link
+              href={CONST.LINKS.MAIVE.WEBSITE}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-primary-600 hover:underline text-sm interactive"
+            >
+              {TEXT.maiveModal.papersAndResources.maiveWebsite.linkText}
+            </Link>
+          </div>
+          <div className="border-l-4 border-green-500 pl-4">
+            <h4 className="font-semibold text-primary">
+              {TEXT.maiveModal.papersAndResources.maivePaper.head}
+            </h4>
+            <p className="text-sm text-muted mb-2">
+              {TEXT.maiveModal.papersAndResources.maivePaper.text}
+            </p>
+            <Link
+              href={CONST.LINKS.MAIVE.PAPER}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-green-600 hover:underline text-sm interactive"
+            >
+              {TEXT.maiveModal.papersAndResources.maivePaper.linkText}
+            </Link>
+          </div>
+          <div className="border-l-4 border-purple-500 pl-4">
+            <h4 className="font-semibold text-primary">
+              {TEXT.maiveModal.papersAndResources.maiveCode.head}
+            </h4>
+            <p className="text-sm text-muted mb-2">
+              {TEXT.maiveModal.papersAndResources.maiveCode.text}
+            </p>
+            <Link
+              href={CONST.LINKS.MAIVE.GITHUB}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-purple-600 hover:underline text-sm interactive"
+            >
+              {TEXT.maiveModal.papersAndResources.maiveCode.linkText}
+            </Link>
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/apps/react-ui/client/src/components/MAIVEInfo/MAIVEInfoGettingStarted.tsx
+++ b/apps/react-ui/client/src/components/MAIVEInfo/MAIVEInfoGettingStarted.tsx
@@ -1,0 +1,35 @@
+import ActionButton from "@components/Buttons/ActionButton";
+import TEXT from "@lib/text";
+
+type MAIVEInfoGettingStartedProps = {
+  onClose?: () => void;
+  showCloseButton?: boolean;
+  className?: string;
+};
+
+export default function MAIVEInfoGettingStarted({
+  onClose,
+  showCloseButton = false,
+  className = "",
+}: MAIVEInfoGettingStartedProps) {
+  return (
+    <section className={className}>
+      <h3 className="text-xl font-semibold text-primary mb-3">
+        {TEXT.maiveModal.gettingStarted.title}
+      </h3>
+      <p className="text-secondary leading-relaxed mb-4">
+        {TEXT.maiveModal.gettingStarted.text}
+      </p>
+      <div className="flex flex-wrap gap-3">
+        <ActionButton href="/upload" variant="primary" size="md">
+          {TEXT.maiveModal.uploadYourData}
+        </ActionButton>
+        {showCloseButton && (
+          <ActionButton onClick={onClose} variant="secondary" size="md">
+            {TEXT.common.close}
+          </ActionButton>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/apps/react-ui/client/src/components/MAIVEInfo/index.ts
+++ b/apps/react-ui/client/src/components/MAIVEInfo/index.ts
@@ -1,0 +1,2 @@
+export { default as MAIVEInfoContent } from "./MAIVEInfoContent";
+export { default as MAIVEInfoGettingStarted } from "./MAIVEInfoGettingStarted";

--- a/apps/react-ui/client/src/components/Modals/MAIVEInfoModal.tsx
+++ b/apps/react-ui/client/src/components/Modals/MAIVEInfoModal.tsx
@@ -1,10 +1,11 @@
-import MDXContent from "@context/MDXContent";
 import ActionButton from "@src/components/Buttons/ActionButton";
 import TEXT from "@lib/text";
-import CONST from "@src/CONST";
-import Link from "next/link";
 import BaseModal from "./BaseModal";
 import VersionInfo from "@src/components/VersionInfo";
+import {
+  MAIVEInfoContent,
+  MAIVEInfoGettingStarted,
+} from "@components/MAIVEInfo";
 
 type MAIVEInfoModalProps = {
   isOpen: boolean;
@@ -33,136 +34,14 @@ export default function MAIVEInfoModal({
 
       <div className="p-6 flex flex-col h-full justify-between">
         <div className="space-y-6 flex-1 overflow-y-auto overscroll-contain">
-          <section>
-            <h3 className="text-xl font-semibold text-primary mb-3">
-              {TEXT.maiveModal.overview.title}
-            </h3>
-            <div className="text-secondary leading-relaxed">
-              <MDXContent
-                source={TEXT.maiveModal.overview.text}
-                lineMargin={4}
-              />
-            </div>
-          </section>
-
-          <section>
-            <h3 className="text-xl font-semibold text-primary mb-3">
-              {TEXT.maiveModal.howItWorks.title}
-            </h3>
-            <div className="space-y-3 text-secondary">
-              {TEXT.maiveModal.howItWorks.text.map((step, index) => (
-                <div key={index} className="leading-relaxed">
-                  <MDXContent source={step} />
-                </div>
-              ))}
-            </div>
-          </section>
-
-          <section>
-            <h3 className="text-xl font-semibold text-primary mb-3">
-              {TEXT.maiveModal.keyFeatures.title}
-            </h3>
-            <ul className="list-disc list-inside space-y-2 text-secondary">
-              {TEXT.maiveModal.keyFeatures.text.map((feature) => (
-                <li key={feature.head}>
-                  <strong>{feature.head}:</strong> {feature.text}
-                </li>
-              ))}
-            </ul>
-          </section>
-
-          <section>
-            <h3 className="text-xl font-semibold text-primary mb-3">
-              {TEXT.maiveModal.applications.title}
-            </h3>
-            <div className="grid md:grid-cols-2 gap-4">
-              {TEXT.maiveModal.applications.text.map((application) => (
-                <div
-                  key={application.head}
-                  className="bg-surface-secondary p-4 rounded-lg"
-                >
-                  <h4 className="font-semibold text-primary mb-2">
-                    {application.head}
-                  </h4>
-                  <p className="text-sm text-muted">{application.text}</p>
-                </div>
-              ))}
-            </div>
-          </section>
-
-          <section>
-            <h3 className="text-xl font-semibold text-primary mb-3">
-              {TEXT.maiveModal.papersAndResources.title}
-            </h3>
-            <div className="space-y-3">
-              <div className="border-l-4 border-primary-500 pl-4">
-                <h4 className="font-semibold text-primary">
-                  {TEXT.maiveModal.papersAndResources.maiveWebsite.head}
-                </h4>
-                <p className="text-sm text-muted mb-2">
-                  {TEXT.maiveModal.papersAndResources.maiveWebsite.text}
-                </p>
-                <Link
-                  href={CONST.LINKS.MAIVE.WEBSITE}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="text-primary-600 hover:underline text-sm interactive"
-                >
-                  {TEXT.maiveModal.papersAndResources.maiveWebsite.linkText}
-                </Link>
-              </div>
-              <div className="border-l-4 border-green-500 pl-4">
-                <h4 className="font-semibold text-primary">
-                  {TEXT.maiveModal.papersAndResources.maivePaper.head}
-                </h4>
-                <p className="text-sm text-muted mb-2">
-                  {TEXT.maiveModal.papersAndResources.maivePaper.text}
-                </p>
-                <Link
-                  href={CONST.LINKS.MAIVE.PAPER}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="text-green-600 hover:underline text-sm interactive"
-                >
-                  {TEXT.maiveModal.papersAndResources.maivePaper.linkText}
-                </Link>
-              </div>
-              <div className="border-l-4 border-purple-500 pl-4">
-                <h4 className="font-semibold text-primary">
-                  {TEXT.maiveModal.papersAndResources.maiveCode.head}
-                </h4>
-                <p className="text-sm text-muted mb-2">
-                  {TEXT.maiveModal.papersAndResources.maiveCode.text}
-                </p>
-                <Link
-                  href={CONST.LINKS.MAIVE.GITHUB}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="text-purple-600 hover:underline text-sm interactive"
-                >
-                  {TEXT.maiveModal.papersAndResources.maiveCode.linkText}
-                </Link>
-              </div>
-            </div>
-          </section>
+          <MAIVEInfoContent />
 
           {!!shouldShowGettingStarted ? (
-            <section>
-              <h3 className="text-xl font-semibold text-primary mb-3">
-                {TEXT.maiveModal.gettingStarted.title}
-              </h3>
-              <p className="text-secondary leading-relaxed mb-4">
-                {TEXT.maiveModal.gettingStarted.text}
-              </p>
-              <div className="flex gap-3">
-                <ActionButton href="/upload" variant="primary" size="md">
-                  {TEXT.maiveModal.uploadYourData}
-                </ActionButton>
-                <ActionButton onClick={onClose} variant="secondary" size="md">
-                  {TEXT.common.close}
-                </ActionButton>
-              </div>
-            </section>
+            <MAIVEInfoGettingStarted
+              onClose={onClose}
+              showCloseButton
+              className="pt-2"
+            />
           ) : (
             <section>
               <div className="flex gap-3">

--- a/apps/react-ui/client/src/pages/about.tsx
+++ b/apps/react-ui/client/src/pages/about.tsx
@@ -1,0 +1,69 @@
+import Head from "next/head";
+import TEXT from "@lib/text";
+import CONST from "@src/CONST";
+import {
+  MAIVEInfoContent,
+  MAIVEInfoGettingStarted,
+} from "@components/MAIVEInfo";
+import ActionButton from "@components/Buttons/ActionButton";
+import VersionInfo from "@components/VersionInfo";
+
+export default function AboutPage() {
+  return (
+    <>
+      <Head>
+        <title>{`${CONST.APP_DISPLAY_NAME} - About MAIVE`}</title>
+        <meta
+          name="description"
+          content="Learn how MAIVE corrects for publication bias, p-hacking, and spurious precision."
+        />
+      </Head>
+      <div className="px-4 py-12 sm:py-16">
+        <div className="max-w-5xl mx-auto space-y-10">
+          <header className="space-y-4 text-center sm:text-left">
+            <p className="text-sm uppercase tracking-wide text-muted">
+              Meta-Analysis Instrumental Variable Estimator
+            </p>
+            <h1 className="text-4xl sm:text-5xl font-bold text-primary">
+              {TEXT.maiveModal.title}
+            </h1>
+            <p className="text-lg text-secondary leading-relaxed max-w-3xl">
+              Adjust your analyses for publication bias, p-hacking, and spurious
+              precision using MAIVE. Explore the methodology, see where it
+              shines, and access the resources that power the estimator.
+            </p>
+          </header>
+
+          <section className="surface-elevated rounded-xl border border-primary/10 p-6 sm:p-8 space-y-8">
+            <MAIVEInfoContent />
+            <MAIVEInfoGettingStarted className="pt-2" />
+          </section>
+
+          <section className="surface-elevated rounded-xl border border-primary/10 p-6 sm:p-8 space-y-4">
+            <h2 className="text-2xl font-semibold text-primary">
+              Beyond the basics
+            </h2>
+            <p className="text-secondary leading-relaxed">
+              Ready to dive deeper? Run the interactive demo to see MAIVE in
+              action, or review your own data with the upload workflow. You can
+              always open the in-app help modal from the header if you prefer a
+              quick refresher without leaving your analysis.
+            </p>
+            <div className="flex flex-wrap gap-3">
+              <ActionButton href="/demo" variant="secondary" size="md">
+                Explore the demo
+              </ActionButton>
+              <ActionButton href="/upload" variant="primary" size="md">
+                Start an analysis
+              </ActionButton>
+            </div>
+          </section>
+
+          <div className="text-right">
+            <VersionInfo />
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/apps/react-ui/client/src/pages/demo.tsx
+++ b/apps/react-ui/client/src/pages/demo.tsx
@@ -1,0 +1,78 @@
+import { useCallback, useEffect, useState } from "react";
+import Head from "next/head";
+import { useRouter } from "next/navigation";
+import LoadingCard from "@components/LoadingCard";
+import ActionButton from "@components/Buttons/ActionButton";
+import CONST from "@src/CONST";
+import { DataProcessingService } from "@src/services/dataProcessingService";
+
+export default function DemoPage() {
+  const router = useRouter();
+  const [hasError, setHasError] = useState(false);
+
+  const runDemo = useCallback(async () => {
+    setHasError(false);
+
+    try {
+      const dataId = await DataProcessingService.processAndStoreMockDataByName(
+        CONST.DEMO_MOCK_DATA_NAME,
+      );
+      router.push(`/model?dataId=${dataId}`);
+    } catch (error) {
+      console.error("Error loading demo data:", error);
+      setHasError(true);
+    }
+  }, [router]);
+
+  useEffect(() => {
+    void runDemo();
+  }, [runDemo]);
+
+  return (
+    <>
+      <Head>
+        <title>{`${CONST.APP_DISPLAY_NAME} - Demo`}</title>
+        <meta
+          name="description"
+          content="Load demo data to explore how MAIVE corrects for publication bias and p-hacking."
+        />
+      </Head>
+
+      <div className="flex items-center justify-center min-h-[60vh] px-4 py-12">
+        {hasError ? (
+          <div className="max-w-lg w-full space-y-4 text-center">
+            <h1 className="text-3xl font-semibold text-primary">
+              We couldn&apos;t load the demo
+            </h1>
+            <p className="text-secondary leading-relaxed">
+              Something went wrong while preparing the demo dataset. Please try
+              again, or return to the home page to continue exploring MAIVE.
+            </p>
+            <div className="flex flex-wrap justify-center gap-3">
+              <ActionButton
+                onClick={() => {
+                  void runDemo();
+                }}
+                variant="primary"
+                size="md"
+              >
+                Try again
+              </ActionButton>
+              <ActionButton href="/" variant="secondary" size="md">
+                Back to home
+              </ActionButton>
+            </div>
+          </div>
+        ) : (
+          <LoadingCard
+            title="Loading Demo Data..."
+            subtitle="Preparing your demo analysis"
+            color="purple"
+            size="md"
+            className="mx-auto"
+          />
+        )}
+      </div>
+    </>
+  );
+}

--- a/apps/react-ui/client/src/pages/index.tsx
+++ b/apps/react-ui/client/src/pages/index.tsx
@@ -1,19 +1,15 @@
 import Head from "next/head";
 import PingButton from "@src/components/Buttons/PingButton";
-import { MAIVEInfoModal } from "@src/components/Modals";
 import ActionButton from "@src/components/Buttons/ActionButton";
 import { useState, useEffect } from "react";
 import CONST from "@src/CONST";
 import TEXT from "@src/lib/text";
 import DemoButton from "@src/components/Buttons/DemoButton";
-import LoadingCard from "@src/components/LoadingCard";
 import { FaInfoCircle } from "react-icons/fa";
 
 export default function Home() {
-  const [isModalOpen, setIsModalOpen] = useState(false);
   const [isDevelopment, setIsDevelopment] = useState(false);
   const [isLoadingUploadPage, setIsLoadingUploadPage] = useState(false);
-  const [isLoadingDemo, setIsLoadingDemo] = useState(false);
 
   useEffect(() => {
     setIsDevelopment(process.env.NODE_ENV === "development");
@@ -25,68 +21,48 @@ export default function Home() {
         <title>{`${CONST.APP_DISPLAY_NAME} - Welcome`}</title>
       </Head>
       <main className="home-page-container">
-        {isLoadingDemo ? (
-          <div className="flex items-center justify-center min-h-[60vh]">
-            <LoadingCard
-              title="Loading Demo Data..."
-              subtitle="Preparing your demo analysis"
-              color="purple"
+        <div className="max-w-4xl text-center animate-fade-in px-3 sm:px-0">
+          <h1 className="text-4xl sm:text-5xl font-bold mb-6 text-primary tracking-tight">
+            {TEXT.home.title}
+          </h1>
+          <p className="text-lg sm:text-xl mb-8 sm:mb-12 text-secondary leading-relaxed">
+            Adjust your data for publication bias, p-hacking, and spurious
+            precision.
+            <br />
+            Powered by the MAIVE estimator (<em>Nature Communications</em>).
+          </p>
+
+          <div className="flex flex-col gap-4 justify-center items-center mb-8 w-full max-w-md sm:max-w-lg mx-auto">
+            <ActionButton
+              href="/upload"
+              onClick={() => setIsLoadingUploadPage(true)}
+              variant="primary"
+              size="lg"
+              className={`w-full sm:w-auto self-center px-8 sm:px-12 lg:px-20 ${
+                isLoadingUploadPage ? "opacity-75" : "opacity-100"
+              }`}
+            >
+              {TEXT.home.uploadYourData}
+            </ActionButton>
+
+            <ActionButton
+              href="/about"
+              variant="secondary"
               size="md"
-              className="mx-auto"
+              className="inline-flex w-full sm:w-auto self-center items-center justify-center gap-2 px-4 sm:px-6"
+            >
+              <FaInfoCircle className="icon-button" />
+              {TEXT.home.whatIsMaive}
+            </ActionButton>
+
+            <DemoButton
+              size="md"
+              className="w-full sm:w-auto self-center px-4 sm:px-6"
             />
           </div>
-        ) : (
-          <div className="max-w-4xl text-center animate-fade-in px-3 sm:px-0">
-            <h1 className="text-4xl sm:text-5xl font-bold mb-6 text-primary tracking-tight">
-              {TEXT.home.title}
-            </h1>
-            <p className="text-lg sm:text-xl mb-8 sm:mb-12 text-secondary leading-relaxed">
-              Adjust your data for publication bias, p-hacking, and spurious
-              precision.
-              <br />
-              Powered by the MAIVE estimator (<em>Nature Communications</em>).
-            </p>
-
-            <div className="flex flex-col gap-4 justify-center items-center mb-8 w-full max-w-md sm:max-w-lg mx-auto">
-              <ActionButton
-                href="/upload"
-                onClick={() => setIsLoadingUploadPage(true)}
-                variant="primary"
-                size="lg"
-                className={`w-full sm:w-auto self-center px-8 sm:px-12 lg:px-20 ${
-                  isLoadingUploadPage ? "opacity-75" : "opacity-100"
-                }`}
-              >
-                {TEXT.home.uploadYourData}
-              </ActionButton>
-
-              <ActionButton
-                onClick={() => setIsModalOpen(true)}
-                variant="secondary"
-                size="md"
-                className="inline-flex w-full sm:w-auto self-center items-center justify-center gap-2 px-4 sm:px-6"
-              >
-                <FaInfoCircle className="icon-button" />
-                {TEXT.home.whatIsMaive}
-              </ActionButton>
-
-              <DemoButton
-                isLoading={isLoadingDemo}
-                setIsLoading={setIsLoadingDemo}
-                size="md"
-                className="w-full sm:w-auto self-center px-4 sm:px-6"
-              />
-            </div>
-          </div>
-        )}
+        </div>
 
         {isDevelopment && <PingButton />}
-
-        <MAIVEInfoModal
-          isOpen={isModalOpen}
-          onClose={() => setIsModalOpen(false)}
-          shouldShowGettingStarted={true}
-        />
       </main>
     </>
   );


### PR DESCRIPTION
## Summary
- convert the landing page secondary calls-to-action into proper links that point to /about and /demo
- extract reusable MAIVE info content blocks for both the modal and a new about page
- add deep-linkable /about and /demo pages, with the demo route preloading mock data before redirecting to the model

## Testing
- npm run ui:lint
- npx vitest run --reporter=basic

------
https://chatgpt.com/codex/tasks/task_e_68ce92534424832abdb76520678597a7