### PR TITLE
fix: filter non-finite values during validation

### DIFF
--- a/apps/react-ui/client/src/pages/validation/index.tsx
+++ b/apps/react-ui/client/src/pages/validation/index.tsx
@@ -244,7 +244,9 @@ const analyzeNormalizedRows = (
     }
   });
 
-  const sanitizedRows = rows.filter((_, index) => !invalidRowIndexes.has(index));
+  const sanitizedRows = rows.filter(
+    (_, index) => !invalidRowIndexes.has(index),
+  );
 
   return {
     sanitizedRows,
@@ -416,8 +418,7 @@ const validateData = (
       message:
         formatted.length > 0
           ? `The data contains missing values in ${formatted}. These rows will be removed from the analysis.`
-          :
-            "The data contains missing values. These rows will be removed from the analysis.",
+          : "The data contains missing values. These rows will be removed from the analysis.",
     });
   }
 
@@ -431,8 +432,7 @@ const validateData = (
       message:
         formatted.length > 0
           ? `Rows with infinite values (${formatted}) were removed before running the analysis. Please replace these values if you want them included.`
-          :
-            "Rows with infinite values were removed before running the analysis. Please replace these values if you want them included.",
+          : "Rows with infinite values were removed before running the analysis. Please replace these values if you want them included.",
     });
   }
 


### PR DESCRIPTION
## Summary
- add normalization helpers that flag missing and infinite values before storing mapped data
- warn users about rows removed for missing or infinite values and drop them from analysis inputs
- ensure sanitized data is persisted so the backend only receives finite numeric values

## Testing
- npm run ui:lint *(fails: next not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68da56d5122c832abfd5e794c50c73fe