### PR TITLE
fix: update funnel plot downweighting scale

### DIFF
--- a/apps/lambda-r-backend/r_scripts/funnel_plot.R
+++ b/apps/lambda-r-backend/r_scripts/funnel_plot.R
@@ -3,7 +3,7 @@
 PLOT_RES <- 120 # Changes the resolution of the plot in pixels per inch; also changes the plot size
 
 # Minimum relative scale used when downweighting WAIVE-adjusted funnel points.
-# NOTE: Update the descriptive copy in apps/react-ui/client/src/lib/text/index.ts when this value changes.
+# NOTE: Update the descriptive copy in apps/react-ui/client/src/CONST.ts (ADJUSTED_POINT_MIN_SCALE) when this value changes.
 ADJUSTED_POINT_MIN_SCALE <- 0.1
 
 #' Get the default options for the funnel plot

--- a/apps/react-ui/client/src/CONST.ts
+++ b/apps/react-ui/client/src/CONST.ts
@@ -99,6 +99,8 @@ const CONST = {
   LARGE_DATASET_ROW_THRESHOLD: 1000,
   MOCK_DATA_ROWS_MIN: 9, // At least 3 studies with 3 observations each
   MOCK_DATA_ROWS_MAX: 200,
+  // NOTE: Update the descriptive copy in apps/lambda-r-backend/r_scripts/funnel_plot.R (ADJUSTED_POINT_MIN_SCALE) when this value changes.
+  ADJUSTED_POINT_MIN_SCALE: 0.1,
   DEMO_MOCK_DATA_NAME: "Mock Data 4",
 } as const;
 

--- a/apps/react-ui/client/src/pages/results/index.tsx
+++ b/apps/react-ui/client/src/pages/results/index.tsx
@@ -51,6 +51,9 @@ import {
   FaArrowLeft,
 } from "react-icons/fa";
 
+const ratioToPercentage = (ratio: number): number =>
+  Math.round(ratio * 1000) / 10;
+
 export default function ResultsPage() {
   const searchParams = useSearchParams();
   const router = useRouter();
@@ -110,7 +113,7 @@ export default function ResultsPage() {
     }
 
     if (isWaiveModel) {
-      return "The figure is a scatter plot of effect sizes against their WAIVE-adjusted precision (black-filled dots). The size of each dot indicates its weight in WAIVE; spuriously precise estimates are downweighted. To preserve visibility, the scaling ranges from 0.5 to 1.0 of the default point size, with size downweighting occurring smoothly within these limits. Hollow dots denote unadjusted precision. Shaded regions represent levels of statistical significance of the reported estimates. The solid line shows the WAIVE fit, and the corrected meta-analytic estimate is given by the intercept of this line with the upper horizontal axis.";
+      return `The figure is a scatter plot of effect sizes against their WAIVE-adjusted precision (black-filled dots). The size of each dot indicates its weight in WAIVE; spuriously precise estimates are downweighted. To preserve visibility, the scaling ranges from ${CONST.ADJUSTED_POINT_MIN_SCALE} (${ratioToPercentage(CONST.ADJUSTED_POINT_MIN_SCALE).toFixed(0)}% of the default point size) to 1.0 (100% of the default point size), with size downweighting occurring smoothly within these limits. Hollow dots denote unadjusted precision. Shaded regions represent levels of statistical significance of the reported estimates. The solid line shows the WAIVE fit, and the corrected meta-analytic estimate is given by the intercept of this line with the upper horizontal axis.`;
     }
 
     return "The figure is a scatter plot of effect sizes against their MAIVE-adjusted precision (black-filled dots). Hollow dots denote unadjusted precision. Shaded regions represent levels of statistical significance of the reported estimates. The solid line shows the MAIVE fit, and the corrected meta-analytic estimate is given by the intercept of this line with the upper horizontal axis.";


### PR DESCRIPTION
## Summary
- add a configurable minimum scale for WAIVE-adjusted funnel plot points
- update the scaling calculation to use the 10% floor across the normalized range
- note the UI text that needs to be updated when the scale changes

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691428bde0d0832aab48d087422159e5)