### PR TITLE
fix: align first-stage f-statistic terminology

### DIFF
--- a/apps/lambda-r-backend/r_scripts/maive_model.R
+++ b/apps/lambda-r-backend/r_scripts/maive_model.R
@@ -424,9 +424,9 @@ run_maive_model <- function(data, parameters) {
     "SE^2 ~ 1/N"
   }
   first_stage_label <- if (first_stage_mode == "log") {
-    "First-Stage F-Test (<U+03B3><U+2081>)"
+    "First-Stage F-Statistic (\u03b3\u2081)"
   } else {
-    "First-Stage F-Test"
+    "First-Stage F-Statistic"
   }
 
   funnel_plot_data <- get_funnel_plot_data( # nolint: object_usage_linter.
@@ -453,7 +453,7 @@ run_maive_model <- function(data, parameters) {
       eggerBootCI = egger_boot_ci,
       eggerAndersonRubinCI = egger_ar_ci
     ),
-    firstStageFTest = maive_res[["F-test"]],
+    firstStageFStatistic = maive_res[["F-test"]],
     hausmanTest = list(
       statistic = maive_res$Hausman,
       criticalValue = maive_res$Chi2,

--- a/apps/lambda-r-backend/r_scripts/tests/e2e/README.md
+++ b/apps/lambda-r-backend/r_scripts/tests/e2e/README.md
@@ -164,7 +164,7 @@ Each successful API call should return:
    "pValue": 0.023,
    "isSignificant": true
   },
-  "firstStageFTest": 15.67,
+  "firstStageFStatistic": 15.67,
   "hausmanTest": {
    "statistic": 8.45,
    "criticalValue": 3.84,

--- a/apps/lambda-r-backend/r_scripts/tests/e2e/utils/test_helpers.R
+++ b/apps/lambda-r-backend/r_scripts/tests/e2e/utils/test_helpers.R
@@ -118,7 +118,7 @@ assert_response_structure <- function(response, expected_fields = NULL) {
   if ("data" %in% names(response)) {
     data_fields <- c(
       "effectEstimate", "standardError", "isSignificant",
-      "andersonRubinCI", "publicationBias", "firstStageFTest",
+      "andersonRubinCI", "publicationBias", "firstStageFStatistic",
       "firstStage",
       "hausmanTest", "seInstrumented", "funnelPlot"
     )

--- a/apps/react-ui/client/src/lib/reproducibility/generators/wrapperScript.ts
+++ b/apps/react-ui/client/src/lib/reproducibility/generators/wrapperScript.ts
@@ -119,8 +119,8 @@ if (!identical(results$publicationBias$eggerBootCI, "NA") && !is.null(results$pu
 }
 
 cat("\\n=== MODEL DIAGNOSTICS ===\\n")
-if (!identical(results$firstStageFTest, "NA") && !is.null(results$firstStageFTest)) {
-  cat("First-Stage F-test:", sprintf("%.6f", results$firstStageFTest), "\\n")
+if (!identical(results$firstStageFStatistic, "NA") && !is.null(results$firstStageFStatistic)) {
+  cat("First-Stage F-statistic:", sprintf("%.6f", results$firstStageFStatistic), "\\n")
 }
 cat("Hausman Statistic: ", sprintf("%.6f", results$hausmanTest$statistic), "\\n")
 cat("Chi-Squared CV:    ", sprintf("%.6f", results$hausmanTest$criticalValue), "\\n")

--- a/apps/react-ui/client/src/lib/text/index.ts
+++ b/apps/react-ui/client/src/lib/text/index.ts
@@ -42,8 +42,8 @@ export type ResultsText = Readonly<{
   diagnosticTests: SectionWithMetrics<{
     hausmanTest: MetricText;
     hausmanCriticalValue: MetricText;
-    firstStageFTest: MetricText;
-    firstStageFTestLog: MetricText;
+    firstStageFStatistic: MetricText;
+    firstStageFStatisticLog: MetricText;
     firstStageSpecification: MetricText;
   }>;
   funnelPlot: Readonly<{
@@ -137,13 +137,13 @@ const RESULTS_TEXT: ResultsText = {
         tooltip:
           "5% critical value for the Hausman test. Reject exogeneity if the test statistic exceeds this value.",
       },
-      firstStageFTest: {
-        label: "First-Stage F-Test",
+      firstStageFStatistic: {
+        label: "First-Stage F-Statistic",
         tooltip:
           "Heteroskedasticity-robust F statistic for the strength of the instrument (inverse sample size) in the levels first-stage regression of reported variances. Values above 10 denote a strong instrument.",
       },
-      firstStageFTestLog: {
-        label: "First-Stage F-Test (γ₁)",
+      firstStageFStatisticLog: {
+        label: "First-Stage F-Statistic (γ₁)",
         tooltip:
           "Heteroskedasticity-robust F statistic for the log-scale slope coefficient (γ₁) in the first-stage regression log(SE²) ~ log N. Values above 10 denote a strong instrument.",
       },

--- a/apps/react-ui/client/src/types/api.ts
+++ b/apps/react-ui/client/src/types/api.ts
@@ -52,7 +52,7 @@ type ModelResults = {
     eggerAndersonRubinCI: [number, number] | "NA";
     pValue?: number;
   };
-  firstStageFTest: number | "NA";
+  firstStageFStatistic: number | "NA";
   hausmanTest: {
     statistic: number;
     criticalValue: number;

--- a/apps/react-ui/client/src/utils/interpretationTextGenerator.ts
+++ b/apps/react-ui/client/src/utils/interpretationTextGenerator.ts
@@ -137,7 +137,7 @@ export function generateTestsInterpretation(
   results: ModelResults,
   parameters: ModelParameters,
 ): string {
-  const { firstStageFTest, hausmanTest } = results;
+  const { firstStageFStatistic, hausmanTest } = results;
   const { shouldUseInstrumenting, useLogFirstStage } = parameters;
 
   // Only generate if instrumenting is used
@@ -147,15 +147,15 @@ export function generateTestsInterpretation(
 
   const sentences: string[] = [];
 
-  // First-stage F-test sentence
-  if (firstStageFTest !== "NA") {
-    const strength = getInstrumentStrength(firstStageFTest);
+  // First-stage F-statistic sentence
+  if (firstStageFStatistic !== "NA") {
+    const strength = getInstrumentStrength(firstStageFStatistic);
     const strengthText = strength === "weak" ? "weak" : "strong";
     const ciRequirement =
       strength === "weak" ? "required" : "optional but recommended";
 
     sentences.push(
-      `The instrument is ${strengthText} (first-stage F = ${formatNumber(firstStageFTest)}), implying that the Anderson–Rubin confidence interval is ${ciRequirement}.`,
+      `The instrument is ${strengthText} (first-stage F-statistic = ${formatNumber(firstStageFStatistic)}), implying that the Anderson–Rubin confidence interval is ${ciRequirement}.`,
     );
   }
 
@@ -176,9 +176,13 @@ export function generateTestsInterpretation(
   }
 
   // Logs recommendation sentence (only if F < 30 AND not using logs)
-  if (firstStageFTest !== "NA" && firstStageFTest < 30 && !useLogFirstStage) {
+  if (
+    firstStageFStatistic !== "NA" &&
+    firstStageFStatistic < 30 &&
+    !useLogFirstStage
+  ) {
     sentences.push(
-      "Because first-stage F < 30, running the first stage in logs is recommended.",
+      "Because the first-stage F-statistic < 30, running the first stage in logs is recommended.",
     );
   }
 

--- a/apps/react-ui/client/src/utils/mockData.ts
+++ b/apps/react-ui/client/src/utils/mockData.ts
@@ -62,8 +62,8 @@ const generateMockResults = (nrow: number, useLogFirstStage = false) => {
     ? "log(SE²) ~ log N; Duan smearing applied"
     : "SE² ~ 1/N.";
   const firstStageLabel = useLogFirstStage
-    ? "First-Stage F-Test (γ₁)"
-    : "First-Stage F-Test";
+    ? "First-Stage F-Statistic (γ₁)"
+    : "First-Stage F-Statistic";
 
   return {
     effectEstimate: faker.number.float({ min: 0, max: 1, multipleOf: 0.0001 }),
@@ -100,7 +100,7 @@ const generateMockResults = (nrow: number, useLogFirstStage = false) => {
             ]
           : "NA",
     },
-    firstStageFTest:
+    firstStageFStatistic:
       Math.random() > 0.5
         ? "NA"
         : faker.number.float({

--- a/apps/react-ui/client/src/utils/resultsDataUtils.ts
+++ b/apps/react-ui/client/src/utils/resultsDataUtils.ts
@@ -125,8 +125,8 @@ export const generateResultsData = (
   const specificationValue = firstStageDescription ?? defaultSpecification;
   const firstStageLabelDefault =
     firstStageMode === "log"
-      ? resultsText.diagnosticTests.metrics.firstStageFTestLog.label
-      : resultsText.diagnosticTests.metrics.firstStageFTest.label;
+      ? resultsText.diagnosticTests.metrics.firstStageFStatisticLog.label
+      : resultsText.diagnosticTests.metrics.firstStageFStatistic.label;
   const firstStageFStatisticLabel =
     results.firstStage?.fStatisticLabel ?? firstStageLabelDefault;
   const hausmanStatisticValue = isFiniteNumber(results.hausmanTest.statistic)
@@ -139,15 +139,20 @@ export const generateResultsData = (
     hausmanStatisticValue !== "NA" && isBoolean(results.hausmanTest.rejectsNull)
       ? results.hausmanTest.rejectsNull
       : null;
-  const firstStageFTestValue =
-    results.firstStageFTest !== "NA" && isFiniteNumber(results.firstStageFTest)
-      ? results.firstStageFTest
+  const firstStageFStatisticValue =
+    results.firstStageFStatistic !== "NA" &&
+    isFiniteNumber(results.firstStageFStatistic)
+      ? results.firstStageFStatistic
       : "NA";
-  const firstStageFTestNumericValue =
-    typeof firstStageFTestValue === "number" ? firstStageFTestValue : null;
-  const hasFirstStageFTestResult = firstStageFTestNumericValue !== null;
-  const isFirstStageFTestStrong =
-    firstStageFTestNumericValue !== null && firstStageFTestNumericValue >= 10;
+  const firstStageFStatisticNumericValue =
+    typeof firstStageFStatisticValue === "number"
+      ? firstStageFStatisticValue
+      : null;
+  const hasFirstStageFStatisticResult =
+    firstStageFStatisticNumericValue !== null;
+  const isFirstStageFStatisticStrong =
+    firstStageFStatisticNumericValue !== null &&
+    firstStageFStatisticNumericValue >= 10;
 
   // AR CI feedback helpers
   const getARCIExtraText = (
@@ -278,15 +283,15 @@ export const generateResultsData = (
     },
     {
       label: firstStageFStatisticLabel,
-      value: firstStageFTestValue,
-      show: isInstrumented && hasFirstStageFTestResult,
-      highlightColor: hasFirstStageFTestResult
-        ? isFirstStageFTestStrong
+      value: firstStageFStatisticValue,
+      show: isInstrumented && hasFirstStageFStatisticResult,
+      highlightColor: hasFirstStageFStatisticResult
+        ? isFirstStageFStatisticStrong
           ? "text-green-600"
           : "text-red-600"
         : undefined,
-      extraText: hasFirstStageFTestResult
-        ? isFirstStageFTestStrong
+      extraText: hasFirstStageFStatisticResult
+        ? isFirstStageFStatisticStrong
           ? " (Strong)"
           : " (Weak)"
         : undefined,


### PR DESCRIPTION
## Summary
- update the R backend to emit First-Stage F-Statistic labels with a proper γ₁ glyph and rename the result field
- refresh UI copy, result processing, and interpretation text to use the First-Stage F-Statistic wording consistently
- align reproducibility assets and mock data with the renamed first-stage statistic field

## Testing
- npm run ui:lint *(fails: `next` binary not available in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691177fcc8d8832a9e508f7659977b5c)