### PR TITLE
fix: default autonomy level and clearer missing-column validation

### DIFF
--- a/inst/artma/data/preprocess.R
+++ b/inst/artma/data/preprocess.R
@@ -1,0 +1,42 @@
+# Data preprocessing helpers.
+
+get_expected_variable_names <- function() {
+  expected <- getOption("artma.expected_columns")
+  if (is.null(expected)) {
+    expected <- c("effect", "se")
+  }
+
+  unique(as.character(expected))
+}
+
+verify_variable_names <- function(df, expected_columns = NULL) {
+  if (is.null(expected_columns)) {
+    expected_columns <- get_expected_variable_names()
+  }
+
+  df_names <- names(df)
+  missing_columns <- setdiff(expected_columns, df_names)
+  unexpected_columns <- setdiff(df_names, expected_columns)
+
+  if (length(missing_columns) > 0 || length(unexpected_columns) > 0) {
+    header <- if (length(missing_columns) > 0) {
+      "Missing columns."
+    } else {
+      "Column name mismatch."
+    }
+
+    details <- c(
+      "All expected non-computed columns must exist, and no extra columns are allowed.",
+      if (length(missing_columns) > 0) {
+        paste0("Missing required columns: ", paste(missing_columns, collapse = ", "))
+      },
+      if (length(unexpected_columns) > 0) {
+        paste0("Unexpected columns: ", paste(unexpected_columns, collapse = ", "))
+      }
+    )
+
+    cli::cli_abort(c(header, i = details))
+  }
+
+  invisible(TRUE)
+}

--- a/inst/artma/interactive/save_preference.R
+++ b/inst/artma/interactive/save_preference.R
@@ -1,0 +1,46 @@
+# Helpers for storing and resolving autonomy preferences.
+
+if (!exists("AUTONOMY_DEFAULT_LEVEL", inherits = TRUE)) {
+  AUTONOMY_DEFAULT_LEVEL <- 5L
+}
+
+resolve_autonomy_level <- function(level = NULL) {
+  resolved <- level
+  if (is.null(resolved)) {
+    resolved <- getOption("artma.autonomy.level")
+  }
+
+  resolved <- suppressWarnings(as.integer(resolved))
+  if (length(resolved) != 1 || is.na(resolved)) {
+    resolved <- AUTONOMY_DEFAULT_LEVEL
+  }
+
+  max(1L, min(5L, resolved))
+}
+
+get_autonomy_level <- function(level = NULL) {
+  resolve_autonomy_level(level)
+}
+
+get_autonomy_description <- function(level = NULL) {
+  resolved <- resolve_autonomy_level(level)
+  if (exists("get_autonomy_description_for_level", inherits = TRUE)) {
+    return(get_autonomy_description_for_level(resolved))
+  }
+
+  sprintf("Level %d: Full autonomy for all supported actions.", resolved)
+}
+
+is_fully_autonomous <- function(level = NULL) {
+  resolve_autonomy_level(level) >= 5L
+}
+
+autonomy.get <- function(level = NULL) {
+  resolve_autonomy_level(level)
+}
+
+autonomy.set <- function(level) {
+  level <- resolve_autonomy_level(level)
+  options(artma.autonomy.level = level)
+  invisible(level)
+}

--- a/inst/artma/options/prompts.R
+++ b/inst/artma/options/prompts.R
@@ -1,0 +1,27 @@
+# Autonomy level descriptions used for interactive prompts.
+
+AUTONOMY_DEFAULT_LEVEL <- 5L
+
+AUTONOMY_LEVEL_DESCRIPTIONS <- c(
+  `1` = "Level 1: Manual execution only.",
+  `2` = "Level 2: Suggests actions with confirmation.",
+  `3` = "Level 3: Executes safe actions with confirmation for risky steps.",
+  `4` = "Level 4: Executes with minimal confirmations.",
+  `5` = "Level 5: Full autonomy for all supported actions."
+)
+
+get_autonomy_description_for_level <- function(level) {
+  level <- suppressWarnings(as.integer(level))
+  if (length(level) != 1 || is.na(level)) {
+    level <- AUTONOMY_DEFAULT_LEVEL
+  }
+
+  level <- max(1L, min(5L, level))
+  description <- AUTONOMY_LEVEL_DESCRIPTIONS[as.character(level)]
+
+  if (length(description) == 0 || is.na(description)) {
+    return("Level 5: Full autonomy for all supported actions.")
+  }
+
+  description
+}


### PR DESCRIPTION
### Motivation
- Restore correct default autonomy behavior so interactive calls resolve to full autonomy when unset, addressing failures in `test-autonomy.R`.
- Provide clearer variable-name validation and error messages to catch missing or unexpected columns, addressing the failure in `test-data-preprocess.R`.

### Description
- Add `inst/artma/interactive/save_preference.R` with `resolve_autonomy_level`, `get_autonomy_level`, `get_autonomy_description`, `is_fully_autonomous`, `autonomy.get`, and `autonomy.set` to centralize autonomy defaults and resolution logic.
- Add `inst/artma/options/prompts.R` defining `AUTONOMY_DEFAULT_LEVEL`, `AUTONOMY_LEVEL_DESCRIPTIONS`, and `get_autonomy_description_for_level` for interactive prompts and descriptive text.
- Add `inst/artma/data/preprocess.R` with `get_expected_variable_names` and `verify_variable_names` that use `getOption("artma.expected_columns")` and produce explicit `cli::cli_abort` messages listing missing or unexpected columns.
- Ensure resolved autonomy defaults to `5L` when unset or invalid, and clamp values to the `1L..5L` range.

### Testing
- No automated test suite was executed as part of this rollout; the changes were implemented to address previously failing tests `test-autonomy.R` and `test-data-preprocess.R`.
- The new functions and defaults are designed to make `get_autonomy_description`, `is_fully_autonomous`, `get_autonomy_level`, and `autonomy.get` behave as expected when `level` is `NULL` and to make `verify_variable_names` fail with a clear `Missing columns` style message when required columns (e.g., `se`) are absent.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697a2d672874832ab6d122144f55296d)