### PR TITLE
fix: guard MAIVE confidence interval names

### DIFF
--- a/apps/lambda-r-backend/r_scripts/maive_model.R
+++ b/apps/lambda-r-backend/r_scripts/maive_model.R
@@ -78,9 +78,10 @@ patch_maive_confidence_interval <- local({
           res <- c(lower = NA_real_, upper = NA_real_)
         } else {
           res <- rep(res, length.out = 2L)
-          names(res) <- c("lower", "upper")
         }
-      } else if (is.atomic(res) && length(res) == 2L && is.null(names(res))) {
+      }
+
+      if (is.atomic(res) && length(res) == 2L) {
         names(res) <- c("lower", "upper")
       }
 


### PR DESCRIPTION
## Summary
- adjust the MAIVE confidence interval patch to only set bounds names when the result contains two values
- ensure single-value intervals are expanded before naming to avoid length mismatches

## Testing
- npm run lambda:test *(fails: `Rscript` is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68df61f37508832aac43c96470ceb6e7