### PR TITLE
fix: refine subsample filter styling

### DIFF
--- a/apps/react-ui/client/src/components/SubsampleFilter/SubsampleFilter.tsx
+++ b/apps/react-ui/client/src/components/SubsampleFilter/SubsampleFilter.tsx
@@ -280,16 +280,16 @@ export default function SubsampleFilter({
 
       {isEnabled && (
         <div className="rounded-lg bg-gray-50 dark:bg-gray-900/40 border border-gray-200 dark:border-gray-700 p-4 space-y-2">
-          <div className="flex items-center justify-between">
+          <div className="flex items-center justify-between gap-4">
             <span className="text-sm font-medium text-secondary">
               {TEXT.validation.subsampleFilter.rowsMatchingLabel}
             </span>
-            <span className="text-sm font-semibold text-primary">
+            <span className="flex min-h-[2.5rem] items-center text-sm font-semibold text-primary text-right">
               {matchedSummary}
             </span>
           </div>
           {statusMessage ? (
-            <p className="text-xs text-amber-600 dark:text-amber-400">
+            <p className="text-xs text-primary-600 dark:text-primary-300">
               {statusMessage}
             </p>
           ) : null}

--- a/apps/react-ui/client/src/styles/formStyles.ts
+++ b/apps/react-ui/client/src/styles/formStyles.ts
@@ -8,7 +8,7 @@
  * Matches the styling used in column mapping and other form elements
  */
 export const INPUT_FIELD_CLASSES =
-  "rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900/40 text-gray-900 dark:text-gray-100 p-2 focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/40";
+  "h-10 rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900/40 px-3 py-2 text-sm text-gray-900 dark:text-gray-100 focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/40";
 
 /**
  * Standard button size classes
@@ -17,9 +17,9 @@ export const INPUT_FIELD_CLASSES =
  * Large: Used for prominent CTAs
  */
 export const BUTTON_SIZE_CLASSES = {
-  sm: "px-3 py-1.5 text-sm",
-  md: "px-4 py-2 text-base",
-  lg: "px-6 py-3 text-lg",
+  sm: "h-10 px-3 text-sm",
+  md: "h-11 px-4 text-base",
+  lg: "h-12 px-6 text-lg",
 } as const;
 
 /**
@@ -27,7 +27,7 @@ export const BUTTON_SIZE_CLASSES = {
  * Used for Yes/No, AND/OR type toggles
  */
 export const TOGGLE_BUTTON_BASE_CLASSES =
-  "font-medium transition-colors duration-150 focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-primary";
+  "inline-flex items-center justify-center font-medium transition-colors duration-150 focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-primary";
 
 /**
  * Gets toggle button classes with active state styling
@@ -38,8 +38,8 @@ export const getToggleButtonClasses = (
 ): string => {
   const sizeClass = BUTTON_SIZE_CLASSES[size];
   const stateClasses = active
-    ? "bg-blue-600 text-white hover:bg-blue-700"
-    : "bg-gray-100 dark:bg-gray-800 text-secondary hover:bg-gray-200 dark:hover:bg-gray-700";
+    ? "bg-primary-600 text-white shadow-sm hover:bg-primary-500 dark:bg-primary-500 dark:hover:bg-primary-400"
+    : "bg-white text-secondary hover:bg-gray-100 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700";
 
   return `${TOGGLE_BUTTON_BASE_CLASSES} ${sizeClass} ${stateClasses}`;
 };
@@ -49,7 +49,7 @@ export const getToggleButtonClasses = (
  * Matches the ActionButton secondary variant styling
  */
 export const SECONDARY_BUTTON_CLASSES =
-  "inline-flex items-center gap-2 px-3 py-1.5 text-sm font-medium rounded-lg border border-gray-200 dark:border-gray-700 text-secondary hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors";
+  "inline-flex h-10 items-center justify-center gap-2 px-4 text-sm font-medium rounded-lg border border-gray-200 dark:border-gray-700 text-secondary hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors";
 
 /**
  * Label classes for form fields


### PR DESCRIPTION
## Summary
- align subsample filter input and button sizing with the column mapping controls for visual consistency
- center the match summary content and update helper text color to better fit the app palette
- refresh toggle styling to improve contrast in light mode while respecting shared form styles

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ef44ed148c832abb7b38134784cdc6