### PR TITLE
feat: enable async runs (flip ASYNC_RUNS_ENABLED on)

### DIFF
--- a/apps/react-ui/client/src/CONFIG.ts
+++ b/apps/react-ui/client/src/CONFIG.ts
@@ -5,8 +5,7 @@ const CONFIG = {
   WAIVE_ENABLED: true,
   RTMA_ENABLED: true,
   // Async (non-blocking) model runs + per-browser runs history.
-  // Dark launch: ships off; flip on after the infra is deployed and verified.
-  ASYNC_RUNS_ENABLED: false,
+  ASYNC_RUNS_ENABLED: true,
   SHOULD_SEND_EMAIL_IN_FOOTER_CONTACT: false,
   SHOULD_USE_CLUSTERED_CR2_SE_AS_DEFAULT: true,
   SHOULD_ADD_CITATION_TO_FUNNEL_PLOT: true,


### PR DESCRIPTION
Turns on the async-runs feature now that Phase 1 infra is deployed (DynamoDB `maive-runs`, SQS `maive-runs` + DLQ, `maive-orchestrator` Lambda). One-line flag flip: `CONFIG.ASYNC_RUNS_ENABLED` false → true.

Rollback = flip back to false + release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)