### PR TITLE
feat: add log first stage option

### DIFF
--- a/apps/lambda-r-backend/r_scripts/maive_model.R
+++ b/apps/lambda-r-backend/r_scripts/maive_model.R
@@ -309,9 +309,9 @@ run_maive_model <- function(data, parameters) {
 
   first_stage_mode <- if (instrument == 1 && isTRUE(log_first_stage)) "log" else "levels"
   first_stage_description <- if (first_stage_mode == "log") {
-    "First stage: log(SE²) ~ log N; Duan smearing applied."
+    "log(SE²) ~ log N; Duan smearing applied"
   } else {
-    "First stage: SE² ~ 1/N."
+    "SE² ~ 1/N"
   }
   first_stage_label <- if (first_stage_mode == "log") {
     "First-Stage F-Test (γ₁)"

--- a/apps/lambda-r-backend/r_scripts/tests/e2e/debug_test.R
+++ b/apps/lambda-r-backend/r_scripts/tests/e2e/debug_test.R
@@ -21,7 +21,8 @@ params <- list(
   computeAndersonRubin = TRUE,
   maiveMethod = "PET",
   weight = "standard_weights",
-  shouldUseInstrumenting = TRUE
+  shouldUseInstrumenting = TRUE,
+  useLogFirstStage = FALSE
 )
 
 # Convert to JSON

--- a/apps/lambda-r-backend/r_scripts/tests/e2e/scenarios/basic_maive_test.R
+++ b/apps/lambda-r-backend/r_scripts/tests/e2e/scenarios/basic_maive_test.R
@@ -80,7 +80,8 @@ test_parameter_combinations <- function() {
         computeAndersonRubin = TRUE,
         maiveMethod = "PET",
         weight = "equal_weights",
-        shouldUseInstrumenting = TRUE
+        shouldUseInstrumenting = TRUE,
+        useLogFirstStage = FALSE
       )
     ),
     list(
@@ -93,7 +94,8 @@ test_parameter_combinations <- function() {
         computeAndersonRubin = FALSE,
         maiveMethod = "PEESE",
         weight = "standard_weights",
-        shouldUseInstrumenting = TRUE
+        shouldUseInstrumenting = TRUE,
+        useLogFirstStage = FALSE
       )
     ),
     list(
@@ -106,7 +108,8 @@ test_parameter_combinations <- function() {
         computeAndersonRubin = TRUE,
         maiveMethod = "EK",
         weight = "adjusted_weights",
-        shouldUseInstrumenting = FALSE
+        shouldUseInstrumenting = FALSE,
+        useLogFirstStage = FALSE
       )
     )
   )

--- a/apps/lambda-r-backend/r_scripts/tests/e2e/scenarios/edge_cases_test.R
+++ b/apps/lambda-r-backend/r_scripts/tests/e2e/scenarios/edge_cases_test.R
@@ -264,7 +264,8 @@ test_invalid_parameters <- function() {
         computeAndersonRubin = TRUE,
         maiveMethod = "INVALID_METHOD",
         weight = "equal_weights",
-        shouldUseInstrumenting = TRUE
+        shouldUseInstrumenting = TRUE,
+        useLogFirstStage = FALSE
       ),
       expected_error = TRUE
     ),
@@ -278,7 +279,8 @@ test_invalid_parameters <- function() {
         computeAndersonRubin = TRUE,
         maiveMethod = "PET-PEESE",
         weight = "standard_weights",
-        shouldUseInstrumenting = TRUE
+        shouldUseInstrumenting = TRUE,
+        useLogFirstStage = FALSE
       ),
       expected_error = TRUE
     )

--- a/apps/lambda-r-backend/r_scripts/tests/e2e/test_config.R
+++ b/apps/lambda-r-backend/r_scripts/tests/e2e/test_config.R
@@ -39,5 +39,6 @@ DEFAULT_PARAMETERS <- list(
   computeAndersonRubin = FALSE,
   maiveMethod = "PET-PEESE",
   weight = "equal_weights",
-  shouldUseInstrumenting = TRUE
+  shouldUseInstrumenting = TRUE,
+  useLogFirstStage = FALSE
 )

