### PR TITLE
docs: add data privacy note to upload page

### DIFF
--- a/apps/react-ui/client/src/pages/upload/index.tsx
+++ b/apps/react-ui/client/src/pages/upload/index.tsx
@@ -163,6 +163,9 @@ export default function UploadPage() {
             />
             <div className="mb-6">
               <p className="text-secondary mb-2">{TEXT.upload.description}</p>
+              <p className="text-secondary mb-4">
+                We do not store your uploaded data and cannot access its contents.
+              </p>
               <ul className="custom-bullet-list text-secondary">
                 {Object.values(TEXT.upload.requirements).map(
                   (requirement, index) => (


### PR DESCRIPTION
## Summary
- add a reassurance sentence to the upload page that uploaded files are neither stored nor accessible to us

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f36a804e64832a89b367adbf21641f