### PR TITLE
fix: tolerate extra params in run_maive_model validation

### DIFF
--- a/apps/lambda-r-backend/r_scripts/maive_model.R
+++ b/apps/lambda-r-backend/r_scripts/maive_model.R
@@ -171,7 +171,7 @@ run_maive_model <- function(data, parameters) {
     "winsorize"
   )
 
-  if (!all(names(params) %in% expected_parameters) || !all(expected_parameters %in% names(params))) {
+  if (!all(expected_parameters %in% names(params))) {
     cli::cli_abort(paste0("The parameters must include the following: ", paste(expected_parameters, collapse = ", ")))
   }
 

--- a/apps/lambda-r-backend/r_scripts/tests/e2e/test_config.R
+++ b/apps/lambda-r-backend/r_scripts/tests/e2e/test_config.R
@@ -44,5 +44,8 @@ DEFAULT_PARAMETERS <- list(
   maiveMethod = "PET-PEESE",
   weight = "equal_weights",
   shouldUseInstrumenting = TRUE,
-  useLogFirstStage = FALSE
+  useLogFirstStage = FALSE,
+  # The UI forwards the full ModelParameters object, which carries the
+  # RTMA-only favorPositive key. run_maive_model must tolerate extra keys.
+  favorPositive = TRUE
 )


### PR DESCRIPTION
## Summary

Production bug: running a **MAIVE** model (and WLS/WAIVE) on https://maive.eu fails with:

> Run failed — Internal server error: The parameters must include the following: modelType, includeStudyDummies, includeStudyClustering, standardErrorTreatment, computeAndersonRubin, maiveMethod, weight, shouldUseInstrumenting, useLogFirstStage, winsorize

RTMA runs are unaffected.

### Root cause

`run_maive_model()` in `apps/lambda-r-backend/r_scripts/maive_model.R` validated params with a **bidirectional exact-set match**:

```r
if (!all(names(params) %in% expected_parameters) || !all(expected_parameters %in% names(params))) { ... abort }
```

Since v0.6.0 the UI's `ModelParameters` carries an extra RTMA-only `favorPositive` key (`CONFIG.DEFAULT_MODEL_PARAMETERS`). Both run paths forward the **full** `ModelParameters` object to `/run-model`:
- **sync**: browser → `modelService.runModel` → `POST /run-model`
- **async**: browser → `/api/runs` → SQS → orchestrator → `POST /run-model`

The extra `favorPositive` key made `all(names(params) %in% expected_parameters)` FALSE, so the guard aborted — independent of the data. RTMA works because `run_rtma_model` has looser validation. (The async feature merely made this more visible; the sync MAIVE path has been broken since v0.6.0.)

### Fix

Relax the guard to only require that the expected keys are **present**, tolerating extra keys:

```r
if (!all(expected_parameters %in% names(params))) { ... abort }
```

One change fixes both sync and async paths and is robust to future param additions.

## Changes

- `maive_model.R`: drop the over-strict `names(params) %in% expected_parameters` clause.
- `tests/e2e/test_config.R`: add `favorPositive = TRUE` to `DEFAULT_PARAMETERS` so the e2e MAIVE scenarios mirror what the UI actually sends (regression guard).

## Test plan

- [x] Verified the real guard: full params + extra `favorPositive` key passes validation (proceeds past the guard); a missing required key is still rejected with the original message.
- [ ] Post-deploy: run a MAIVE model end-to-end on https://maive.eu (via the async `/api/runs` flow) and confirm `status: succeeded`.
- [ ] Confirm RTMA still works (uses `/run-rtma`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)