--- a/apps/lambda-r-backend/r_scripts/tests/e2e/utils/test_helpers.R
+++ b/apps/lambda-r-backend/r_scripts/tests/e2e/utils/test_helpers.R
@@ -119,6 +119,7 @@ assert_response_structure <- function(response, expected_fields = NULL) {
     data_fields <- c(
       "effectEstimate", "standardError", "isSignificant",
       "andersonRubinCI", "publicationBias", "firstStageFTest",
+      "firstStage",
       "hausmanTest", "seInstrumented", "funnelPlot"
     )
 

--- a/apps/react-ui/client/.eslintrc.js
+++ b/apps/react-ui/client/.eslintrc.js
@@ -69,7 +69,7 @@ module.exports = {
 		"plugin:prettier/recommended",
 	],
 	plugins: ["@typescript-eslint", "react", "react-hooks"],
-	ignorePatterns: ["vite.config.ts", ".eslintrc.js"],
+	ignorePatterns: ["vite.config.ts", "vitest.config.ts", ".eslintrc.js"],
 	parser: "@typescript-eslint/parser",
 	parserOptions: {
 		project: path.resolve(__dirname, "./tsconfig.json"),
@@ -186,5 +186,4 @@ module.exports = {
 	},
 
 	overrides: [],
-	ignorePatterns: ["vitest.config.ts"],
 }

--- a/apps/react-ui/client/src/CONFIG.ts
+++ b/apps/react-ui/client/src/CONFIG.ts
@@ -24,6 +24,7 @@ const CONFIG = {
     maiveMethod: CONST.MAIVE_METHODS.PET_PEESE,
     weight: CONST.WEIGHT_OPTIONS.EQUAL_WEIGHTS.VALUE,
     shouldUseInstrumenting: true,
+    useLogFirstStage: false,
   },
 } as const;
 

--- a/apps/react-ui/client/src/components/Modals/RunInfoModal.tsx
+++ b/apps/react-ui/client/src/components/Modals/RunInfoModal.tsx
@@ -49,6 +49,7 @@ export default function RunInfoModal({
       case "includeStudyClustering":
       case "computeAndersonRubin":
       case "shouldUseInstrumenting":
+      case "useLogFirstStage":
         return value ? "Yes" : "No";
       case "standardErrorTreatment":
         const seTreatment = value as string;

--- a/apps/react-ui/client/src/config/optionsConfig.ts
+++ b/apps/react-ui/client/src/config/optionsConfig.ts
@@ -116,6 +116,15 @@ export const modelOptionsConfig: ModelOptionsConfig = {
         tooltip: TEXT.model.shouldUseInstrumenting.tooltip,
         type: "yesno",
       },
+      {
+        key: "useLogFirstStage",
+        label: TEXT.model.useLogFirstStage.label,
+        tooltip: TEXT.model.useLogFirstStage.tooltip,
+        type: "yesno",
+        visibility: {
+          hideIf: ({ parameters }) => !parameters.shouldUseInstrumenting,
+        },
+      },
     ],
   },
 };

--- a/apps/react-ui/client/src/lib/text/index.ts
+++ b/apps/react-ui/client/src/lib/text/index.ts
@@ -28,6 +28,8 @@ export type ResultsText = Readonly<{
     hausmanTest: MetricText;
     hausmanCriticalValue: MetricText;
     firstStageFTest: MetricText;
+    firstStageFTestLog: MetricText;
+    firstStageSpecification: MetricText;
   }>;
   funnelPlot: Readonly<{
     title: string;
@@ -110,7 +112,17 @@ const RESULTS_TEXT: ResultsText = {
       firstStageFTest: {
         label: "First-Stage F-Test",
         tooltip:
-          "Heteroskedasticity-robust F statistic for the strength of the instrument (inverse sample size) in the first-stage regression of reported variances. Values above 10 denote a strong instrument.",
+          "Heteroskedasticity-robust F statistic for the strength of the instrument (inverse sample size) in the levels first-stage regression of reported variances. Values above 10 denote a strong instrument.",
+      },
+      firstStageFTestLog: {
+        label: "First-Stage F-Test (γ₁)",
+        tooltip:
+          "Heteroskedasticity-robust F statistic for the log-scale slope coefficient (γ₁) in the first-stage regression log(SE²) ~ log N. Values above 10 denote a strong instrument.",
+      },
+      firstStageSpecification: {
+        label: "First-stage specification",
+        tooltip:
+          "Indicates the functional form used for the first-stage variance regression. Log mode reports log(SE²) ~ log N with Duan smearing to return fitted variances to levels.",
       },
     },
   },
