### PR TITLE
fix: keep funnel plot labels in frame and scale download button

### DIFF
--- a/apps/lambda-r-backend/r_scripts/funnel_plot.R
+++ b/apps/lambda-r-backend/r_scripts/funnel_plot.R
@@ -477,7 +477,8 @@ get_funnel_plot <- function(
   on.exit(par(xpd = par_xpd_old), add = TRUE)
   par(xpd = NA)
 
-  label_y_simple <- min(label_y_simple, par_usr[4] - simple_label_height - vertical_padding)
+  top_limit_simple <- par_usr[4] - simple_label_height - vertical_padding
+  label_y_simple <- min(label_y_simple, top_limit_simple)
   label_x_simple <- clamp_value(
     simple_mean,
     xlim[1] + simple_label_width / 2 + horizontal_padding,
@@ -515,7 +516,8 @@ get_funnel_plot <- function(
       xlim[2] - intercept_label_width / 2 - total_horizontal_padding
     )
 
-    label_y_maive <- min(label_y_maive, par_usr[4] - intercept_label_height - vertical_padding)
+    top_limit_intercept <- par_usr[4] - intercept_label_height - vertical_padding
+    label_y_maive <- min(label_y_maive, top_limit_intercept)
 
     simple_bounds <- c(
       label_x_simple - simple_label_width / 2,
@@ -551,11 +553,6 @@ get_funnel_plot <- function(
           label_y_maive <- min(label_y_maive, desired_baseline)
         }
       }
-    }
-
-    min_baseline <- ylim[1] + vertical_padding
-    if (is.finite(min_baseline)) {
-      label_y_maive <- max(label_y_maive, min_baseline)
     }
 
     if (is.finite(label_x_intercept) && is.finite(label_y_maive)) {

--- a/apps/lambda-r-backend/r_scripts/funnel_plot.R
+++ b/apps/lambda-r-backend/r_scripts/funnel_plot.R
@@ -508,6 +508,11 @@ get_funnel_plot <- function(
 
     intercept_label_width <- convert_width_to_user(strwidth(intercept_label_text, cex = 0.9))
     intercept_label_height <- convert_height_to_user(strheight(intercept_label_text, cex = 0.9))
+    stack_gap <- max(
+      vertical_padding * 1.5,
+      simple_label_height * 0.35,
+      intercept_label_height * 0.35
+    )
 
     total_horizontal_padding <- max(horizontal_padding, intercept_label_width * 0.05)
     label_x_intercept <- clamp_value(
@@ -529,16 +534,16 @@ get_funnel_plot <- function(
     )
 
     ranges_overlap <- !(
-      is.na(simple_bounds[1]) ||
-        is.na(simple_bounds[2]) ||
-        is.na(intercept_bounds[1]) ||
-        is.na(intercept_bounds[2]) ||
+      !is.finite(simple_bounds[1]) ||
+        !is.finite(simple_bounds[2]) ||
+        !is.finite(intercept_bounds[1]) ||
+        !is.finite(intercept_bounds[2]) ||
         intercept_bounds[1] > simple_bounds[2] ||
         intercept_bounds[2] < simple_bounds[1]
     )
 
     if (ranges_overlap) {
-      desired_baseline <- label_y_simple - intercept_label_height - vertical_padding
+      desired_baseline <- label_y_simple - intercept_label_height - stack_gap
       if (is.finite(desired_baseline)) {
         label_y_maive <- min(label_y_maive, desired_baseline)
       }
@@ -548,7 +553,7 @@ get_funnel_plot <- function(
       distance <- abs(label_x_simple - label_x_intercept)
       proximity_threshold <- max(simple_label_width, intercept_label_width) * 0.6
       if (distance < proximity_threshold) {
-        desired_baseline <- label_y_simple - intercept_label_height - vertical_padding
+        desired_baseline <- label_y_simple - intercept_label_height - stack_gap
         if (is.finite(desired_baseline)) {
           label_y_maive <- min(label_y_maive, desired_baseline)
         }

--- a/apps/lambda-r-backend/r_scripts/funnel_plot.R
+++ b/apps/lambda-r-backend/r_scripts/funnel_plot.R
@@ -424,43 +424,149 @@ get_funnel_plot <- function(
 
   box()
 
+  clamp_value <- function(value, lower, upper) {
+    if (is.na(value) || !is.finite(value)) {
+      return(value)
+    }
+    if (!is.finite(lower) || !is.finite(upper)) {
+      return(value)
+    }
+    if (lower > upper) {
+      midpoint <- (lower + upper) / 2
+      return(midpoint)
+    }
+    max(min(value, upper), lower)
+  }
+
+  convert_width_to_user <- function(width_in_inches) {
+    pin <- par("pin")
+    if (length(pin) < 2 || pin[1] <= 0) {
+      return(0)
+    }
+    width_in_inches * x_span / pin[1]
+  }
+
+  convert_height_to_user <- function(height_in_inches) {
+    pin <- par("pin")
+    if (length(pin) < 2 || pin[2] <= 0) {
+      return(0)
+    }
+    height_in_inches * y_span / pin[2]
+  }
+
   par_usr <- par("usr")
+  x_span <- abs(par_usr[2] - par_usr[1])
+  if (!is.finite(x_span) || x_span == 0) {
+    x_span <- 1
+  }
   y_span <- abs(par_usr[4] - par_usr[3])
+  if (!is.finite(y_span) || y_span == 0) {
+    y_span <- 1
+  }
   top_offset <- y_span * 0.04
   label_y_simple <- par_usr[4] - top_offset
   label_y_maive <- label_y_simple
+
+  simple_label <- paste0("Simple mean = ", round(simple_mean, 2))
+  simple_label_width <- convert_width_to_user(strwidth(simple_label, cex = 0.9))
+  simple_label_height <- convert_height_to_user(strheight(simple_label, cex = 0.9))
+  horizontal_padding <- max(x_span * 0.01, simple_label_width * 0.05)
+  vertical_padding <- y_span * 0.01
 
   par_xpd_old <- par("xpd")
   on.exit(par(xpd = par_xpd_old), add = TRUE)
   par(xpd = NA)
 
-  text(
+  label_y_simple <- min(label_y_simple, par_usr[4] - simple_label_height - vertical_padding)
+  label_x_simple <- clamp_value(
     simple_mean,
-    label_y_simple,
-    labels = paste0("Simple mean = ", round(simple_mean, 2)),
-    cex = 0.9,
-    adj = c(0.5, 0)
+    xlim[1] + simple_label_width / 2 + horizontal_padding,
+    xlim[2] - simple_label_width / 2 - horizontal_padding
   )
 
-  if (!is.null(intercept) && !is.null(intercept_se)) {
-    x_range <- diff(range(xlim))
-    if (!is.finite(x_range) || x_range == 0) {
-      x_range <- 1
-    }
-    distance <- abs(simple_mean - intercept)
-    if (is.finite(distance) && distance < 0.2 * x_range) {
-      label_y_maive <- label_y_simple - y_span * 0.05
-    }
-
-    intercept_label <- if (instrument == 0) "Regression fit" else "MAIVE"
-
+  if (is.finite(label_x_simple)) {
     text(
-      intercept,
-      label_y_maive,
-      labels = paste0(intercept_label, " = ", round(intercept, 2), " (SE = ", round(intercept_se, 2), ")"),
+      label_x_simple,
+      label_y_simple,
+      labels = simple_label,
       cex = 0.9,
       adj = c(0.5, 0)
     )
+  }
+
+  if (!is.null(intercept) && !is.null(intercept_se) && is.finite(intercept)) {
+    intercept_label <- if (instrument == 0) "Regression fit" else "MAIVE"
+    intercept_label_text <- paste0(
+      intercept_label,
+      " = ",
+      round(intercept, 2),
+      " (SE = ",
+      round(intercept_se, 2),
+      ")"
+    )
+
+    intercept_label_width <- convert_width_to_user(strwidth(intercept_label_text, cex = 0.9))
+    intercept_label_height <- convert_height_to_user(strheight(intercept_label_text, cex = 0.9))
+
+    total_horizontal_padding <- max(horizontal_padding, intercept_label_width * 0.05)
+    label_x_intercept <- clamp_value(
+      intercept,
+      xlim[1] + intercept_label_width / 2 + total_horizontal_padding,
+      xlim[2] - intercept_label_width / 2 - total_horizontal_padding
+    )
+
+    label_y_maive <- min(label_y_maive, par_usr[4] - intercept_label_height - vertical_padding)
+
+    simple_bounds <- c(
+      label_x_simple - simple_label_width / 2,
+      label_x_simple + simple_label_width / 2
+    )
+    intercept_bounds <- c(
+      label_x_intercept - intercept_label_width / 2,
+      label_x_intercept + intercept_label_width / 2
+    )
+
+    ranges_overlap <- !(
+      is.na(simple_bounds[1]) ||
+        is.na(simple_bounds[2]) ||
+        is.na(intercept_bounds[1]) ||
+        is.na(intercept_bounds[2]) ||
+        intercept_bounds[1] > simple_bounds[2] ||
+        intercept_bounds[2] < simple_bounds[1]
+    )
+
+    if (ranges_overlap) {
+      desired_baseline <- label_y_simple - intercept_label_height - vertical_padding
+      if (is.finite(desired_baseline)) {
+        label_y_maive <- min(label_y_maive, desired_baseline)
+      }
+    }
+
+    if (is.finite(label_x_simple) && is.finite(label_x_intercept)) {
+      distance <- abs(label_x_simple - label_x_intercept)
+      proximity_threshold <- max(simple_label_width, intercept_label_width) * 0.6
+      if (distance < proximity_threshold) {
+        desired_baseline <- label_y_simple - intercept_label_height - vertical_padding
+        if (is.finite(desired_baseline)) {
+          label_y_maive <- min(label_y_maive, desired_baseline)
+        }
+      }
+    }
+
+    min_baseline <- ylim[1] + vertical_padding
+    if (is.finite(min_baseline)) {
+      label_y_maive <- max(label_y_maive, min_baseline)
+    }
+
+    if (is.finite(label_x_intercept) && is.finite(label_y_maive)) {
+      text(
+        label_x_intercept,
+        label_y_maive,
+        labels = intercept_label_text,
+        cex = 0.9,
+        adj = c(0.5, 0)
+      )
+    }
   }
 
   par(xpd = par_xpd_old)

--- a/apps/react-ui/client/src/components/Buttons/DownloadButton.tsx
+++ b/apps/react-ui/client/src/components/Buttons/DownloadButton.tsx
@@ -17,6 +17,9 @@ export default function DownloadButton({
 }: DownloadButtonProps) {
   const [isLoading, setIsLoading] = useState(false);
 
+  const buttonSize = "clamp(1.5rem, 1.5rem + 1vw, 2.5rem)";
+  const iconSizeClass = "h-[55%] w-[55%]";
+
   const handleClick = () => {
     if (disabled || isLoading) {
       return;
@@ -34,12 +37,16 @@ export default function DownloadButton({
     <button
       onClick={handleClick}
       disabled={disabled || isLoading}
-      className={`inline-flex items-center justify-center w-10 h-10 text-sm font-medium bg-gray-600 hover:bg-gray-700 disabled:bg-gray-400 disabled:cursor-not-allowed transition-colors duration-200 text-white shadow-md hover:shadow-lg rounded-lg ${className}`}
+      className={`inline-flex items-center justify-center text-sm font-medium bg-gray-600 hover:bg-gray-700 disabled:bg-gray-400 disabled:cursor-not-allowed transition-colors duration-200 text-white shadow-md hover:shadow-lg rounded-lg ${className}`}
+      style={{
+        width: buttonSize,
+        height: buttonSize,
+      }}
       title={title}
     >
       {isLoading ? (
         <svg
-          className="animate-spin h-5 w-5 text-white"
+          className={`animate-spin text-white ${iconSizeClass}`}
           xmlns="http://www.w3.org/2000/svg"
           fill="none"
           viewBox="0 0 24 24"
@@ -60,7 +67,7 @@ export default function DownloadButton({
         </svg>
       ) : (
         <svg
-          className="w-5 h-5"
+          className={iconSizeClass}
           fill="none"
           stroke="currentColor"
           viewBox="0 0 24 24"


### PR DESCRIPTION
## Summary
- clamp funnel plot summary labels within the plot bounds and reuse device metrics to keep annotations readable
- refine MAIVE/regression label stacking logic so overlapping captions drop below the simple mean marker in edge cases
- scale the funnel plot download button and icons with viewport size so the control stays proportional on smaller screens

## Testing
- npm run ui:lint *(fails: `next` command not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68da53ec2d8c832ab7f2254112f6065c