### PR TITLE
feat: scale WAIVE funnel plot points by weight

### DIFF
--- a/apps/react-ui/client/src/pages/results/index.tsx
+++ b/apps/react-ui/client/src/pages/results/index.tsx
@@ -106,13 +106,17 @@ export default function ResultsPage() {
     parsedParameters?.shouldUseInstrumenting ?? true;
   const isWaiveModel = parsedParameters.modelType === CONST.MODEL_TYPES.WAIVE;
 
-  const funnelInterpretationText = useMemo(
-    () =>
-      shouldUseInstrumenting
-        ? "The figure is a scatter plot of effect sizes against their MAIVE-adjusted precision (black-filled dots). Hollow dots denote unadjusted precision. Shaded regions represent levels of statistical significance of the reported estimates. The solid line shows the MAIVE fit, and the corrected meta-analytic estimate is given by the intercept of this line with the upper horizontal axis."
-        : "The figure is a scatter plot of effect sizes against their precision. Shaded regions represent levels of statistical significance of the reported estimates. The solid line shows the regression fit, and the corrected meta-analytic estimate is given by the intercept of this line with the upper horizontal axis.",
-    [shouldUseInstrumenting],
-  );
+  const funnelInterpretationText = useMemo(() => {
+    if (!shouldUseInstrumenting) {
+      return "The figure is a scatter plot of effect sizes against their precision. Shaded regions represent levels of statistical significance of the reported estimates. The solid line shows the regression fit, and the corrected meta-analytic estimate is given by the intercept of this line with the upper horizontal axis.";
+    }
+
+    if (isWaiveModel) {
+      return "The figure is a scatter plot of effect sizes against their MAIVE-adjusted precision (black-filled dots). The size of each dot indicates its weight in WAIVE; spuriously precise estimates are downweighted. Hollow dots denote unadjusted precision. Shaded regions represent levels of statistical significance of the reported estimates. The solid line shows the WAIVE fit, and the corrected meta-analytic estimate is given by the intercept of this line with the upper horizontal axis.";
+    }
+
+    return "The figure is a scatter plot of effect sizes against their MAIVE-adjusted precision (black-filled dots). Hollow dots denote unadjusted precision. Shaded regions represent levels of statistical significance of the reported estimates. The solid line shows the MAIVE fit, and the corrected meta-analytic estimate is given by the intercept of this line with the upper horizontal axis.";
+  }, [isWaiveModel, shouldUseInstrumenting]);
 
   const uploadedData = useMemo(() => {
     if (!dataId) {


### PR DESCRIPTION
## Summary
- scale WAIVE-adjusted funnel plot markers according to their WAIVE weights and update the legend sizing logic
- surface WAIVE weights from the model results into the funnel-plot generator when available
- refresh the WAIVE funnel plot interpretation copy to describe weight-dependent point sizing

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_690b034a84c8832ab7b6768704490f71