### PR TITLE
Update WAIVE help text with documentation link

### DIFF
--- a/apps/react-ui/client/src/lib/text/index.ts
+++ b/apps/react-ui/client/src/lib/text/index.ts
@@ -371,8 +371,8 @@ const TEXT = {
           rel: "noopener noreferrer",
           className: "underline",
         },
-        "Details on WAIVE are available here."
-      )
+        "Details on WAIVE are available here.",
+      ),
     ),
     cautionNote: "WAIVE is experimental. Interpretation should be cautious.",
     runInfoLabel: "Experimental model (WAIVE)",


### PR DESCRIPTION
## Summary
- update the WAIVE help copy to describe potentially p-hacked estimates
- add a direct link to the WAIVE PDF so the informational text points to the documentation

## Testing
- npm run ui:lint *(fails: `next` not found in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f8919c4ad8832a93fd7350056f659c