### PR TITLE
feat: add subsample filtering before validation

### DIFF
--- a/apps/react-ui/client/src/lib/text/index.ts
+++ b/apps/react-ui/client/src/lib/text/index.ts
@@ -250,6 +250,28 @@ const TEXT = {
     resultsTitle: "Validation results",
     resultsDescription:
       "Review the findings below. Fix any errors before proceeding to modeling.",
+    filter: {
+      title: "Use subsample filter?",
+      description:
+        "Rows that do not match the conditions will be excluded from all downstream analyses.",
+      prompt: "Would you like to include only a subset of your data in the analysis?",
+      yes: "Yes",
+      no: "No",
+      conditionALabel: "Condition A",
+      conditionBLabel: "Condition B (optional)",
+      selectColumn: "Select a column",
+      operatorLabel: "Operator",
+      valueLabel: "Value",
+      joinerLabel: "Joiner",
+      joinerAnd: "AND",
+      joinerOr: "OR",
+      rowsMatching: "Rows matching: {matching} of {total} ({percentage}%)",
+      noMatches: "The filter produced no matching rows.",
+      previewEmpty: "No rows match the current filter.",
+      updateError:
+        "We couldn't update your data with the current filter. Please try again.",
+      allRowsSummary: "All rows",
+    },
   },
   model: {
     basicOptions: {

--- a/apps/react-ui/client/src/services/dataProcessingService.ts
+++ b/apps/react-ui/client/src/services/dataProcessingService.ts
@@ -4,6 +4,7 @@ import {
   type UploadedData,
   type ColumnMapping,
 } from "@store/dataStore";
+import type { SubsampleFilter } from "@src/types";
 import { generateDataId, processUploadedFile } from "@utils/dataUtils";
 import { mockCsvFiles } from "@utils/mockCsvFiles";
 import { generateMockCSVFile } from "@utils/mockData";
@@ -133,6 +134,9 @@ export class DataProcessingService {
     dataId: string,
     mapping: ColumnMapping,
     normalizedData: UploadedData["data"],
+    options?: {
+      subsampleFilter?: SubsampleFilter | null;
+    },
   ): void {
     const existingData = dataCache.get(dataId);
 
@@ -144,6 +148,10 @@ export class DataProcessingService {
       ...existingData,
       data: normalizedData,
       columnMapping: mapping,
+      subsampleFilter:
+        options?.subsampleFilter !== undefined
+          ? options.subsampleFilter
+          : existingData.subsampleFilter ?? null,
     };
 
     this.updateStoredData(updatedData);

--- a/apps/react-ui/client/src/store/dataStore.ts
+++ b/apps/react-ui/client/src/store/dataStore.ts
@@ -1,4 +1,4 @@
-import type { DataArray } from "@src/types";
+import type { DataArray, SubsampleFilter } from "@src/types";
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
 
@@ -19,6 +19,7 @@ export type UploadedData = {
   base64Data: string;
   uploadedAt: Date;
   columnMapping?: ColumnMapping;
+  subsampleFilter?: SubsampleFilter | null;
 };
 
 type DataStore = {

--- a/apps/react-ui/client/src/types/filter.ts
+++ b/apps/react-ui/client/src/types/filter.ts
@@ -1,0 +1,23 @@
+export type FilterOperator =
+  | "equals"
+  | "notEquals"
+  | "greaterThan"
+  | "greaterThanOrEqual"
+  | "lessThan"
+  | "lessThanOrEqual";
+
+export type FilterJoiner = "AND" | "OR";
+
+export type SubsampleFilterCondition = {
+  column: string;
+  operator: FilterOperator;
+  value: string;
+};
+
+export type SubsampleFilter = {
+  enabled: boolean;
+  joiner: FilterJoiner;
+  conditions: SubsampleFilterCondition[];
+  totalRowCount: number;
+  matchingRowCount: number;
+};

--- a/apps/react-ui/client/src/types/index.tsx
+++ b/apps/react-ui/client/src/types/index.tsx
@@ -12,6 +12,12 @@ import type {
   ApiError,
 } from "./api";
 import type DataArray from "./data";
+import type {
+  FilterJoiner,
+  FilterOperator,
+  SubsampleFilter,
+  SubsampleFilterCondition,
+} from "./filter";
 
 /** A type of the results main estimate value. This is used to determine which model was used to produce the main estimate. */
 type EstimateType = DeepValueOf<typeof CONST.MODEL_TYPES> | "Unknown";
@@ -29,4 +35,8 @@ export type {
   PingResponse,
   RuntimeConfig,
   AlertType,
+  FilterOperator,
+  FilterJoiner,
+  SubsampleFilter,
+  SubsampleFilterCondition,
 };

--- a/apps/react-ui/client/src/utils/filterUtils.ts
+++ b/apps/react-ui/client/src/utils/filterUtils.ts
@@ -1,0 +1,70 @@
+import type {
+  FilterJoiner,
+  FilterOperator,
+  SubsampleFilterCondition,
+} from "@src/types";
+
+export const FILTER_OPERATOR_OPTIONS: Array<{
+  value: FilterOperator;
+  label: string;
+  symbol: string;
+}> = [
+  { value: "equals", label: "Equals", symbol: "==" },
+  { value: "notEquals", label: "Does not equal", symbol: "!=" },
+  { value: "greaterThan", label: "Greater than", symbol: ">" },
+  { value: "greaterThanOrEqual", label: "Greater than or equal", symbol: ">=" },
+  { value: "lessThan", label: "Less than", symbol: "<" },
+  { value: "lessThanOrEqual", label: "Less than or equal", symbol: "<=" },
+];
+
+const getOperatorOption = (operator: FilterOperator) =>
+  FILTER_OPERATOR_OPTIONS.find((option) => option.value === operator);
+
+export const getOperatorSymbol = (operator: FilterOperator): string => {
+  return getOperatorOption(operator)?.symbol ?? "=";
+};
+
+const formatConditionValue = (value: string): string => {
+  const trimmed = value.trim();
+
+  if (trimmed === "") {
+    return '""';
+  }
+
+  const numericValue = Number(trimmed);
+  if (!Number.isNaN(numericValue)) {
+    return trimmed;
+  }
+
+  if (/^(true|false)$/i.test(trimmed)) {
+    return trimmed.toLowerCase();
+  }
+
+  if (/^".*"$|^'.*'$/.test(trimmed)) {
+    return trimmed;
+  }
+
+  if (/^[\w.-]+$/.test(trimmed)) {
+    return trimmed;
+  }
+
+  return `"${trimmed}"`;
+};
+
+export const formatFilterCondition = (
+  condition: SubsampleFilterCondition,
+): string => {
+  const symbol = getOperatorSymbol(condition.operator);
+  return `${condition.column} ${symbol} ${formatConditionValue(condition.value)}`;
+};
+
+export const formatFilterSummary = (
+  conditions: SubsampleFilterCondition[],
+  joiner: FilterJoiner,
+): string => {
+  if (!conditions.length) {
+    return "";
+  }
+
+  return conditions.map(formatFilterCondition).join(` ${joiner} `);
+};


### PR DESCRIPTION
## Summary
- add optional subsample filter controls on the validation page, including row count feedback and guardrails when no matches remain
- persist the chosen filter alongside mapped data so downstream modeling uses the filtered rows and expose the active filter summary on the results page
- introduce shared filter types, operator helpers, and copy updates to support the new workflow

## Testing
- npm run ui:lint *(fails: `next` binary not found in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ee38609418832aaeca916324c8437a