### PR TITLE
fix: restore enter key behavior on validation continue button

### DIFF
--- a/apps/react-ui/client/src/pages/validation/index.tsx
+++ b/apps/react-ui/client/src/pages/validation/index.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import Head from "next/head";
 import { useRouter, useSearchParams } from "next/navigation";
 
@@ -18,6 +18,7 @@ import type { ColumnMapping, UploadedData } from "@store/dataStore";
 import type { AlertType, DataArray } from "@src/types";
 import { parseLocalizedNumber } from "@utils/dataUtils";
 import { DataProcessingService } from "@src/services/dataProcessingService";
+import { useEnterKeyAction } from "@src/hooks/useEnterKeyAction";
 
 const REQUIRED_FIELDS: Array<keyof ColumnMapping> = ["effect", "se", "nObs"];
 
@@ -488,6 +489,15 @@ export default function ValidationPage() {
   const [normalizedData, setNormalizedData] = useState<DataArray>([]);
   const [normalizationIssues, setNormalizationIssues] =
     useState<NormalizationIssues>(createEmptyNormalizationIssues);
+  const continueButtonRef = useRef<HTMLButtonElement>(null);
+
+  useEnterKeyAction(() => {
+    const button = continueButtonRef.current;
+
+    if (button && !button.disabled) {
+      button.click();
+    }
+  });
 
   useEffect(() => {
     if (!dataId) {
@@ -897,6 +907,7 @@ export default function ValidationPage() {
                 )}
 
                 <ActionButton
+                  ref={continueButtonRef}
                   onClick={handleContinue}
                   variant="primary"
                   className="w-full"


### PR DESCRIPTION
## Summary
- restore the Enter key shortcut on the validation page by wiring the main Continue button to the shared useEnterKeyAction hook
- ensure the handler only clicks the button when it is enabled so the shortcut mirrors manual interaction

## Testing
- npm run ui:lint *(fails: `next` command is unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e4a8ec8ea4832ab4f517d933aecb17