### PR TITLE
feat: add footer link to meta-analysis ecosystem

### DIFF
--- a/apps/react-ui/client/src/CONST.ts
+++ b/apps/react-ui/client/src/CONST.ts
@@ -15,6 +15,7 @@ const CONST = {
       HOMEPAGE: "https://github.com/PetrCala/maive-ui",
       ISSUES: "https://github.com/PetrCala/maive-ui/issues",
     },
+    APPLICATIONS_URL: "https://meta-analysis.cz/",
     CREATOR_URL: "https://github.com/PetrCala",
     CONTACT_WEBSITE_URL: "https://irsova.com/",
     INSTITUTION_URL: "https://ies.fsv.cuni.cz/en",

--- a/apps/react-ui/client/src/components/Footer.tsx
+++ b/apps/react-ui/client/src/components/Footer.tsx
@@ -11,6 +11,7 @@ import {
   FaGithub,
   FaEnvelope,
   FaExclamationTriangle,
+  FaGlobe,
 } from "react-icons/fa";
 
 type FooterProps = {
@@ -119,6 +120,11 @@ const Footer = ({ className = "" }: FooterProps) => {
             onClick={handleCitationClick}
             icon={<FaFileAlt />}
             text="Cite"
+          />
+          <FooterHrefLinkItem
+            href={CONST.LINKS.APPLICATIONS_URL}
+            icon={<FaGlobe />}
+            text="Applications"
           />
           <FooterHrefLinkItem
             href={CONST.LINKS.APP_GITHUB.HOMEPAGE}


### PR DESCRIPTION
## Summary
- add Applications footer link pointing to meta-analysis.cz
- store ecosystem URL in shared CONST links for reuse
- ensure new link opens externally with consistent styling

## Testing
- npm run ui:lint

------
https://chatgpt.com/codex/tasks/task_e_68d10913eb68832abe41551be33c903b