### PR TITLE
fix: deactivate subsample filter when last item removed

### DIFF
--- a/apps/react-ui/client/src/components/SubsampleFilter/SubsampleFilter.tsx
+++ b/apps/react-ui/client/src/components/SubsampleFilter/SubsampleFilter.tsx
@@ -149,6 +149,7 @@ type GroupEditorProps = {
   columns: string[];
   onChange: (group: SubsampleFilterGroupNode) => void;
   onRemove?: () => void;
+  onRootEmpty?: () => void;
   isRoot?: boolean;
 };
 
@@ -157,6 +158,7 @@ const GroupEditor = ({
   columns,
   onChange,
   onRemove,
+  onRootEmpty,
   isRoot = false,
 }: GroupEditorProps) => {
   const containerRef = useRef<HTMLDivElement | null>(null);
@@ -297,6 +299,7 @@ const GroupEditor = ({
 
     if (nextChildren.length === 0) {
       if (isRoot) {
+        onRootEmpty?.();
         onChange({
           ...group,
           children: [createEmptyCondition()],
@@ -564,6 +567,7 @@ export default function SubsampleFilter({
           group={rootGroup}
           columns={columns}
           onChange={onRootGroupChange}
+          onRootEmpty={() => onToggle(false)}
           isRoot
         />
       ) : null}


### PR DESCRIPTION
## Summary
- add a root-level callback so removing the final condition notifies the parent
- disable the subsample filter when its last condition or group is cleared

## Testing
- npm run ui:lint *(fails: `next` command not found in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68f0a81eab70832a9778b0641567725d