### PR TITLE
feat: align about page layout with other screens

### DIFF
--- a/apps/react-ui/client/src/pages/about.tsx
+++ b/apps/react-ui/client/src/pages/about.tsx
@@ -1,6 +1,7 @@
 import Head from "next/head";
 import TEXT from "@lib/text";
 import CONST from "@src/CONST";
+import { GoBackButton } from "@src/components/Buttons";
 import {
   MAIVEInfoContent,
   MAIVEInfoGettingStarted,
@@ -17,32 +18,32 @@ export default function AboutPage() {
           content="Learn how MAIVE corrects for publication bias, p-hacking, and spurious precision."
         />
       </Head>
-      <div className="px-4 py-12 sm:py-16">
-        <div className="max-w-5xl mx-auto space-y-10">
-          <header className="space-y-4 text-center sm:text-left">
-            <p className="text-sm uppercase tracking-wide text-muted">
-              Meta-Analysis Instrumental Variable Estimator
-            </p>
-            <h1 className="text-4xl sm:text-5xl font-bold text-primary">
-              {TEXT.maiveModal.title}
-            </h1>
-            <p className="text-lg text-secondary leading-relaxed max-w-3xl">
-              Adjust your analyses for publication bias, p-hacking, and spurious
-              precision using MAIVE. Explore the methodology, see where it
-              shines, and access the resources that power the estimator.
-            </p>
-          </header>
+      <main className="content-page-container">
+        <div className="max-w-5xl w-full px-2 sm:px-0">
+          <GoBackButton href="/" text="Back to Home" />
 
-          <section className="surface-elevated rounded-xl border border-primary/10 p-6 sm:p-8 space-y-8">
+          <div className="card p-6 sm:p-8 space-y-8">
+            <header className="space-y-4">
+              <h1 className="text-4xl sm:text-5xl font-bold text-primary">
+                {TEXT.maiveModal.title}
+              </h1>
+              <p className="text-lg text-secondary leading-relaxed">
+                Adjust your analyses for publication bias, p-hacking, and
+                spurious precision using MAIVE. Explore the methodology, see
+                where it shines, and access the resources that power the
+                estimator.
+              </p>
+            </header>
+
             <MAIVEInfoContent />
             <MAIVEInfoGettingStarted className="pt-2" shouldShowIcon={false} />
-          </section>
+          </div>
 
-          <div className="text-right">
+          <div className="text-right mt-6">
             <VersionInfo />
           </div>
         </div>
-      </div>
+      </main>
     </>
   );
 }


### PR DESCRIPTION
## Summary
- align the About page with the shared content layout and add the Back to Home control at the top
- render the MAIVE overview and info sections inside a single card that mirrors the info modal styling while keeping the description unique to the page
- retain the existing getting started call-to-action and version info within the refreshed layout

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68da4d1c05e4832a9e2be507871d3c4c