### PR TITLE
fix: align standard error tooltips with selected treatment

### DIFF
--- a/apps/react-ui/client/src/lib/text/index.ts
+++ b/apps/react-ui/client/src/lib/text/index.ts
@@ -57,7 +57,8 @@ const STANDARD_ERROR_TREATMENT_TOOLTIPS: Record<
   clustered: "Cluster-robust standard error",
   clustered_cr2:
     "Cluster-robust standard error (CR2); robust to a small number of clusters",
-  bootstrap: "Wild bootstrap standard error; robust to a small number of clusters",
+  bootstrap:
+    "Wild bootstrap standard error; robust to a small number of clusters",
 };
 
 const RESULTS_TEXT: ResultsText = {

--- a/apps/react-ui/client/src/pages/results/index.tsx
+++ b/apps/react-ui/client/src/pages/results/index.tsx
@@ -65,8 +65,12 @@ export default function ResultsPage() {
   const dataInfo = useMemo(() => generateDataInfo(dataId), [dataId]);
 
   const resultsText = useMemo(
-    () => getResultsText(shouldUseInstrumenting),
-    [shouldUseInstrumenting],
+    () =>
+      getResultsText(
+        shouldUseInstrumenting,
+        parsedParameters.standardErrorTreatment,
+      ),
+    [shouldUseInstrumenting, parsedParameters.standardErrorTreatment],
   );
 
   if (!results) {

--- a/apps/react-ui/client/src/utils/dataUtils.ts
+++ b/apps/react-ui/client/src/utils/dataUtils.ts
@@ -413,6 +413,7 @@ export const exportComprehensiveResults = (
 
   const resultsText = getResultsText(
     parameters?.shouldUseInstrumenting ?? true,
+    parameters?.standardErrorTreatment ?? "not_clustered",
   );
 
   // Sheet 1: Results Summary


### PR DESCRIPTION
## Summary
- map each standard error treatment to a specific tooltip description in the shared results text helper
- update results rendering and export utilities to request text with the selected treatment so tooltips stay consistent

## Testing
- npm run ui:lint *(fails: `next` binary is unavailable in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e250b61670832a88a9b7773dd2882a