### PR TITLE
Fix demo and model loading experience

### DIFF
--- a/apps/react-ui/client/src/pages/demo.tsx
+++ b/apps/react-ui/client/src/pages/demo.tsx
@@ -77,7 +77,11 @@ export default function DemoPage() {
       </Head>
 
       <main className="content-page-container">
-        <div className="flex w-full flex-1 items-center justify-center px-4 py-12">
+        <div
+          className={`flex w-full flex-1 justify-center px-4 ${
+            isLoading ? "items-start pt-16 pb-12" : "items-center py-12"
+          }`}
+        >
           {hasError ? (
             <div className="max-w-lg w-full space-y-4 text-center">
               <h1 className="text-3xl font-semibold text-primary">

--- a/apps/react-ui/client/src/pages/demo.tsx
+++ b/apps/react-ui/client/src/pages/demo.tsx
@@ -11,6 +11,7 @@ const MINIMUM_VISIBLE_DURATION_MS = 400;
 export default function DemoPage() {
   const router = useRouter();
   const [hasError, setHasError] = useState(false);
+  const [isLoading, setIsLoading] = useState(true);
   const minimumLoaderTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(
     null,
   );
@@ -24,6 +25,7 @@ export default function DemoPage() {
 
   const runDemo = useCallback(async () => {
     setHasError(false);
+    setIsLoading(true);
     clearPendingTimeout();
 
     try {
@@ -47,6 +49,7 @@ export default function DemoPage() {
     } catch (error) {
       console.error("Error loading demo data:", error);
       setHasError(true);
+      setIsLoading(false);
     }
   }, [clearPendingTimeout, router]);
 
@@ -56,6 +59,12 @@ export default function DemoPage() {
       clearPendingTimeout();
     };
   }, [clearPendingTimeout, runDemo]);
+
+  useEffect(() => {
+    if (isLoading) {
+      window.scrollTo({ top: 0, behavior: "smooth" });
+    }
+  }, [isLoading]);
 
   return (
     <>
@@ -67,42 +76,45 @@ export default function DemoPage() {
         />
       </Head>
 
-      <div className="flex items-center justify-center min-h-[60vh] px-4 py-12">
-        {hasError ? (
-          <div className="max-w-lg w-full space-y-4 text-center">
-            <h1 className="text-3xl font-semibold text-primary">
-              We couldn&apos;t load the demo
-            </h1>
-            <p className="text-secondary leading-relaxed">
-              Something went wrong while preparing the demo dataset. Please try
-              again, or return to the home page to continue exploring MAIVE.
-            </p>
-            <div className="flex flex-wrap justify-center gap-3">
-              <ActionButton
-                onClick={() => {
-                  void runDemo();
-                }}
-                variant="primary"
-                size="md"
-              >
-                Try again
-              </ActionButton>
-              <ActionButton href="/" variant="secondary" size="md">
-                Back to home
-              </ActionButton>
+      <main className="content-page-container">
+        <div className="flex w-full flex-1 items-center justify-center px-4 py-12">
+          {hasError ? (
+            <div className="max-w-lg w-full space-y-4 text-center">
+              <h1 className="text-3xl font-semibold text-primary">
+                We couldn&apos;t load the demo
+              </h1>
+              <p className="text-secondary leading-relaxed">
+                Something went wrong while preparing the demo dataset. Please
+                try again, or return to the home page to continue exploring
+                MAIVE.
+              </p>
+              <div className="flex flex-wrap justify-center gap-3">
+                <ActionButton
+                  onClick={() => {
+                    void runDemo();
+                  }}
+                  variant="primary"
+                  size="md"
+                >
+                  Try again
+                </ActionButton>
+                <ActionButton href="/" variant="secondary" size="md">
+                  Back to home
+                </ActionButton>
+              </div>
             </div>
-          </div>
-        ) : (
-          <LoadingCard
-            title="Loading Demo Data..."
-            subtitle="Preparing your demo analysis"
-            color="purple"
-            size="md"
-            fullWidth={false}
-            containerClassName="w-full max-w-md"
-          />
-        )}
-      </div>
+          ) : (
+            <LoadingCard
+              title="Loading Demo Data..."
+              subtitle="Preparing your demo analysis"
+              color="purple"
+              size="md"
+              fullWidth={false}
+              containerClassName="w-full max-w-md"
+            />
+          )}
+        </div>
+      </main>
     </>
   );
 }

--- a/apps/react-ui/client/src/pages/model/index.tsx
+++ b/apps/react-ui/client/src/pages/model/index.tsx
@@ -183,22 +183,10 @@ export default function ModelPage() {
     }));
   }, [parameters.shouldUseInstrumenting, parameters.computeAndersonRubin]);
 
-  const modelLoadingCopy = useMemo(() => {
-    switch (parameters.modelType) {
-      case CONST.MODEL_TYPES.WAIVE:
-        return {
-          title: "Running WAIVE analysis...",
-          subtitle: "Applying weighted adjustments to your dataset.",
-        };
-      case CONST.MODEL_TYPES.MAIVE:
-      default:
-        return {
-          title: "Running MAIVE analysis...",
-          subtitle:
-            "Correcting for publication bias and p-hacking in your results.",
-        };
-    }
-  }, [parameters.modelType]);
+  const modelLoadingCopy = {
+    title: "Running your analysis...",
+    subtitle: "Hang tight while we process your model settings.",
+  };
 
   useEffect(() => {
     if (loading || hasRunModel) {

--- a/apps/react-ui/client/src/pages/model/index.tsx
+++ b/apps/react-ui/client/src/pages/model/index.tsx
@@ -183,9 +183,31 @@ export default function ModelPage() {
     }));
   }, [parameters.shouldUseInstrumenting, parameters.computeAndersonRubin]);
 
+  const modelLoadingCopy = useMemo(() => {
+    switch (parameters.modelType) {
+      case CONST.MODEL_TYPES.WAIVE:
+        return {
+          title: "Running WAIVE analysis...",
+          subtitle: "Applying weighted adjustments to your dataset.",
+        };
+      case CONST.MODEL_TYPES.MAIVE:
+      default:
+        return {
+          title: "Running MAIVE analysis...",
+          subtitle:
+            "Correcting for publication bias and p-hacking in your results.",
+        };
+    }
+  }, [parameters.modelType]);
+
+  useEffect(() => {
+    if (loading || hasRunModel) {
+      window.scrollTo({ top: 0, behavior: "smooth" });
+    }
+  }, [loading, hasRunModel]);
+
   const handleRunModel = useCallback(() => {
     void (async () => {
-      window.scrollTo({ top: 0, behavior: "smooth" }); // Scroll to top of page
       setLoading(true);
       setHasRunModel(true);
       abortControllerRef.current = new AbortController();
@@ -312,7 +334,8 @@ export default function ModelPage() {
             <div className="min-h-[400px] w-full items-center justify-center">
               {loading || hasRunModel ? (
                 <LoadingCard
-                  title={`Running ${parameters.modelType}... Please wait.`}
+                  title={modelLoadingCopy.title}
+                  subtitle={modelLoadingCopy.subtitle}
                   color="blue"
                   size="md"
                 />


### PR DESCRIPTION
## Summary
- ensure the demo loading state uses the standard content layout and scrolls to the top for visibility
- scroll the model page to the top while the analysis spinner is displayed
- tailor the model loading copy to describe the selected model type

## Testing
- npm run ui:lint *(fails: next not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68da534580b4832a8353f71187c33ec2