### PR TITLE
fix: preserve subsample filters when toggled

### DIFF
--- a/apps/react-ui/client/src/components/SubsampleFilter/SubsampleFilter.tsx
+++ b/apps/react-ui/client/src/components/SubsampleFilter/SubsampleFilter.tsx
@@ -280,16 +280,30 @@ const GroupEditor = ({
 
           return (
             <div key={child.id} className="space-y-3">
-              <div className="rounded-lg border border-dashed border-gray-200 p-4 dark:border-gray-700">
+              <div
+                className={`rounded-lg border border-dashed border-gray-200 p-4 dark:border-gray-700 ${
+                  child.type === "condition" ? "relative pr-12" : ""
+                }`}
+              >
                 {child.type === "condition" ? (
-                  <ConditionFields
-                    label={conditionLabel}
-                    condition={child}
-                    columns={columns}
-                    onChange={(updatedCondition) =>
-                      handleChildChange(index, updatedCondition)
-                    }
-                  />
+                  <>
+                    <button
+                      type="button"
+                      className={`${iconButtonBaseClasses} absolute right-2 top-2 text-red-500 hover:text-red-600 dark:text-red-400 dark:hover:text-red-300`}
+                      onClick={() => handleRemoveChild(index)}
+                      aria-label={TEXT.validation.subsampleFilter.removeCondition}
+                    >
+                      <FaTimes className="h-4 w-4" />
+                    </button>
+                    <ConditionFields
+                      label={conditionLabel}
+                      condition={child}
+                      columns={columns}
+                      onChange={(updatedCondition) =>
+                        handleChildChange(index, updatedCondition)
+                      }
+                    />
+                  </>
                 ) : (
                   <GroupEditor
                     group={child}
@@ -324,16 +338,6 @@ const GroupEditor = ({
                   </button>
                 </div>
 
-                {child.type === "condition" ? (
-                  <button
-                    type="button"
-                    className={`${iconButtonBaseClasses} text-red-500 hover:text-red-600 dark:text-red-400 dark:hover:text-red-300`}
-                    onClick={() => handleRemoveChild(index)}
-                    aria-label={TEXT.validation.subsampleFilter.removeCondition}
-                  >
-                    <FaTimes className="h-4 w-4" />
-                  </button>
-                ) : null}
               </div>
 
               {!isLast ? (
@@ -421,7 +425,6 @@ export default function SubsampleFilter({
             active={!isEnabled}
             onClick={() => {
               onToggle(false);
-              onRootGroupChange(createEmptyGroup());
             }}
             ariaLabel={TEXT.validation.subsampleFilter.disableLabel}
           >

--- a/apps/react-ui/client/src/pages/validation/index.tsx
+++ b/apps/react-ui/client/src/pages/validation/index.tsx
@@ -850,9 +850,6 @@ export default function ValidationPage() {
 
   const handleFilterToggle = (enabled: boolean) => {
     setIsFilterEnabled(enabled);
-    if (!enabled) {
-      setFilterGroup(createEmptyGroup());
-    }
   };
 
   const handleContinue = () => {


### PR DESCRIPTION
## Summary
- move the condition delete button to the top-right corner of each condition card in the subsample filter
- keep subsample filter groups intact when toggling the filter off and back on so users don't lose their configuration

## Testing
- npm run ui:lint *(fails: `next` binary missing in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ef7d86bac4832aba2ed7306b00b725