### PR TITLE
Serverless UI migration (Phase 1): UI Lambda alongside ECS

### DIFF
--- a/terraform/stacks/prod-runtime/outputs.tf
+++ b/terraform/stacks/prod-runtime/outputs.tf
@@ -9,3 +9,9 @@ output "ui_alb_dns_name" {
   description = "DNS name of the public UI ALB"
   value       = aws_lb.ui.dns_name
 }
+
+# UI Lambda Function URL (Cloudflare origin for the serverless UI)
+output "ui_lambda_url" {
+  description = "Function URL of the UI Lambda"
+  value       = aws_lambda_function_url.ui.function_url
+}

--- a/terraform/stacks/prod-runtime/ui_lambda.tf
+++ b/terraform/stacks/prod-runtime/ui_lambda.tf
@@ -1,0 +1,95 @@
+# UI (Next.js) on Lambda via the AWS Lambda Web Adapter.
+# Stood up alongside the existing ECS service (additive); not fronted by any
+# DNS yet. Cloudflare points at the Function URL in a later phase.
+
+resource "aws_iam_role" "ui_lambda" {
+  name = "${var.project}-ui-lambda-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action    = "sts:AssumeRole"
+        Effect    = "Allow"
+        Principal = { Service = "lambda.amazonaws.com" }
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "ui_lambda_basic" {
+  role       = aws_iam_role.ui_lambda.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+}
+
+# /api/system-status reads the status-banner SSM parameters server-side.
+resource "aws_iam_policy" "ui_lambda_ssm_read" {
+  name        = "${var.project}-ui-lambda-ssm-read"
+  description = "Allow the UI Lambda to read the status-banner SSM parameters"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = ["ssm:GetParameter", "ssm:GetParameters"]
+        Resource = [
+          aws_ssm_parameter.ui_unstable_banner_enabled.arn,
+          aws_ssm_parameter.ui_unstable_banner_message.arn,
+        ]
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "ui_lambda_ssm_read" {
+  role       = aws_iam_role.ui_lambda.name
+  policy_arn = aws_iam_policy.ui_lambda_ssm_read.arn
+}
+
+# Explicit log group so retention is bounded (Lambda otherwise auto-creates one
+# that never expires).
+resource "aws_cloudwatch_log_group" "ui_lambda" {
+  name              = "/aws/lambda/${var.project}-ui"
+  retention_in_days = var.ui_lambda_log_retention_days
+  tags              = { Project = var.project }
+}
+
+resource "aws_lambda_function" "ui" {
+  function_name = "${var.project}-ui"
+  role          = aws_iam_role.ui_lambda.arn
+  timeout       = var.ui_lambda_timeout
+  memory_size   = var.ui_lambda_memory_size
+
+  package_type = "Image"
+  image_uri    = "${local.ecr_urls["react-ui"]}:${var.image_tag}"
+
+  environment {
+    variables = {
+      NEXT_PUBLIC_R_API_URL                = aws_lambda_function_url.r_backend.function_url
+      STATUS_BANNER_ENABLED_PARAMETER_NAME = aws_ssm_parameter.ui_unstable_banner_enabled.name
+      STATUS_BANNER_MESSAGE_PARAMETER_NAME = aws_ssm_parameter.ui_unstable_banner_message.name
+      STATUS_BANNER_AWS_REGION             = var.region
+    }
+  }
+
+  depends_on = [aws_cloudwatch_log_group.ui_lambda]
+
+  tags = {
+    Project = var.project
+  }
+}
+
+# Public Function URL; Cloudflare will be the only thing in front of it.
+resource "aws_lambda_function_url" "ui" {
+  function_name      = aws_lambda_function.ui.function_name
+  authorization_type = "NONE"
+}
+
+resource "aws_lambda_permission" "ui_public_invoke" {
+  statement_id           = "FunctionURLAllowPublicAccess"
+  action                 = "lambda:InvokeFunctionUrl"
+  function_name          = aws_lambda_function.ui.function_name
+  principal              = "*"
+  function_url_auth_type = "NONE"
+}

--- a/terraform/stacks/prod-runtime/variables.tf
+++ b/terraform/stacks/prod-runtime/variables.tf
@@ -37,6 +37,24 @@ variable "ui_desired_count" {
   default     = 1
 }
 
+variable "ui_lambda_memory_size" {
+  type        = number
+  description = "Memory size in MB for the UI Lambda function"
+  default     = 1024
+}
+
+variable "ui_lambda_timeout" {
+  type        = number
+  description = "Timeout in seconds for the UI Lambda function (web tier; long analyses bypass it and hit the R backend directly)"
+  default     = 30
+}
+
+variable "ui_lambda_log_retention_days" {
+  type        = number
+  description = "Number of days to retain UI Lambda CloudWatch logs"
+  default     = 3
+}
+
 variable "lambda_r_backend_function_base_name" {
   type        = string
   description = "The base name of the Lambda function"


### PR DESCRIPTION
## Summary

Phase 1 of the serverless UI migration. Stands up the Next.js UI as a **container-image Lambda** (via the Lambda Web Adapter baked in Phase 0) **alongside the existing ECS service** — purely additive, no traffic routed to it yet.

`terragrunt plan` (pinned to the currently-deployed image tag `d389fc8`):

```
Plan: 8 to add, 0 to change, 0 to destroy.
```

## What it adds (`terraform/stacks/prod-runtime/ui_lambda.tf`)

- `aws_lambda_function.ui` — package_type=Image, `react-ui` ECR image at `var.image_tag`, env vars mirrored from the ECS task def (`NEXT_PUBLIC_R_API_URL` → R backend Function URL, `STATUS_BANNER_*`).
- `aws_lambda_function_url.ui` (auth NONE) + public-invoke permission — the future **Cloudflare origin**. No CORS (Cloudflare serves it same-origin as the page).
- `aws_iam_role.ui_lambda` + `AWSLambdaBasicExecutionRole` + an SSM-read policy scoped to the two status-banner parameters (used by `/api/system-status`).
- `aws_cloudwatch_log_group.ui_lambda` with bounded retention (Lambda otherwise auto-creates a never-expiring group).
- New vars: `ui_lambda_memory_size` (1024), `ui_lambda_timeout` (30s — long analyses bypass the web tier), `ui_lambda_log_retention_days` (3). New output: `ui_lambda_url`.

## Pipeline (#8 — no change needed)

`release.yml` already builds/pushes the `react-ui` image and runs `terragrunt apply` with `TF_VAR_image_tag`. The UI Lambda uses that same `var.image_tag`, so the existing pipeline deploys it (updating both the ECS task and the Lambda during coexistence).

## Safety / rollout

- Applying this changes **nothing** about how users reach the app — ECS + ALB keep serving. The Lambda just exists, reachable only via its Function URL.
- Validated with `terragrunt validate` (config valid) and `terragrunt plan` (additive-only) using the `kiroku` profile.
- Cloudflare wiring + DNS cutover are Phase 2/3.

## Test plan

- [ ] CI passes.
- [ ] After apply, `terraform output ui_lambda_url` resolves; hitting it returns the app (cold start acceptable).
- [ ] `/api/runtime-config`, `/api/system-status` (SSM read), `/api/health` work on the Function URL.
- [ ] ECS service unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)