### PR TITLE
Hide Egger bootstrap CI when standard errors not bootstrapped

### DIFF
--- a/apps/react-ui/client/src/utils/resultsDataUtils.ts
+++ b/apps/react-ui/client/src/utils/resultsDataUtils.ts
@@ -95,6 +95,9 @@ export const generateResultsData = (
   const shouldShowHausman = isInstrumented && !hasFixedIntercept;
   const firstStageMode = results.firstStage?.mode ?? "levels";
   const firstStageDescription = results.firstStage?.description ?? null;
+  const shouldShowBootstrapResults =
+    parameters?.standardErrorTreatment === undefined ||
+    parameters.standardErrorTreatment === "bootstrap";
   const defaultSpecification =
     firstStageMode === "log"
       ? "log(SE²) ~ log N; Duan smearing applied"
@@ -131,7 +134,7 @@ export const generateResultsData = (
     {
       label: resultsText.effectEstimate.metrics.bootCI.label,
       value: bootCI ? formatCI(bootCI[0]) : "NA",
-      show: Boolean(bootCI),
+      show: shouldShowBootstrapResults && Boolean(bootCI),
       section: "effect",
     },
     {
@@ -164,7 +167,7 @@ export const generateResultsData = (
     {
       label: resultsText.publicationBias.metrics.eggerBootCI.label,
       value: eggerBootCI ? formatCI(eggerBootCI) : "NA",
-      show: Boolean(eggerBootCI),
+      show: shouldShowBootstrapResults && Boolean(eggerBootCI),
       section: "bias",
     },
     {


### PR DESCRIPTION
## Summary
- hide bootstrap confidence interval rows unless the bootstrap standard error treatment is selected
- ensure Egger publication bias metrics follow the same display rule as the corrected mean estimate

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e2511a5234832aac26dff62b67e8e6