@@ -255,6 +267,11 @@ const TEXT = {
       label: "Use Instrumenting",
       tooltip:
         "Whether to use instrumenting in the analysis. When “No” is chosen, you can estimate classical (non-MAIVE) versions of PET, PEESE, PET-PEESE, and EK.",
+    },
+    useLogFirstStage: {
+      label: "Use log first stage",
+      tooltip:
+        "Estimate the first-stage regression on log variances versus log sample size. Applies Duan smearing when transforming fitted variances back to levels.",
     },
     runModel: "Run Model",
   },

--- a/apps/react-ui/client/src/pages/model/index.tsx
+++ b/apps/react-ui/client/src/pages/model/index.tsx
@@ -200,7 +200,9 @@ export default function ModelPage() {
           // Use mock data in development mode
           console.debug("Generating mock results in development mode");
           const nrow = uploadedData?.data.length ?? 0;
-          result = { data: generateMockResults(nrow) };
+          result = {
+            data: generateMockResults(nrow, parameters.useLogFirstStage),
+          };
         } else {
           // This is a client-side call to the server-side API
           // For server-side, use the runModelClient function

--- a/apps/react-ui/client/src/types/api.ts
+++ b/apps/react-ui/client/src/types/api.ts
@@ -21,6 +21,7 @@ type ModelParameters = {
   maiveMethod: "PET" | "PEESE" | "PET-PEESE" | "EK";
   weight: "equal_weights" | "standard_weights" | "adjusted_weights";
   shouldUseInstrumenting: boolean;
+  useLogFirstStage: boolean;
 };
 
 type ModelRequest = {
@@ -58,6 +59,11 @@ type ModelResults = {
   funnelPlotHeight: number;
   bootCI: [[number, number], [number, number]] | "NA";
   bootSE: [number, number] | "NA";
+  firstStage?: {
+    mode: "levels" | "log";
+    description: string;
+    fStatisticLabel?: string;
+  } | null;
 };
 
 type PingResponse = {

--- a/apps/react-ui/client/src/utils/mockData.ts
+++ b/apps/react-ui/client/src/utils/mockData.ts
@@ -54,8 +54,16 @@ const loadRandomMockCsvFile = (): File => {
  * @param nrow - The number of rows in the data.
  * @returns The mock results.
  */
-const generateMockResults = (nrow: number) => {
+const generateMockResults = (nrow: number, useLogFirstStage = false) => {
   const funnelPlotBase64 = mockFunnelPlot;
+
+  const firstStageMode = useLogFirstStage ? "log" : "levels";
+  const firstStageDescription = useLogFirstStage
+    ? "First stage: log(SE²) ~ log N; Duan smearing applied."
+    : "First stage: SE² ~ 1/N.";
+  const firstStageLabel = useLogFirstStage
+    ? "First-Stage F-Test (γ₁)"
+    : "First-Stage F-Test";
 
   return {
     effectEstimate: faker.number.float({ min: 0, max: 1, multipleOf: 0.0001 }),
@@ -111,6 +119,11 @@ const generateMockResults = (nrow: number) => {
     funnelPlot: funnelPlotBase64,
     funnelPlotWidth: 672,
     funnelPlotHeight: 672,
+    firstStage: {
+      mode: firstStageMode,
+      description: firstStageDescription,
+      fStatisticLabel: firstStageLabel,
+    },
   };
 };
 

--- a/apps/react-ui/client/src/utils/mockData.ts
+++ b/apps/react-ui/client/src/utils/mockData.ts
@@ -59,8 +59,8 @@ const generateMockResults = (nrow: number, useLogFirstStage = false) => {
 
   const firstStageMode = useLogFirstStage ? "log" : "levels";
   const firstStageDescription = useLogFirstStage
-    ? "First stage: log(SE²) ~ log N; Duan smearing applied."
-    : "First stage: SE² ~ 1/N.";
+    ? "log(SE²) ~ log N; Duan smearing applied"
+    : "SE² ~ 1/N.";
   const firstStageLabel = useLogFirstStage
     ? "First-Stage F-Test (γ₁)"
     : "First-Stage F-Test";

--- a/apps/react-ui/client/src/utils/resultsDataUtils.ts
+++ b/apps/react-ui/client/src/utils/resultsDataUtils.ts
@@ -47,8 +47,8 @@ export const generateResultsData = (
   const firstStageDescription = results.firstStage?.description ?? null;
   const defaultSpecification =
     firstStageMode === "log"
-      ? "First stage: log(SE²) ~ log N; Duan smearing applied."
-      : "First stage: SE² ~ 1/N.";
+      ? "log(SE²) ~ log N; Duan smearing applied"
+      : "SE² ~ 1/N";
   const specificationValue = firstStageDescription ?? defaultSpecification;
   const firstStageLabelDefault =
     firstStageMode === "log"

--- a/apps/react-ui/client/src/utils/resultsDataUtils.ts
+++ b/apps/react-ui/client/src/utils/resultsDataUtils.ts
@@ -42,6 +42,21 @@ export const generateResultsData = (
     return `[${formatValue(ci[0])}, ${formatValue(ci[1])}]`;
   };
 
+  const isInstrumented = parameters?.shouldUseInstrumenting ?? true;
+  const firstStageMode = results.firstStage?.mode ?? "levels";
+  const firstStageDescription = results.firstStage?.description ?? null;
+  const defaultSpecification =
+    firstStageMode === "log"
+      ? "First stage: log(SE²) ~ log N; Duan smearing applied."
+      : "First stage: SE² ~ 1/N.";
+  const specificationValue = firstStageDescription ?? defaultSpecification;
+  const firstStageLabelDefault =
+    firstStageMode === "log"
+      ? resultsText.diagnosticTests.metrics.firstStageFTestLog.label
+      : resultsText.diagnosticTests.metrics.firstStageFTest.label;
+  const firstStageFStatisticLabel =
+    results.firstStage?.fStatisticLabel ?? firstStageLabelDefault;
+
   // Core results
   const coreResults: ResultItem[] = [
     {
@@ -120,7 +135,7 @@ export const generateResultsData = (
     {
       label: resultsText.diagnosticTests.metrics.hausmanTest.label,
       value: results.hausmanTest.statistic,
-      show: parameters?.shouldUseInstrumenting ?? true,
+      show: isInstrumented,
       highlightColor: results.hausmanTest.rejectsNull
         ? "text-green-600"
         : "text-red-600",
@@ -132,15 +147,19 @@ export const generateResultsData = (
     {
       label: resultsText.diagnosticTests.metrics.hausmanCriticalValue.label,
       value: results.hausmanTest.criticalValue,
-      show: parameters?.shouldUseInstrumenting ?? true,
+      show: isInstrumented,
       section: "tests",
     },
     {
-      label: resultsText.diagnosticTests.metrics.firstStageFTest.label,
+      label: resultsText.diagnosticTests.metrics.firstStageSpecification.label,
+      value: specificationValue,
+      show: isInstrumented,
+      section: "tests",
+    },
+    {
+      label: firstStageFStatisticLabel,
       value: results.firstStageFTest !== "NA" ? results.firstStageFTest : "NA",
-      show:
-        (parameters?.shouldUseInstrumenting ?? true) &&
-        results.firstStageFTest !== "NA",
+      show: isInstrumented && results.firstStageFTest !== "NA",
       highlightColor:
         results.firstStageFTest !== "NA" && results.firstStageFTest >= 10
           ? "text-green-600"


### PR DESCRIPTION
## Summary
- add a `useLogFirstStage` parameter to MAIVE configuration, expose it in the Advanced Options UI, and show the setting in run details
- surface log-mode first-stage diagnostics in results summaries with clear labeling and a specification line
- plumb the option through the R backend to toggle log estimation, ensure positive fitted variances, and update the E2E test fixtures

## Testing
- npm run ui:lint
- npm run ui:test -- -- --reporter basic --silent
- npm run r:test-e2e *(fails: Rscript: not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d12c1f62a0832a81cdca86c6b523ec