### PR TITLE
feat: clarify instrumenting toggle messaging

### DIFF
--- a/apps/react-ui/client/src/components/Alert/index.tsx
+++ b/apps/react-ui/client/src/components/Alert/index.tsx
@@ -7,6 +7,7 @@ const Alert = ({
   className = "",
   onClick,
   standalone = false,
+  role = "alert",
 }: AlertProps) => {
   const getAlertStyles = () => {
     switch (type) {
@@ -90,7 +91,8 @@ const Alert = ({
     <div
       className={`flex items-start p-4 rounded-lg border ${getAlertStyles()} ${!!standalone ? "fixed left-6 bottom-6 z-50 min-w-[250px] max-w-xs opacity-95" : ""} ${className} ${onClick ? "cursor-pointer" : "cursor-default"}`}
       onClick={onClick}
-      role="alert"
+      role={role}
+      aria-live={role === "status" ? "polite" : undefined}
     >
       <div className="flex-shrink-0 mr-3 mt-0.5">{getIcon()}</div>
       <div className="flex-1">

--- a/apps/react-ui/client/src/components/Alert/types.ts
+++ b/apps/react-ui/client/src/components/Alert/types.ts
@@ -6,6 +6,7 @@ type AlertProps = {
   className?: string;
   onClick?: () => void;
   standalone?: boolean;
+  role?: "alert" | "status";
 };
 
 export type { AlertType, AlertProps };

--- a/apps/react-ui/client/src/components/Alert/types.ts
+++ b/apps/react-ui/client/src/components/Alert/types.ts
@@ -1,7 +1,8 @@
+import type { ReactNode } from "react";
 import type { AlertType } from "@src/types/alert";
 
 type AlertProps = {
-  message: string;
+  message: ReactNode;
   type?: AlertType;
   className?: string;
   onClick?: () => void;

--- a/apps/react-ui/client/src/components/CitationReminder.tsx
+++ b/apps/react-ui/client/src/components/CitationReminder.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import TEXT from "@src/lib/text";
+import renderRichInfoMessage from "@src/lib/text/richText";
 
 type CitationReminderProps = {
   className?: string;
@@ -46,7 +47,7 @@ const CitationReminder = ({
             }`}
           >
             <span className="font-medium">Citation:</span>{" "}
-            {TEXT.citation.reminder.text}
+            {renderRichInfoMessage(TEXT.citation.reminder.richText)}
           </p>
         </div>
       </div>
@@ -85,7 +86,7 @@ const CitationReminder = ({
           }`}
         >
           <p className="font-medium mb-1">{TEXT.citation.reminder.title}</p>
-          <p>{TEXT.citation.reminder.text}</p>
+          <p>{renderRichInfoMessage(TEXT.citation.reminder.richText)}</p>
         </div>
       </div>
     </div>

--- a/apps/react-ui/client/src/components/Options/OptionRenderer.tsx
+++ b/apps/react-ui/client/src/components/Options/OptionRenderer.tsx
@@ -32,6 +32,9 @@ export default function OptionRenderer({
       ? TEXT.model.maiveMethod.nonInstrumentingLabel
       : option.label;
 
+  const noInstrumentingInfo =
+    TEXT.model.shouldUseInstrumenting.noInstrumentingInfo;
+
   const renderOption = () => {
     switch (option.type) {
       case "yesno":
@@ -102,7 +105,15 @@ export default function OptionRenderer({
       {option.key === "shouldUseInstrumenting" &&
         !parameters.shouldUseInstrumenting && (
           <Alert
-            message={TEXT.model.shouldUseInstrumenting.noInstrumentingInfo}
+            message={
+              <>
+                {noInstrumentingInfo.leading}
+                <em>{noInstrumentingInfo.citation}</em>
+                {noInstrumentingInfo.postCitation}
+                <strong>{noInstrumentingInfo.citeButtonLabel}</strong>
+                {noInstrumentingInfo.postCiteButton}
+              </>
+            }
             type={CONST.ALERT_TYPES.INFO}
             className="mt-3"
             role="status"

--- a/apps/react-ui/client/src/components/Options/OptionRenderer.tsx
+++ b/apps/react-ui/client/src/components/Options/OptionRenderer.tsx
@@ -7,6 +7,7 @@ import type { ModelParameters } from "@src/types/api";
 import CONFIG from "@src/CONFIG";
 import CONST from "@src/CONST";
 import TEXT from "@src/lib/text";
+import renderRichInfoMessage from "@src/lib/text/richText";
 
 type OptionRendererProps = {
   option: OptionConfig;
@@ -87,7 +88,11 @@ export default function OptionRenderer({
       .map((warning, index) => (
         <Alert
           key={index}
-          message={warning.message}
+          message={
+            warning.richText
+              ? renderRichInfoMessage(warning.richText)
+              : warning.message
+          }
           type={warning.type}
           className="mt-3"
         />
@@ -105,15 +110,7 @@ export default function OptionRenderer({
       {option.key === "shouldUseInstrumenting" &&
         !parameters.shouldUseInstrumenting && (
           <Alert
-            message={
-              <>
-                {noInstrumentingInfo.leading}
-                <em>{noInstrumentingInfo.citation}</em>
-                {noInstrumentingInfo.postCitation}
-                <strong>{noInstrumentingInfo.citeButtonLabel}</strong>
-                {noInstrumentingInfo.postCiteButton}
-              </>
-            }
+            message={renderRichInfoMessage(noInstrumentingInfo)}
             type={CONST.ALERT_TYPES.INFO}
             className="mt-3"
             role="status"

--- a/apps/react-ui/client/src/components/Options/OptionRenderer.tsx
+++ b/apps/react-ui/client/src/components/Options/OptionRenderer.tsx
@@ -6,6 +6,7 @@ import type { OptionConfig } from "@src/types/options";
 import type { ModelParameters } from "@src/types/api";
 import CONFIG from "@src/CONFIG";
 import CONST from "@src/CONST";
+import TEXT from "@src/lib/text";
 
 type OptionRendererProps = {
   option: OptionConfig;
@@ -26,12 +27,17 @@ export default function OptionRenderer({
     onChange(option.key, newValue);
   };
 
+  const optionLabel =
+    option.key === "maiveMethod" && !parameters.shouldUseInstrumenting
+      ? TEXT.model.maiveMethod.nonInstrumentingLabel
+      : option.label;
+
   const renderOption = () => {
     switch (option.type) {
       case "yesno":
         return (
           <YesNoSelect
-            label={option.label}
+            label={optionLabel}
             value={value as boolean}
             onChange={handleChange as (value: boolean) => void}
             className={option.className}
@@ -54,7 +60,7 @@ export default function OptionRenderer({
             : option.options;
         return (
           <DropdownSelect
-            label={option.label}
+            label={optionLabel}
             value={value as string}
             onChange={handleChange as (value: string) => void}
             options={dropdownOptions}
@@ -93,6 +99,15 @@ export default function OptionRenderer({
       >
         {renderOption()}
       </Tooltip>
+      {option.key === "shouldUseInstrumenting" &&
+        !parameters.shouldUseInstrumenting && (
+          <Alert
+            message={TEXT.model.shouldUseInstrumenting.noInstrumentingInfo}
+            type={CONST.ALERT_TYPES.INFO}
+            className="mt-3"
+            role="status"
+          />
+        )}
       {renderWarnings()}
     </div>
   );

--- a/apps/react-ui/client/src/config/optionsConfig.ts
+++ b/apps/react-ui/client/src/config/optionsConfig.ts
@@ -85,6 +85,7 @@ export const modelOptionsConfig: ModelOptionsConfig = {
             type: CONST.ALERT_TYPES.INFO,
             condition: (parameters: ModelParameters) =>
               parameters.maiveMethod !== CONST.MAIVE_METHODS.PET_PEESE,
+            richText: TEXT.citation.reminder.richText,
           },
         ],
       },

--- a/apps/react-ui/client/src/lib/text/index.ts
+++ b/apps/react-ui/client/src/lib/text/index.ts
@@ -256,6 +256,7 @@ const TEXT = {
     },
     maiveMethod: {
       label: "MAIVE Method",
+      nonInstrumentingLabel: "Method",
       tooltip: "The correction method to use. PET-PEESE is the default.",
     },
     weight: {
@@ -267,6 +268,8 @@ const TEXT = {
       label: "Use Instrumenting",
       tooltip:
         "Whether to use instrumenting in the analysis. When “No” is chosen, you can estimate classical (non-MAIVE) versions of PET, PEESE, PET-PEESE, and EK.",
+      noInstrumentingInfo:
+        "Without instrumenting, this run is not MAIVE. Please still cite *Irsova et al., Nature Communications (2025)* as the app used using the button in the footer if you use this tool in your research.",
     },
     useLogFirstStage: {
       label: "Use log first stage",

--- a/apps/react-ui/client/src/lib/text/index.ts
+++ b/apps/react-ui/client/src/lib/text/index.ts
@@ -268,8 +268,15 @@ const TEXT = {
       label: "Use Instrumenting",
       tooltip:
         "Whether to use instrumenting in the analysis. When “No” is chosen, you can estimate classical (non-MAIVE) versions of PET, PEESE, PET-PEESE, and EK.",
-      noInstrumentingInfo:
-        "Without instrumenting, this run is not MAIVE. Please still cite *Irsova et al., Nature Communications (2025)* as the app used using the button in the footer if you use this tool in your research.",
+      noInstrumentingInfo: {
+        leading:
+          "Without instrumenting, this run is not MAIVE. Please still cite ",
+        citation: "Irsova et al., Nature Communications (2025)",
+        postCitation: " using the ",
+        citeButtonLabel: "Cite",
+        postCiteButton:
+          " button in the footer if you use this tool in your research.",
+      },
     },
     useLogFirstStage: {
       label: "Use log first stage",

--- a/apps/react-ui/client/src/lib/text/index.ts
+++ b/apps/react-ui/client/src/lib/text/index.ts
@@ -3,6 +3,14 @@ type MetricText = Readonly<{
   tooltip: string;
 }>;
 
+export type RichInfoMessage = Readonly<{
+  leading: string;
+  citation: string;
+  postCitation: string;
+  citeButtonLabel: string;
+  postCiteButton: string;
+}>;
+
 type SectionWithMetrics<TMetrics extends Record<string, MetricText>> =
   Readonly<{
     title: string;
@@ -147,6 +155,15 @@ const TEXT = {
     reminder: {
       title: "Citation Reminder",
       text: "This method is included in the MAIVE app (Irsova et al., Nature Communications, 2025). Please cite the paper using the button in the footer if you use this tool in your research.",
+      richText: {
+        leading: "This method is included in the MAIVE app (",
+        citation: "Irsova et al., Nature Communications, 2025",
+        postCitation:
+          "). Please cite the paper using the ",
+        citeButtonLabel: "Cite",
+        postCiteButton:
+          " button in the footer if you use this tool in your research.",
+      },
     },
     title: "How to Cite This App",
     description:
@@ -272,7 +289,7 @@ const TEXT = {
         leading:
           "Without instrumenting, this run is not MAIVE. Please still cite ",
         citation: "Irsova et al., Nature Communications (2025)",
-        postCitation: " using the ",
+        postCitation: " as the app used using the ",
         citeButtonLabel: "Cite",
         postCiteButton:
           " button in the footer if you use this tool in your research.",

--- a/apps/react-ui/client/src/lib/text/index.ts
+++ b/apps/react-ui/client/src/lib/text/index.ts
@@ -158,8 +158,7 @@ const TEXT = {
       richText: {
         leading: "This method is included in the MAIVE app (",
         citation: "Irsova et al., Nature Communications, 2025",
-        postCitation:
-          "). Please cite the paper using the ",
+        postCitation: "). Please cite the paper using the ",
         citeButtonLabel: "Cite",
         postCiteButton:
           " button in the footer if you use this tool in your research.",

--- a/apps/react-ui/client/src/lib/text/richText.tsx
+++ b/apps/react-ui/client/src/lib/text/richText.tsx
@@ -1,0 +1,22 @@
+import React from "react";
+import type { ReactNode } from "react";
+
+import type { RichInfoMessage } from "@src/lib/text";
+
+export const renderRichInfoMessage = ({
+  leading,
+  citation,
+  postCitation,
+  citeButtonLabel,
+  postCiteButton,
+}: RichInfoMessage): ReactNode => (
+  <>
+    {leading}
+    <em>{citation}</em>
+    {postCitation}
+    <strong>{citeButtonLabel}</strong>
+    {postCiteButton}
+  </>
+);
+
+export default renderRichInfoMessage;

--- a/apps/react-ui/client/src/types/options.ts
+++ b/apps/react-ui/client/src/types/options.ts
@@ -1,5 +1,6 @@
 import type { AlertType } from "./alert";
 import type { ModelParameters } from "./api";
+import type { RichInfoMessage } from "@src/lib/text";
 
 // Visibility control for options
 export type OptionVisibility = {
@@ -25,6 +26,7 @@ export type OptionWarning = {
   message: string;
   type: AlertType;
   condition: (parameters: ModelParameters) => boolean;
+  richText?: RichInfoMessage;
 };
 
 // Base option configuration that all options share


### PR DESCRIPTION
## Summary
- display an information banner when instrumenting is disabled to clarify the run is not MAIVE
- relabel the MAIVE method selector to "Method" whenever instrumenting is turned off while leaving existing messaging intact
- enhance the shared Alert component to support polite status announcements used by the new banner

## Testing
- npm run ui:lint *(fails: `next` command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68da6997f604832a8ef83ffe972b0d95