### PR TITLE
feat: add Egger interval outputs to results summary

### DIFF
--- a/apps/lambda-r-backend/r_scripts/maive_model.R
+++ b/apps/lambda-r-backend/r_scripts/maive_model.R
@@ -245,8 +245,31 @@ run_maive_model <- function(data, parameters) {
   slope_metadata <- parse_slope_metadata(maive_res)
 
   parse_boot_result <- function(boot_result, field) if (is.null(boot_result)) "NA" else boot_result[[field]]
+  format_ci_field <- function(ci_field) {
+    if (is.null(ci_field)) {
+      return("NA")
+    }
+
+    ci_values <- if (is.list(ci_field)) unlist(ci_field) else ci_field
+
+    if (length(ci_values) == 0) {
+      return("NA")
+    }
+
+    if (is.character(ci_values) && length(ci_values) == 1 && ci_values == "NA") {
+      return("NA")
+    }
+
+    if (all(is.na(ci_values))) {
+      return("NA")
+    }
+
+    ci_field
+  }
   boot_se <- parse_boot_result(maive_res$boot_result, "boot_se") # [a, b]
   boot_ci <- parse_boot_result(maive_res$boot_result, "boot_ci") # [[a, b], [c, d]]
+  egger_boot_ci <- format_ci_field(maive_res$egger_boot_ci)
+  egger_ar_ci <- format_ci_field(maive_res$egger_ar_ci)
 
   se_adjusted_for_plot <- if (instrument == 0) NULL else maive_res$SE_instrumented
 
@@ -269,7 +292,9 @@ run_maive_model <- function(data, parameters) {
       pValue = pub_bias_p_value,
       eggerCoef = maive_res$egger_coef,
       eggerSE = maive_res$egger_se,
-      isSignificant = pb_is_significant
+      isSignificant = pb_is_significant,
+      eggerBootCI = egger_boot_ci,
+      eggerAndersonRubinCI = egger_ar_ci
     ),
     firstStageFTest = maive_res[["F-test"]],
     hausmanTest = list(

--- a/apps/react-ui/client/src/lib/text/index.ts
+++ b/apps/react-ui/client/src/lib/text/index.ts
@@ -18,10 +18,11 @@ export type ResultsText = Readonly<{
     bootCI: MetricText;
   }>;
   publicationBias: SectionWithMetrics<{
-    pValue: MetricText;
     eggerCoef: MetricText;
     eggerSE: MetricText;
     significance: MetricText;
+    eggerBootCI: MetricText;
+    eggerAndersonRubinCI: MetricText;
   }>;
   diagnosticTests: SectionWithMetrics<{
     hausmanTest: MetricText;
@@ -66,25 +67,30 @@ const RESULTS_TEXT: ResultsText = {
   publicationBias: {
     title: "Publication Bias and p-hacking Analysis",
     metrics: {
-      pValue: {
-        label: "Egger Test p-value",
-        tooltip:
-          "p-value from the instrumented FAT-PET regression that tests for publication bias / p-hacking after MAIVE adjustment.",
-      },
       eggerCoef: {
-        label: "Egger Coefficient",
+        label: "Egger Coefficient (Estimate)",
         tooltip:
           "Coefficient capturing funnel asymmetry in the instrumented Egger regression.",
       },
       eggerSE: {
-        label: "Standard Error of the Egger Coefficient",
+        label: "Standard Error",
         tooltip:
           "Robust standard error of the coefficient capturing funnel asymmetry in the instrumented Egger regression.",
       },
       significance: {
-        label: "Egger Test Significant at 5% level",
+        label: "Significant at 5% level",
         tooltip:
           "Indicates whether publication bias is statistically significant at the 5% level according to the instrumented FAT test.",
+      },
+      eggerBootCI: {
+        label: "Egger Coefficient Bootstrap 95% CI",
+        tooltip:
+          "Bootstrap 95% confidence interval for the Egger coefficient from the instrumented regression.",
+      },
+      eggerAndersonRubinCI: {
+        label: "Egger Coefficient Anderson-Rubin 95% CI",
+        tooltip:
+          "Weak-instrument-robust 95% Anderson-Rubin confidence interval for the Egger coefficient, matching the options used for the main estimate.",
       },
     },
   },
@@ -374,11 +380,6 @@ export const getResultsText = (
       ...publicationBias,
       metrics: {
         ...publicationBias.metrics,
-        pValue: {
-          ...publicationBias.metrics.pValue,
-          tooltip:
-            "p-value from the Egger regression that tests for publication bias or p-hacking.",
-        },
         eggerCoef: {
           ...publicationBias.metrics.eggerCoef,
           tooltip:
@@ -393,6 +394,16 @@ export const getResultsText = (
           ...publicationBias.metrics.significance,
           tooltip:
             "Indicates whether publication bias is statistically significant at the 5% level according to the Egger test.",
+        },
+        eggerBootCI: {
+          ...publicationBias.metrics.eggerBootCI,
+          tooltip:
+            "Bootstrap 95% confidence interval for the Egger coefficient from the regression without instrumenting.",
+        },
+        eggerAndersonRubinCI: {
+          ...publicationBias.metrics.eggerAndersonRubinCI,
+          tooltip:
+            "Weak-instrument-robust 95% Anderson-Rubin confidence interval for the Egger coefficient when computed without instrumenting.",
         },
       },
     },

--- a/apps/react-ui/client/src/types/api.ts
+++ b/apps/react-ui/client/src/types/api.ts
@@ -39,10 +39,12 @@ type ModelResults = {
   isSignificant: boolean;
   andersonRubinCI: [number, number] | "NA";
   publicationBias: {
-    pValue: number;
     eggerCoef: number;
     eggerSE: number;
     isSignificant: boolean;
+    eggerBootCI: [number, number] | "NA";
+    eggerAndersonRubinCI: [number, number] | "NA";
+    pValue?: number;
   };
   firstStageFTest: number | "NA";
   hausmanTest: {

--- a/apps/react-ui/client/src/utils/mockData.ts
+++ b/apps/react-ui/client/src/utils/mockData.ts
@@ -77,6 +77,20 @@ const generateMockResults = (nrow: number) => {
       eggerCoef: faker.number.float({ min: -2, max: 2, multipleOf: 0.0001 }),
       eggerSE: faker.number.float({ min: 0, max: 1, multipleOf: 0.0001 }),
       isSignificant: faker.datatype.boolean(),
+      eggerBootCI:
+        Math.random() > 0.5
+          ? [
+              faker.number.float({ min: -2, max: 2, multipleOf: 0.0001 }),
+              faker.number.float({ min: -2, max: 2, multipleOf: 0.0001 }),
+            ]
+          : "NA",
+      eggerAndersonRubinCI:
+        Math.random() > 0.5
+          ? [
+              faker.number.float({ min: -2, max: 2, multipleOf: 0.0001 }),
+              faker.number.float({ min: -2, max: 2, multipleOf: 0.0001 }),
+            ]
+          : "NA",
     },
     firstStageFTest:
       Math.random() > 0.5

--- a/apps/react-ui/client/src/utils/resultsDataUtils.ts
+++ b/apps/react-ui/client/src/utils/resultsDataUtils.ts
@@ -91,18 +91,30 @@ export const generateResultsData = (
       section: "bias",
     },
     {
-      label: resultsText.publicationBias.metrics.pValue.label,
-      value: results.publicationBias.pValue,
-      show: true,
-      section: "bias",
-    },
-    {
       label: resultsText.publicationBias.metrics.significance.label,
       value: results.publicationBias.isSignificant ? "Yes" : "No",
       show: true,
       highlightColor: results.publicationBias.isSignificant
         ? "text-green-600"
         : "text-red-600",
+      section: "bias",
+    },
+    {
+      label: resultsText.publicationBias.metrics.eggerBootCI.label,
+      value:
+        results.publicationBias.eggerBootCI !== "NA"
+          ? formatCI(results.publicationBias.eggerBootCI)
+          : "NA",
+      show: results.publicationBias.eggerBootCI !== "NA",
+      section: "bias",
+    },
+    {
+      label: resultsText.publicationBias.metrics.eggerAndersonRubinCI.label,
+      value:
+        results.publicationBias.eggerAndersonRubinCI !== "NA"
+          ? formatCI(results.publicationBias.eggerAndersonRubinCI)
+          : "NA",
+      show: results.publicationBias.eggerAndersonRubinCI !== "NA",
       section: "bias",
     },
     {


### PR DESCRIPTION
## Summary
- align the publication bias panel with the main estimate by showing Egger significance alongside bootstrap and Anderson–Rubin confidence intervals
- update shared copy, types, and mock data to expose the new Egger interval fields returned by the MAIVE service
- extend the R backend payload so egger_boot_ci and egger_ar_ci are forwarded when present

## Testing
- npm run ui:lint
- npm run r:test-e2e *(fails: Rscript not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d124e786dc832a9a8728d01c9dcde1