### PR TITLE
fix: add eslint tsconfig for config file

### DIFF
--- a/apps/react-ui/client/.eslintrc.js
+++ b/apps/react-ui/client/.eslintrc.js
@@ -71,9 +71,9 @@ module.exports = {
 	plugins: ["@typescript-eslint", "react", "react-hooks"],
 	ignorePatterns: ["vite.config.ts", ".eslintrc.js"],
 	parser: "@typescript-eslint/parser",
-	parserOptions: {
-		project: path.resolve(__dirname, "./tsconfig.json"),
-	},
+        parserOptions: {
+                project: path.resolve(__dirname, "./tsconfig.eslint.json"),
+        },
 	env: {
 		jest: true,
 	},

--- a/apps/react-ui/client/tsconfig.eslint.json
+++ b/apps/react-ui/client/tsconfig.eslint.json
@@ -1,0 +1,12 @@
+{
+        "extends": "./tsconfig.json",
+        "include": [
+                "next-env.d.ts",
+                "**/*.ts",
+                "**/*.tsx",
+                ".next/types/**/*.ts",
+                "src/types/global.d.ts",
+                ".eslintrc.js"
+        ],
+        "exclude": ["node_modules", "vitest.config.ts"]
+}


### PR DESCRIPTION
## Summary
- point the client ESLint configuration at a dedicated tsconfig for linting
- add tsconfig.eslint.json so typed linting also covers configuration files

## Testing
- npm run ui:lint

------
https://chatgpt.com/codex/tasks/task_e_68d109d98a98832a90d4ce4d6cf68c07