### PR TITLE
test: skip CSV header row in mockCsvFiles data-quality tests

### DIFF
--- a/apps/react-ui/client/src/tests/mockCsvFiles.test.ts
+++ b/apps/react-ui/client/src/tests/mockCsvFiles.test.ts
@@ -62,7 +62,8 @@ describe("Mock CSV Files", () => {
 
     it("should have valid numeric values in first three columns", () => {
       mockCsvFiles.forEach((csvFile) => {
-        const lines = csvFile.content.trim().split("\n");
+        // Skip the header row prepended by mockCsvFiles
+        const lines = csvFile.content.trim().split("\n").slice(1);
 
         lines.forEach((line, lineIndex) => {
           const columns = line.split(",");
@@ -181,7 +182,8 @@ describe("Mock CSV Files", () => {
   describe("Data quality checks", () => {
     it("should have reasonable effect size values", () => {
       mockCsvFiles.forEach((csvFile) => {
-        const lines = csvFile.content.trim().split("\n");
+        // Skip the header row prepended by mockCsvFiles
+        const lines = csvFile.content.trim().split("\n").slice(1);
 
         lines.forEach((line, lineIndex) => {
           const effectSize = parseFloat(line.split(",")[0]);
@@ -197,7 +199,8 @@ describe("Mock CSV Files", () => {
 
     it("should have reasonable sample sizes", () => {
       mockCsvFiles.forEach((csvFile) => {
-        const lines = csvFile.content.trim().split("\n");
+        // Skip the header row prepended by mockCsvFiles
+        const lines = csvFile.content.trim().split("\n").slice(1);
 
         lines.forEach((line, lineIndex) => {
           const sampleSize = parseInt(line.split(",")[2], 10);
@@ -213,7 +216,8 @@ describe("Mock CSV Files", () => {
 
     it("should have reasonable standard errors", () => {
       mockCsvFiles.forEach((csvFile) => {
-        const lines = csvFile.content.trim().split("\n");
+        // Skip the header row prepended by mockCsvFiles
+        const lines = csvFile.content.trim().split("\n").slice(1);
 
         lines.forEach((line, lineIndex) => {
           const standardError = parseFloat(line.split(",")[1]);


### PR DESCRIPTION
## Summary

Fixes 4 pre-existing failing tests in `apps/react-ui/client/src/tests/mockCsvFiles.test.ts`:

- `should have valid numeric values in first three columns`
- `should have reasonable effect size values`
- `should have reasonable sample sizes`
- `should have reasonable standard errors`

## Why

Commit af904c2 ("fix: add headers to mock csv data") made the `mockCsvFiles` export prepend a `effect,se,n_obs,study_id` header row to each file's `content`. These four tests iterate over **every** line of `content` and call `parseFloat`/`parseInt` on the columns. They now hit the header row first, producing `NaN`, which fails the numeric and range assertions on line 1 of "Mock Data 1".

The mock data is valid — the tests just need to ignore the header. Each affected test now slices off the header row (`.split("\n").slice(1)`). The mock data itself is unchanged. Other tests in the file parse non-numeric columns (column count, study identifiers) and were unaffected, so they're left as-is.

## Notes for reviewers

- This is a standalone fix off `master`; it is unrelated to the serverless-ui-phase0 work in https://github.com/PetrCala/maive-ui/pull/445 (which doesn't touch these files).
- All 18 tests in the file pass after the change.

## Test plan

- [x] `cd apps/react-ui/client && CI=true npx vitest run src/tests/mockCsvFiles.test.ts` → 18 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)