### PR TITLE
chore: disable ECS Container Insights to cut CloudWatch cost

### DIFF
--- a/terraform/stacks/prod-runtime/main.tf
+++ b/terraform/stacks/prod-runtime/main.tf
@@ -12,6 +12,6 @@ resource "aws_ecs_cluster" "this" {
   name = "${var.project}-cluster"
   setting {
     name  = "containerInsights"
-    value = "enabled"
+    value = "disabled"
   }
 }


### PR DESCRIPTION
## Summary

Disables ECS Container Insights on the `maive-cluster` ([terraform/stacks/prod-runtime/main.tf](terraform/stacks/prod-runtime/main.tf)), which was responsible for the **entire ~$8.40/mo CloudWatch bill** — 28 custom metrics published for a single always-on Fargate task.

This is the first of the "low-hanging fruit" cost optimizations identified in a review of the AWS bill (~$84/mo incl. 21% VAT, essentially flat month-to-month).

## Why it's safe

- The CloudWatch alarms in [monitoring.tf](terraform/stacks/prod-runtime/monitoring.tf) use the standard `AWS/ECS` namespace (`CPUUtilization` / `MemoryUtilization`), which is **not** part of Container Insights and remains available.
- ECS service autoscaling uses the predefined `ECSServiceAverageCPUUtilization` metric — also standard, unaffected.
- Container Insights only adds per-container/detailed dashboards, which provide little value for a single-task service.

## Cost impact

- **~$8.40/mo** (~$10/mo incl. VAT) removed from the CloudWatch line.

## Follow-up (not in this PR)

A separate operational cleanup will **release 3 orphaned, unassociated Elastic IPs** (leftover NAT-gateway EIPs from when `enable_nat_gateway` was disabled), worth a further **~$11.16/mo**. These are not Terraform-managed, so they're handled out-of-band rather than in this PR.

## Test plan

- [ ] `terragrunt plan` in `prod-runtime` shows only the `containerInsights` setting changing from `enabled` to `disabled`.
- [ ] After apply, confirm ECS alarms (`maive-ui-high-cpu`, `maive-ui-high-memory`) remain in OK/ALARM state (not INSUFFICIENT_DATA) and autoscaling still functions.
- [ ] Verify next month's CloudWatch `MetricMonitorUsage` drops to ~0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)