### PR TITLE
fix: center MAIVE info buttons on small screens

### DIFF
--- a/apps/react-ui/client/src/components/Buttons/ActionButton.tsx
+++ b/apps/react-ui/client/src/components/Buttons/ActionButton.tsx
@@ -46,7 +46,7 @@ const ActionButton = forwardRef<HTMLButtonElement, ActionButtonProps>(
           lg: "px-6",
         }[size];
 
-    const baseClasses = `${sizeClasses[size]} ${paddingClasses} rounded-lg transition-colors duration-200 font-medium items-center justify-center`;
+    const baseClasses = `${sizeClasses[size]} ${paddingClasses} rounded-lg transition-colors duration-200 font-medium inline-flex items-center justify-center text-center`;
 
     const variantClasses = {
       primary:

--- a/apps/react-ui/client/src/components/MAIVEInfo/MAIVEInfoGettingStarted.tsx
+++ b/apps/react-ui/client/src/components/MAIVEInfo/MAIVEInfoGettingStarted.tsx
@@ -19,13 +19,18 @@ export default function MAIVEInfoGettingStarted({
       <p className="text-secondary leading-relaxed mb-4">
         {TEXT.maiveModal.gettingStarted.text}
       </p>
-      <div className="flex flex-wrap gap-3">
+      <div className="flex flex-wrap gap-3 justify-center sm:justify-start">
         <DemoButton
           size="md"
           className="w-full sm:w-auto"
           shouldShowIcon={shouldShowIcon}
         />
-        <ActionButton href="/upload" variant="primary" size="md">
+        <ActionButton
+          href="/upload"
+          variant="primary"
+          size="md"
+          className="w-full sm:w-auto"
+        >
           {TEXT.maiveModal.uploadYourData}
         </ActionButton>
       </div>


### PR DESCRIPTION
## Summary
- center MAIVE info modal buttons on small screens while keeping existing large screen alignment
- ensure both action buttons expand to full width on narrow viewports for consistent spacing

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68da67cf6864832a83efb2845677f3a8