### PR TITLE
feat: async runs phase 2 — live statuses, notifications, durable history

### DIFF
--- a/apps/react-ui/client/bun.lock
+++ b/apps/react-ui/client/bun.lock
@@ -9,6 +9,7 @@
         "@aws-sdk/client-ssm": "^3.714.0",
         "@aws-sdk/lib-dynamodb": "^3.1061.0",
         "file-saver": "^2.0.5",
+        "idb": "^8.0.3",
         "jszip": "^3.10.1",
         "next": "14.0.4",
         "papaparse": "^5.4.1",
@@ -873,6 +874,8 @@
     "human-signals": ["human-signals@5.0.0", "", {}, "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ=="],
 
     "iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
+
+    "idb": ["idb@8.0.3", "", {}, "sha512-LtwtVyVYO5BqRvcsKuB2iUMnHwPVByPCXFXOpuU96IZPPoPN6xjOGxZQ74pgSVVLQWtUOYgyeL4GE98BY5D3wg=="],
 
     "ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
 

--- a/apps/react-ui/client/package-lock.json
+++ b/apps/react-ui/client/package-lock.json
@@ -13,6 +13,7 @@
 				"@aws-sdk/client-ssm": "^3.714.0",
 				"@aws-sdk/lib-dynamodb": "^3.1061.0",
 				"file-saver": "^2.0.5",
+				"idb": "^8.0.3",
 				"jszip": "^3.10.1",
 				"next": "14.0.4",
 				"papaparse": "^5.4.1",
@@ -7461,6 +7462,12 @@
 			"engines": {
 				"node": ">=0.10.0"
 			}
+		},
+		"node_modules/idb": {
+			"version": "8.0.3",
+			"resolved": "https://registry.npmjs.org/idb/-/idb-8.0.3.tgz",
+			"integrity": "sha512-LtwtVyVYO5BqRvcsKuB2iUMnHwPVByPCXFXOpuU96IZPPoPN6xjOGxZQ74pgSVVLQWtUOYgyeL4GE98BY5D3wg==",
+			"license": "ISC"
 		},
 		"node_modules/ignore": {
 			"version": "5.3.2",

--- a/apps/react-ui/client/package.json
+++ b/apps/react-ui/client/package.json
@@ -17,6 +17,7 @@
 		"@aws-sdk/client-ssm": "^3.714.0",
 		"@aws-sdk/lib-dynamodb": "^3.1061.0",
 		"file-saver": "^2.0.5",
+		"idb": "^8.0.3",
 		"jszip": "^3.10.1",
 		"next": "14.0.4",
 		"papaparse": "^5.4.1",

--- a/apps/react-ui/client/src/api/services/modelService.ts
+++ b/apps/react-ui/client/src/api/services/modelService.ts
@@ -94,6 +94,33 @@ export class ModelService {
   }
 
   /**
+   * Batch-fetch the status of multiple runs by jobId (for the My Runs list /
+   * the global watcher). Returns status-only entries (no heavy result payload).
+   * @param jobIds - The run job ids to look up
+   */
+  async getRuns(jobIds: string[]): Promise<GetRunResponse[]> {
+    if (jobIds.length === 0) {
+      return [];
+    }
+    try {
+      return await httpGet<GetRunResponse[]>(
+        `/api/runs?ids=${jobIds.map((id) => encodeURIComponent(id)).join(",")}`,
+        {
+          timeout: 30000,
+          headers: {
+            // eslint-disable-next-line @typescript-eslint/naming-convention
+            "Content-Type": "application/json",
+          },
+        },
+      );
+    } catch (error: unknown) {
+      throw new Error(
+        `Failed to fetch runs: ${error instanceof Error ? error.message : "Unknown error"}`,
+      );
+    }
+  }
+
+  /**
    * Submit a model run to the async queue (non-blocking).
    * Calls the same-origin UI Lambda route, which persists a queued job and
    * enqueues it for the orchestrator, returning a jobId. Returns

--- a/apps/react-ui/client/src/components/RunLoading.tsx
+++ b/apps/react-ui/client/src/components/RunLoading.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import LoadingCard from "@src/components/LoadingCard";
+import ActionButton from "@src/components/Buttons/ActionButton";
+
+export type RunLoadingPhase = "submitting" | "running" | "blocking";
+
+type RunLoadingProps = {
+  phase: RunLoadingPhase;
+  // For the "Model setup" shortcut in the running phase.
+  dataId?: string | null;
+  // Reuse the cold-start warm-up copy in the blocking (synchronous) phase.
+  showWarmupHint?: boolean;
+};
+
+const COPY: Record<RunLoadingPhase, { title: string; subtitle: string }> = {
+  submitting: {
+    title: "Queueing your analysis…",
+    subtitle: "One moment — we're setting things up.",
+  },
+  running: {
+    title: "Your analysis is running…",
+    subtitle:
+      "You're free to leave this page — it keeps running in the background and will appear under My Runs.",
+  },
+  blocking: {
+    title: "Running your analysis…",
+    subtitle: "Hang tight while we process your model settings.",
+  },
+};
+
+/**
+ * Unified run-loading screen. Drives a single, consistent loading card across
+ * the model page (async "submitting" / synchronous "blocking") and the results
+ * page (async "running"), so the experience reads as one continuous screen with
+ * status-driven copy. In the "running" phase the user is free to leave and gets
+ * shortcuts to queue another run while this one finishes in the background.
+ */
+export default function RunLoading({
+  phase,
+  dataId,
+  showWarmupHint = false,
+}: RunLoadingProps) {
+  const router = useRouter();
+  const { title } = COPY[phase];
+  const subtitle =
+    phase === "blocking" && showWarmupHint
+      ? "Still working — the first run can take a little longer while the analysis engine warms up."
+      : COPY[phase].subtitle;
+
+  return (
+    <div className="mx-auto max-w-md">
+      <LoadingCard title={title} subtitle={subtitle}>
+        {phase === "running" && (
+          <div className="mt-6 flex flex-wrap items-center justify-center gap-3">
+            <ActionButton
+              variant="primary"
+              size="sm"
+              onClick={() => router.push("/upload")}
+            >
+              Run another analysis
+            </ActionButton>
+            {dataId ? (
+              <ActionButton
+                variant="secondary"
+                size="sm"
+                onClick={() =>
+                  router.push(`/model?dataId=${encodeURIComponent(dataId)}`)
+                }
+              >
+                Model setup
+              </ActionButton>
+            ) : null}
+            <ActionButton
+              variant="secondary"
+              size="sm"
+              onClick={() => router.push("/runs")}
+            >
+              View My Runs
+            </ActionButton>
+          </div>
+        )}
+      </LoadingCard>
+    </div>
+  );
+}

--- a/apps/react-ui/client/src/components/RunsWatcher.tsx
+++ b/apps/react-ui/client/src/components/RunsWatcher.tsx
@@ -1,0 +1,97 @@
+"use client";
+
+import { useEffect } from "react";
+import CONFIG from "@src/CONFIG";
+import { useRunsStore } from "@src/store/runsStore";
+import { modelService } from "@src/api/services/modelService";
+import { useGlobalAlert } from "@src/components/GlobalAlertProvider";
+import { notifyRunComplete } from "@src/utils/notifications";
+import type { RunStatus } from "@src/types/api";
+
+const TERMINAL_STATUSES: RunStatus[] = ["succeeded", "failed", "timedout"];
+const POLL_INTERVAL_MS = 5000;
+
+const isTerminal = (status: RunStatus) => TERMINAL_STATUSES.includes(status);
+
+/**
+ * App-level watcher (renders nothing). While the per-browser runs list has any
+ * non-terminal run, it polls their status via the batch endpoint, updates the
+ * store (so the My Runs list reflects live status from anywhere in the app),
+ * and fires a browser notification when a run transitions to terminal — with an
+ * in-app alert fallback. Inert when CONFIG.ASYNC_RUNS_ENABLED is false.
+ */
+export default function RunsWatcher() {
+  const runsList = useRunsStore((state) => state.runsList);
+  const updateRunStatus = useRunsStore((state) => state.updateRunStatus);
+  const { showAlert } = useGlobalAlert();
+
+  // Stable key of the runs still in flight — drives the polling effect.
+  const pendingIdsKey = runsList
+    .filter((run) => !isTerminal(run.status))
+    .map((run) => run.jobId)
+    .join(",");
+
+  useEffect(() => {
+    if (!CONFIG.ASYNC_RUNS_ENABLED || pendingIdsKey === "") {
+      return undefined;
+    }
+
+    let cancelled = false;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+
+    const poll = async () => {
+      // Read fresh store state each cycle (it's the source of "previous" status).
+      const current = useRunsStore.getState().runsList;
+      const pending = current.filter((run) => !isTerminal(run.status));
+      if (pending.length === 0) {
+        return; // nothing left to watch; effect re-runs if new runs appear
+      }
+
+      try {
+        const runs = await modelService.getRuns(pending.map((r) => r.jobId));
+        if (cancelled) {
+          return;
+        }
+        const byId = new Map(current.map((r) => [r.jobId, r] as const));
+        runs.forEach((run) => {
+          const prev = byId.get(run.jobId);
+          // Notify on a transition into a terminal status.
+          if (prev && !isTerminal(prev.status) && isTerminal(run.status)) {
+            const shown = notifyRunComplete({
+              jobId: run.jobId,
+              modelType: run.modelType ?? prev.modelType ?? "Model",
+              status: run.status,
+            });
+            if (!shown) {
+              const ok = run.status === "succeeded";
+              showAlert(
+                ok
+                  ? "Your run finished — open it from My Runs."
+                  : "A run did not complete — see My Runs.",
+                ok ? "success" : "error",
+              );
+            }
+          }
+          updateRunStatus(run.jobId, run.status);
+        });
+      } catch {
+        // transient (network/throttle) — keep polling
+      }
+
+      if (!cancelled) {
+        timer = setTimeout(() => void poll(), POLL_INTERVAL_MS);
+      }
+    };
+
+    void poll();
+
+    return () => {
+      cancelled = true;
+      if (timer) {
+        clearTimeout(timer);
+      }
+    };
+  }, [pendingIdsKey, updateRunStatus, showAlert]);
+
+  return null;
+}

--- a/apps/react-ui/client/src/hooks/useRunStatus.ts
+++ b/apps/react-ui/client/src/hooks/useRunStatus.ts
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import type { ModelResults, RTMAResults, RunStatus } from "@src/types/api";
 import { modelService } from "@api/services/modelService";
 import { useRunsStore } from "@src/store/runsStore";
+import { getResult, putResult } from "@src/utils/runsCache";
 
 type UseRunStatusResult = {
   status: RunStatus | null;
@@ -67,7 +68,9 @@ export function useRunStatus(jobId: string | null): UseRunStatusResult {
         }
         if (run.result) {
           try {
-            setResult(JSON.parse(run.result) as ModelResults | RTMAResults);
+            const parsed = JSON.parse(run.result) as ModelResults | RTMAResults;
+            setResult(parsed);
+            void putResult(jobId, parsed); // durable client-side cache
           } catch {
             setErrorMessage("Failed to parse run result.");
           }
@@ -103,7 +106,24 @@ export function useRunStatus(jobId: string | null): UseRunStatusResult {
       timer = setTimeout(() => void poll(), interval);
     };
 
-    void poll();
+    const init = async () => {
+      // Durable cache: if this result is already cached locally, render it
+      // immediately and skip polling (results are immutable once produced, and
+      // this still works after the 48h server TTL).
+      const cached = await getResult(jobId);
+      if (cancelled) {
+        return;
+      }
+      if (cached) {
+        setResult(cached);
+        setStatus("succeeded");
+        setIsPolling(false);
+        return;
+      }
+      void poll();
+    };
+
+    void init();
 
     return () => {
       cancelled = true;

--- a/apps/react-ui/client/src/pages/_app.tsx
+++ b/apps/react-ui/client/src/pages/_app.tsx
@@ -6,6 +6,7 @@ import type { AppProps } from "next/app";
 import { usePathname } from "next/navigation";
 import Header from "@components/Header";
 import Footer from "@components/Footer";
+import RunsWatcher from "@components/RunsWatcher";
 import Script from "next/script";
 
 export default function App({ Component, pageProps }: AppProps) {
@@ -17,6 +18,7 @@ export default function App({ Component, pageProps }: AppProps) {
   return (
     <Providers>
       <Script src="/api/runtime-config" />
+      <RunsWatcher />
       <div className="flex flex-col min-h-screen">
         {!isHomePage && <Header />}
         <main className="flex-1 flex-col">

--- a/apps/react-ui/client/src/pages/api/runs.ts
+++ b/apps/react-ui/client/src/pages/api/runs.ts
@@ -1,8 +1,16 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
-import { DynamoDBDocumentClient, PutCommand } from "@aws-sdk/lib-dynamodb";
+import {
+  DynamoDBDocumentClient,
+  PutCommand,
+  BatchGetCommand,
+} from "@aws-sdk/lib-dynamodb";
 import { SQSClient, SendMessageCommand } from "@aws-sdk/client-sqs";
-import type { SubmitRunResponse } from "@src/types/api";
+import type {
+  SubmitRunResponse,
+  GetRunResponse,
+  RunStatus,
+} from "@src/types/api";
 import { generateJobId } from "@src/utils/idUtils";
 
 // Allow larger request bodies than Next.js's 1mb default so we can accept a
@@ -25,6 +33,7 @@ const TTL_SECONDS = 48 * 60 * 60; // 48h pickup buffer
 // Keep the SQS message under the 256KB hard limit; larger datasets fall back
 // to the synchronous path (which posts directly to the R Lambda).
 const MAX_QUEUE_BODY_BYTES = 200 * 1024;
+const MAX_BATCH_IDS = 100; // DynamoDB BatchGetItem caps at 100 keys
 
 let ddbDocClient: DynamoDBDocumentClient | undefined;
 let sqsClient: SQSClient | undefined;
@@ -51,20 +60,78 @@ const getSqsClient = () => {
 
 const handler = async (
   req: NextApiRequest,
-  res: NextApiResponse<SubmitRunResponse>,
+  res: NextApiResponse<
+    SubmitRunResponse | GetRunResponse[] | { error: string }
+  >,
 ) => {
-  if (req.method !== "POST") {
-    res.setHeader("Allow", "POST");
-    return res.status(405).json({ error: "Method Not Allowed" });
-  }
-
-  if (!tableName || !queueUrl) {
+  if (!tableName) {
     return res.status(503).json({ error: "Async runs are not configured." });
   }
 
   const ddb = getDdbDocClient();
+  if (!ddb) {
+    return res.status(503).json({ error: "Async runs are not configured." });
+  }
+
+  // GET /api/runs?ids=a,b,c — batch status lookup for the My Runs list / watcher.
+  if (req.method === "GET") {
+    const idsParam = req.query.ids;
+    const idsRaw = Array.isArray(idsParam)
+      ? idsParam.join(",")
+      : (idsParam ?? "");
+    const ids = idsRaw
+      .split(",")
+      .map((s) => s.trim())
+      .filter(Boolean)
+      .slice(0, MAX_BATCH_IDS);
+    if (ids.length === 0) {
+      return res.status(200).json([]);
+    }
+    try {
+      const out = await ddb.send(
+        new BatchGetCommand({
+          RequestItems: {
+            [tableName]: {
+              Keys: ids.map((id) => ({ jobId: id })),
+              // Status-only projection (no heavy `result`) — the list/watcher
+              // only needs status; the full result is fetched per-run elsewhere.
+              ProjectionExpression:
+                "jobId, #status, modelType, errorMessage, runDurationMs, submittedAt",
+              // eslint-disable-next-line @typescript-eslint/naming-convention
+              ExpressionAttributeNames: { "#status": "status" },
+            },
+          },
+        }),
+      );
+      const items = out.Responses?.[tableName] ?? [];
+      const runs: GetRunResponse[] = items.map((item) => ({
+        jobId: item.jobId as string,
+        status: item.status as RunStatus,
+        modelType: item.modelType as GetRunResponse["modelType"],
+        errorMessage: (item.errorMessage as string | undefined) ?? undefined,
+        runDurationMs:
+          typeof item.runDurationMs === "number"
+            ? item.runDurationMs
+            : undefined,
+        runTimestamp:
+          typeof item.submittedAt === "number"
+            ? new Date(item.submittedAt).toISOString()
+            : undefined,
+      }));
+      return res.status(200).json(runs);
+    } catch (error) {
+      console.error("Failed to batch-fetch runs", error);
+      return res.status(500).json({ error: "Failed to fetch runs." });
+    }
+  }
+
+  if (req.method !== "POST") {
+    res.setHeader("Allow", "GET, POST");
+    return res.status(405).json({ error: "Method Not Allowed" });
+  }
+
   const sqs = getSqsClient();
-  if (!ddb || !sqs) {
+  if (!queueUrl || !sqs) {
     return res.status(503).json({ error: "Async runs are not configured." });
   }
 

--- a/apps/react-ui/client/src/pages/model/index.tsx
+++ b/apps/react-ui/client/src/pages/model/index.tsx
@@ -14,7 +14,7 @@ import ActionButton from "@src/components/Buttons/ActionButton";
 import { GoBackButton } from "@src/components/Buttons";
 import { useGlobalAlert } from "@src/components/GlobalAlertProvider";
 import { useParameterAlert } from "@src/components/ParameterAlertProvider";
-import LoadingCard from "@src/components/LoadingCard";
+import RunLoading, { type RunLoadingPhase } from "@src/components/RunLoading";
 import SectionHeading from "@src/components/SectionHeading";
 import CONFIG from "@src/CONFIG";
 import CONST from "@src/CONST";
@@ -27,6 +27,7 @@ import { hasStudyIdColumn } from "@src/utils/dataUtils";
 import { useEnterKeyAction } from "@src/hooks/useEnterKeyAction";
 import { detectAndDispatchAlerts } from "@src/utils/parameterChangeTracking";
 import { cleanCliErrorMessage } from "@src/utils/errorMessageUtils";
+import { requestNotificationPermission } from "@src/utils/notifications";
 
 const isModelWeight = (weight: string): weight is ModelParameters["weight"] =>
   Object.values(CONST.WEIGHT_OPTIONS).some((option) => option.VALUE === weight);
@@ -40,6 +41,10 @@ export default function ModelPage() {
   const [loading, setLoading] = useState(false);
   const [showWarmupHint, setShowWarmupHint] = useState(false);
   const [hasRunModel, setHasRunModel] = useState(false);
+  // Drives the unified loading screen: "submitting" for the async queue path
+  // (before we navigate to /results, which then shows "running"), "blocking"
+  // for the synchronous / mock / too-large fallback where the user must stay.
+  const [loadingPhase, setLoadingPhase] = useState<RunLoadingPhase>("blocking");
   const [uploadedData, setUploadedData] = useState<UploadedData | null>(null);
   const [parameters, setParameters] = useState<ModelParameters>({
     ...CONFIG.DEFAULT_MODEL_PARAMETERS,
@@ -469,13 +474,6 @@ export default function ModelPage() {
     return () => clearTimeout(timer);
   }, [loading]);
 
-  const modelLoadingCopy = {
-    title: "Running your analysis...",
-    subtitle: showWarmupHint
-      ? "Still working - the first run can take a little longer while the analysis engine warms up."
-      : "Hang tight while we process your model settings.",
-  };
-
   useEffect(() => {
     if (parameters.modelType === CONST.MODEL_TYPES.WAIVE) {
       if (
@@ -632,6 +630,8 @@ export default function ModelPage() {
 
   const handleRunModel = useCallback(() => {
     void (async () => {
+      const isAsyncRun = CONFIG.ASYNC_RUNS_ENABLED && !shouldUseMockResults();
+      setLoadingPhase(isAsyncRun ? "submitting" : "blocking");
       setLoading(true);
       setHasRunModel(true);
       abortControllerRef.current = new AbortController();
@@ -644,7 +644,10 @@ export default function ModelPage() {
         // and navigate immediately so the user can keep working. Skips mock
         // mode (dev); falls back to the synchronous path below when the dataset
         // is too large to queue.
-        if (CONFIG.ASYNC_RUNS_ENABLED && !shouldUseMockResults()) {
+        if (isAsyncRun) {
+          // Ask for notification permission lazily, on first submit, so the
+          // global RunsWatcher can ping the user when a backgrounded run ends.
+          requestNotificationPermission();
           const runParameters: ModelParameters | RTMAParameters =
             parameters.modelType === CONST.MODEL_TYPES.RTMA
               ? {
@@ -697,7 +700,9 @@ export default function ModelPage() {
             }
             return;
           }
-          // tooLarge → fall through to the synchronous path below.
+          // tooLarge → fall through to the synchronous path below, where the
+          // user must stay on the page while the run completes.
+          setLoadingPhase("blocking");
         }
 
         let result: { data?: unknown; error?: string; message?: string };
@@ -890,11 +895,10 @@ export default function ModelPage() {
             {/* Card transition: parameters or loading */}
             <div className="min-h-[400px] w-full items-center justify-center">
               {loading || hasRunModel ? (
-                <LoadingCard
-                  title={modelLoadingCopy.title}
-                  subtitle={modelLoadingCopy.subtitle}
-                  color="blue"
-                  size="md"
+                <RunLoading
+                  phase={loadingPhase}
+                  dataId={dataId}
+                  showWarmupHint={showWarmupHint}
                 />
               ) : (
                 <div className="bg-white dark:bg-gray-800 p-8 rounded-xl shadow-lg border border-gray-100 dark:border-gray-700 transition-all duration-500 opacity-100 scale-100">

--- a/apps/react-ui/client/src/pages/model/index.tsx
+++ b/apps/react-ui/client/src/pages/model/index.tsx
@@ -21,7 +21,7 @@ import CONST from "@src/CONST";
 import TEXT from "@src/lib/text";
 import { modelService } from "@src/api/services/modelService";
 import type { ModelParameters } from "@src/types";
-import type { RTMAParameters } from "@src/types/api";
+import type { RTMAParameters, SubmitRunResponse } from "@src/types/api";
 import { modelOptionsConfig } from "@src/config/optionsConfig";
 import { hasStudyIdColumn } from "@src/utils/dataUtils";
 import { useEnterKeyAction } from "@src/hooks/useEnterKeyAction";
@@ -659,15 +659,33 @@ export default function ModelPage() {
                 }
               : parameters;
 
-          const submission = await modelService.submitRun(
-            uploadedData?.data ?? [],
-            runParameters,
-            dataId ?? "",
-            parameters.modelType,
-            abortControllerRef.current ?? undefined,
-          );
+          // Best-effort: if the async submit fails (e.g. the queue/table isn't
+          // configured — 503 locally — or a transient error), degrade to the
+          // synchronous path below rather than failing the whole run. A user
+          // abort is re-thrown so the outer handler can report it.
+          let submission: SubmitRunResponse | null = null;
+          try {
+            submission = await modelService.submitRun(
+              uploadedData?.data ?? [],
+              runParameters,
+              dataId ?? "",
+              parameters.modelType,
+              abortControllerRef.current ?? undefined,
+            );
+          } catch (submitError) {
+            if (
+              submitError instanceof Error &&
+              submitError.name === "AbortError"
+            ) {
+              throw submitError;
+            }
+            console.warn(
+              "Async submit unavailable; running synchronously instead:",
+              submitError,
+            );
+          }
 
-          if (submission.jobId && !submission.tooLarge) {
+          if (submission?.jobId && !submission.tooLarge) {
             addRun({
               jobId: submission.jobId,
               modelType: parameters.modelType,
@@ -700,8 +718,9 @@ export default function ModelPage() {
             }
             return;
           }
-          // tooLarge → fall through to the synchronous path below, where the
-          // user must stay on the page while the run completes.
+          // Not queued (too large, async not configured, or submit failed) →
+          // fall through to the synchronous path below, where the user must
+          // stay on the page while the run completes.
           setLoadingPhase("blocking");
         }
 

--- a/apps/react-ui/client/src/pages/results/index.tsx
+++ b/apps/react-ui/client/src/pages/results/index.tsx
@@ -27,7 +27,7 @@ import CitationBox from "@src/components/CitationBox";
 import { RunInfoModal } from "@src/components/Modals";
 import ResultsSummary from "@src/components/ResultsSummary";
 import RTMAResultsSummary from "@src/components/RTMAResultsSummary";
-import LoadingCard from "@src/components/LoadingCard";
+import RunLoading from "@src/components/RunLoading";
 import { useRunStatus } from "@src/hooks/useRunStatus";
 import CONST from "@src/CONST";
 import CONFIG from "@src/CONFIG";
@@ -287,12 +287,7 @@ export default function ResultsPage() {
               />
             </div>
           ) : (
-            <div className="mx-auto max-w-md">
-              <LoadingCard
-                title="Running your analysis..."
-                subtitle="You can leave this page — your run is queued and will appear in My Runs. The first run can take a little longer while the engine warms up."
-              />
-            </div>
+            <RunLoading phase="running" dataId={dataId} />
           )}
         </main>
       </>

--- a/apps/react-ui/client/src/pages/runs/index.tsx
+++ b/apps/react-ui/client/src/pages/runs/index.tsx
@@ -4,8 +4,10 @@ import Head from "next/head";
 import { useRouter } from "next/navigation";
 import SectionHeading from "@src/components/SectionHeading";
 import { GoBackButton } from "@src/components/Buttons";
+import ActionButton from "@src/components/Buttons/ActionButton";
 import CONST from "@src/CONST";
 import { useRunsStore } from "@src/store/runsStore";
+import { deleteResult, clearAllResults } from "@src/utils/runsCache";
 import type { RunStatus } from "@src/types/api";
 
 const statusLabel = (status: RunStatus): string => {
@@ -25,15 +27,16 @@ const statusLabel = (status: RunStatus): string => {
   }
 };
 
+// Badge classes (background + text) for the status pill.
 const statusClasses = (status: RunStatus): string => {
   switch (status) {
     case "succeeded":
-      return "text-green-600 dark:text-green-400";
+      return "bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400";
     case "failed":
     case "timedout":
-      return "text-red-600 dark:text-red-400";
+      return "bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400";
     default:
-      return "text-blue-600 dark:text-blue-400";
+      return "bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400";
   }
 };
 
@@ -68,13 +71,16 @@ export default function RunsPage() {
           <div className="mb-4 flex items-center justify-between">
             <SectionHeading level="h1" text="My Runs" />
             {runsList.length > 0 && (
-              <button
-                type="button"
-                className="btn-secondary"
-                onClick={() => clearRuns()}
+              <ActionButton
+                variant="secondary"
+                size="sm"
+                onClick={() => {
+                  clearRuns();
+                  void clearAllResults();
+                }}
               >
                 Clear all
-              </button>
+              </ActionButton>
             )}
           </div>
 
@@ -91,38 +97,41 @@ export default function RunsPage() {
               />
             </div>
           ) : (
-            <ul className="space-y-3">
+            <ul className="space-y-2">
               {runsList.map((run) => (
                 <li
                   key={run.jobId}
-                  className="card flex items-center justify-between gap-4"
+                  className="surface-elevated flex items-center justify-between gap-4 rounded-lg border border-primary px-4 py-3"
                 >
-                  <div>
+                  <div className="min-w-0">
                     <p className="font-medium">{run.modelType}</p>
                     <p className="text-sm text-gray-500 dark:text-gray-400">
                       {new Date(run.submittedAt).toLocaleString()}
                     </p>
                   </div>
-                  <div className="flex items-center gap-4">
+                  <div className="flex items-center gap-3">
                     <span
-                      className={`text-sm font-medium ${statusClasses(run.status)}`}
+                      className={`inline-flex items-center rounded-full px-2 py-1 text-xs font-semibold ${statusClasses(run.status)}`}
                     >
                       {statusLabel(run.status)}
                     </span>
-                    <button
-                      type="button"
-                      className="btn-primary"
+                    <ActionButton
+                      variant="primary"
+                      size="sm"
                       onClick={() =>
                         openRun(run.jobId, run.dataId, run.parameters)
                       }
                     >
                       Open
-                    </button>
+                    </ActionButton>
                     <button
                       type="button"
-                      className="text-sm text-gray-400 hover:text-red-500"
+                      className="text-sm text-gray-400 transition-colors hover:text-red-600"
                       aria-label="Remove run"
-                      onClick={() => removeRun(run.jobId)}
+                      onClick={() => {
+                        removeRun(run.jobId);
+                        void deleteResult(run.jobId);
+                      }}
                     >
                       Remove
                     </button>

--- a/apps/react-ui/client/src/tests/RunsWatcher.test.tsx
+++ b/apps/react-ui/client/src/tests/RunsWatcher.test.tsx
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, waitFor } from "@testing-library/react";
+import RunsWatcher from "@src/components/RunsWatcher";
+import { GlobalAlertProvider } from "@src/components/GlobalAlertProvider";
+import { useRunsStore } from "@src/store/runsStore";
+import { modelService } from "@src/api/services/modelService";
+
+vi.mock("@src/utils/notifications", () => ({
+  notifyRunComplete: vi.fn(() => true),
+  requestNotificationPermission: vi.fn(),
+}));
+
+const addRun = (jobId: string, status: "queued" | "succeeded") => {
+  useRunsStore.getState().addRun({
+    jobId,
+    modelType: "RTMA",
+    dataId: "d1",
+    parameters: "{}",
+    submittedAt: Date.now(),
+    status,
+  });
+};
+
+const renderWatcher = () =>
+  render(
+    <GlobalAlertProvider>
+      <RunsWatcher />
+    </GlobalAlertProvider>,
+  );
+
+describe("RunsWatcher", () => {
+  beforeEach(() => {
+    useRunsStore.getState().clearRuns();
+    vi.restoreAllMocks();
+  });
+
+  it("polls pending runs and reflects their terminal status in the store", async () => {
+    addRun("job-1", "queued");
+    const getRuns = vi
+      .spyOn(modelService, "getRuns")
+      .mockResolvedValue([{ jobId: "job-1", status: "succeeded" }]);
+
+    renderWatcher();
+
+    await waitFor(() => expect(getRuns).toHaveBeenCalledWith(["job-1"]));
+    await waitFor(() =>
+      expect(useRunsStore.getState().runsList[0].status).toBe("succeeded"),
+    );
+  });
+
+  it("does not poll when every run is already terminal", async () => {
+    addRun("done-1", "succeeded");
+    const getRuns = vi.spyOn(modelService, "getRuns").mockResolvedValue([]);
+
+    renderWatcher();
+
+    // Allow the effect to run; a terminal-only list must never be polled.
+    await new Promise((resolve) => {
+      setTimeout(resolve, 50);
+    });
+    expect(getRuns).not.toHaveBeenCalled();
+  });
+});

--- a/apps/react-ui/client/src/tests/modelServiceGetRuns.test.ts
+++ b/apps/react-ui/client/src/tests/modelServiceGetRuns.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { modelService } from "@api/services/modelService";
+
+describe("modelService.getRuns", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns [] without hitting the network for an empty id list", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    const result = await modelService.getRuns([]);
+    expect(result).toEqual([]);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("requests the batch endpoint with comma-joined, encoded ids", async () => {
+    const payload = [
+      { jobId: "a", status: "running" },
+      { jobId: "b", status: "succeeded" },
+    ];
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(
+        new Response(JSON.stringify(payload), { status: 200 }),
+      );
+
+    const result = await modelService.getRuns(["a", "b"]);
+
+    expect(result).toEqual(payload);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(String(fetchSpy.mock.calls[0][0])).toBe("/api/runs?ids=a,b");
+  });
+
+  it("throws a descriptive error when the endpoint fails", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ error: "boom" }), { status: 500 }),
+    );
+
+    await expect(modelService.getRuns(["a"])).rejects.toThrow(
+      /Failed to fetch runs/,
+    );
+  });
+});

--- a/apps/react-ui/client/src/tests/notifications.test.ts
+++ b/apps/react-ui/client/src/tests/notifications.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  requestNotificationPermission,
+  notifyRunComplete,
+} from "@src/utils/notifications";
+
+type Perm = "default" | "granted" | "denied";
+
+const constructed: Array<{ title: string; options?: NotificationOptions }> = [];
+
+const requestPermissionMock = vi.fn(
+  (): Promise<Perm> => Promise.resolve("granted"),
+);
+
+class MockNotification {
+  static permission: Perm = "granted";
+
+  static requestPermission = requestPermissionMock;
+
+  onclick: (() => void) | null = null;
+
+  constructor(title: string, options?: NotificationOptions) {
+    constructed.push({ title, options });
+  }
+}
+
+const installNotification = (permission: Perm) => {
+  MockNotification.permission = permission;
+  vi.stubGlobal("Notification", MockNotification);
+};
+
+describe("notifications", () => {
+  beforeEach(() => {
+    constructed.length = 0;
+    requestPermissionMock.mockClear();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  describe("notifyRunComplete", () => {
+    it("returns false when notifications are unsupported", () => {
+      expect(
+        notifyRunComplete({
+          jobId: "j1",
+          modelType: "RTMA",
+          status: "succeeded",
+        }),
+      ).toBe(false);
+    });
+
+    it("returns false (and shows nothing) when permission is not granted", () => {
+      installNotification("default");
+      expect(
+        notifyRunComplete({
+          jobId: "j1",
+          modelType: "RTMA",
+          status: "succeeded",
+        }),
+      ).toBe(false);
+      expect(constructed).toHaveLength(0);
+    });
+
+    it("shows a success notification when permission is granted", () => {
+      installNotification("granted");
+      const shown = notifyRunComplete({
+        jobId: "j1",
+        modelType: "MAIVE",
+        status: "succeeded",
+      });
+      expect(shown).toBe(true);
+      expect(constructed).toHaveLength(1);
+      expect(constructed[0].title).toBe("MAIVE run finished");
+      expect(constructed[0].options?.tag).toBe("j1");
+    });
+
+    it("labels a failed run", () => {
+      installNotification("granted");
+      notifyRunComplete({ jobId: "j2", modelType: "RTMA", status: "failed" });
+      expect(constructed[0].title).toBe("RTMA run failed");
+    });
+
+    it("labels a timed-out run", () => {
+      installNotification("granted");
+      notifyRunComplete({ jobId: "j3", modelType: "RTMA", status: "timedout" });
+      expect(constructed[0].title).toBe("RTMA run timed out");
+    });
+  });
+
+  describe("requestNotificationPermission", () => {
+    it("requests permission when the user has not decided", () => {
+      installNotification("default");
+      requestNotificationPermission();
+      expect(requestPermissionMock).toHaveBeenCalledTimes(1);
+    });
+
+    it("does nothing once permission is already decided", () => {
+      installNotification("denied");
+      requestNotificationPermission();
+      expect(requestPermissionMock).not.toHaveBeenCalled();
+    });
+
+    it("does nothing when notifications are unsupported", () => {
+      requestNotificationPermission();
+      expect(requestPermissionMock).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/react-ui/client/src/tests/runsCache.test.ts
+++ b/apps/react-ui/client/src/tests/runsCache.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import type { RTMAResults } from "@src/types/api";
+
+// In-memory store backing a mocked idb database, so we can exercise the
+// runsCache wrapper without a real IndexedDB (jsdom has none).
+const store = new Map<string, unknown>();
+
+vi.mock("idb", () => ({
+  openDB: vi.fn(() =>
+    Promise.resolve({
+      put: (_storeName: string, value: unknown, key: string) => {
+        store.set(key, value);
+        return Promise.resolve();
+      },
+      get: (_storeName: string, key: string) => Promise.resolve(store.get(key)),
+      delete: (_storeName: string, key: string) => {
+        store.delete(key);
+        return Promise.resolve();
+      },
+      clear: () => {
+        store.clear();
+        return Promise.resolve();
+      },
+      objectStoreNames: { contains: () => true },
+      createObjectStore: () => undefined,
+    }),
+  ),
+}));
+
+// eslint-disable-next-line import/first
+import {
+  putResult,
+  getResult,
+  deleteResult,
+  clearAllResults,
+} from "@src/utils/runsCache";
+
+const sample = { foo: "bar" } as unknown as RTMAResults;
+
+describe("runsCache", () => {
+  beforeEach(() => {
+    store.clear();
+    // Satisfy the `typeof indexedDB === "undefined"` guard; the actual idb
+    // openDB is mocked above.
+    vi.stubGlobal("indexedDB", {});
+  });
+
+  it("stores and retrieves a result by jobId", async () => {
+    await putResult("job-1", sample);
+    expect(await getResult("job-1")).toEqual(sample);
+  });
+
+  it("returns undefined for a missing jobId", async () => {
+    expect(await getResult("missing")).toBeUndefined();
+  });
+
+  it("deletes a cached result", async () => {
+    await putResult("job-1", sample);
+    await deleteResult("job-1");
+    expect(await getResult("job-1")).toBeUndefined();
+  });
+
+  it("clears all cached results", async () => {
+    await putResult("a", sample);
+    await putResult("b", sample);
+    await clearAllResults();
+    expect(await getResult("a")).toBeUndefined();
+    expect(await getResult("b")).toBeUndefined();
+  });
+});

--- a/apps/react-ui/client/src/utils/notifications.ts
+++ b/apps/react-ui/client/src/utils/notifications.ts
@@ -1,0 +1,55 @@
+import type { RunStatus } from "@src/types/api";
+
+const isSupported = (): boolean =>
+  typeof window !== "undefined" && "Notification" in window;
+
+/**
+ * Lazily request browser-notification permission. No-op if unsupported or the
+ * user has already decided (granted/denied). Safe to call on every submit.
+ */
+export const requestNotificationPermission = (): void => {
+  if (!isSupported() || Notification.permission !== "default") {
+    return;
+  }
+  void Notification.requestPermission().catch(() => {
+    // ignore — we fall back to in-app alerts
+  });
+};
+
+type NotifyArgs = {
+  jobId: string;
+  modelType: string;
+  status: RunStatus;
+};
+
+/**
+ * Fire a browser notification for a finished run. Returns true if a native
+ * notification was shown, false otherwise (caller can fall back to an in-app
+ * alert).
+ */
+export const notifyRunComplete = ({
+  jobId,
+  modelType,
+  status,
+}: NotifyArgs): boolean => {
+  if (!isSupported() || Notification.permission !== "granted") {
+    return false;
+  }
+  const succeeded = status === "succeeded";
+  const title = succeeded
+    ? `${modelType} run finished`
+    : `${modelType} run ${status === "timedout" ? "timed out" : "failed"}`;
+  const body = succeeded
+    ? "Your analysis is ready — open it from My Runs."
+    : "Open My Runs for details.";
+  try {
+    const notification = new Notification(title, { body, tag: jobId });
+    notification.onclick = () => {
+      window.focus();
+      window.location.href = `/results?jobId=${encodeURIComponent(jobId)}`;
+    };
+    return true;
+  } catch {
+    return false;
+  }
+};

--- a/apps/react-ui/client/src/utils/runsCache.ts
+++ b/apps/react-ui/client/src/utils/runsCache.ts
@@ -1,0 +1,87 @@
+import { openDB, type IDBPDatabase } from "idb";
+import type { ModelResults, RTMAResults } from "@src/types/api";
+
+// Durable, client-side cache of run results (IndexedDB). Lets a run stay
+// viewable after the 48h server TTL and across browser restarts. Browser-only,
+// so there is no server/infra cost.
+
+const DB_NAME = "maive-runs-cache";
+const STORE = "results";
+const DB_VERSION = 1;
+
+type CachedResult = ModelResults | RTMAResults;
+
+let dbPromise: Promise<IDBPDatabase> | undefined;
+
+const getDb = (): Promise<IDBPDatabase> | undefined => {
+  if (typeof indexedDB === "undefined") {
+    return undefined;
+  }
+  if (!dbPromise) {
+    dbPromise = openDB(DB_NAME, DB_VERSION, {
+      upgrade(db) {
+        if (!db.objectStoreNames.contains(STORE)) {
+          db.createObjectStore(STORE);
+        }
+      },
+    });
+  }
+  return dbPromise;
+};
+
+export const putResult = async (
+  jobId: string,
+  result: CachedResult,
+): Promise<void> => {
+  const dbp = getDb();
+  if (!dbp) {
+    return;
+  }
+  try {
+    const db = await dbp;
+    await db.put(STORE, result, jobId);
+  } catch {
+    // cache write failures are non-fatal
+  }
+};
+
+export const getResult = async (
+  jobId: string,
+): Promise<CachedResult | undefined> => {
+  const dbp = getDb();
+  if (!dbp) {
+    return undefined;
+  }
+  try {
+    const db = await dbp;
+    return (await db.get(STORE, jobId)) as CachedResult | undefined;
+  } catch {
+    return undefined;
+  }
+};
+
+export const deleteResult = async (jobId: string): Promise<void> => {
+  const dbp = getDb();
+  if (!dbp) {
+    return;
+  }
+  try {
+    const db = await dbp;
+    await db.delete(STORE, jobId);
+  } catch {
+    // non-fatal
+  }
+};
+
+export const clearAllResults = async (): Promise<void> => {
+  const dbp = getDb();
+  if (!dbp) {
+    return;
+  }
+  try {
+    const db = await dbp;
+    await db.clear(STORE);
+  } catch {
+    // non-fatal
+  }
+};

--- a/terraform/stacks/prod-runtime/ui_lambda.tf
+++ b/terraform/stacks/prod-runtime/ui_lambda.tf
@@ -57,7 +57,7 @@ resource "aws_iam_policy" "ui_lambda_runs" {
     Statement = [
       {
         Effect   = "Allow"
-        Action   = ["dynamodb:GetItem", "dynamodb:PutItem"]
+        Action   = ["dynamodb:GetItem", "dynamodb:BatchGetItem", "dynamodb:PutItem"]
         Resource = aws_dynamodb_table.runs.arn
       },
       {


### PR DESCRIPTION
## Summary

Phase 2 of async runs — polishing the shipped non-blocking-runs feature into a finished experience (design: `docs/ASYNC_RUNS_DESIGN.md` §9). All behavior is gated by `CONFIG.ASYNC_RUNS_ENABLED` (already on → ships live on merge).

- **My Runs UI polish** — buttons unified via the shared `ActionButton` (`size="sm"`), status rendered as badges, denser rows. Matches the rest of the app (was using full-CTA padding and looked oversized).
- **Live statuses + notifications** — new app-level `RunsWatcher` (`_app.tsx`) polls non-terminal runs via a new batch endpoint `GET /api/runs?ids=…` (`BatchGetItem`, status-only projection) and fires a **browser notification** on completion, falling back to an in-app alert. Permission is requested lazily on first submit. The My Runs list now reflects live status app-wide with no page-local polling.
- **Durable history** — result payloads are cached client-side in **IndexedDB** (`idb`) so a run stays viewable after the 48h server TTL and across restarts. Browser-only → **$0 infra**.
- **Unified loading screen** — a single status-driven `RunLoading` screen replaces the old two-layer loader: `submitting` → (navigate) → `running` on the results page, with shortcuts to queue another run / view My Runs while the current one finishes in the background. `blocking` phase keeps the "please stay" copy for the sync / mock / >256 KB fallback.
- **IAM** — `dynamodb:BatchGetItem` added to the `ui_lambda_runs` policy (applied by the runtime release; the `gha_terraform` role already permits it from the Phase 1 foundation apply).

Out of scope (deferred): compare-runs view → tracked as a separate issue.

## Test plan

- [x] `npm run ui:lint` clean
- [x] `npm run ui:test` — 47 passing (added: `modelService.getRuns`, `runsCache` put/get/delete/clear, `RunsWatcher` polling, notifications permission-gating)
- [x] `tsc --noEmit` clean for changed files
- [x] `bun install --frozen-lockfile` passes after adding `idb`
- [ ] Post-deploy: `curl "https://maive.eu/api/runs?ids=<id1>,<id2>"` returns a status array
- [ ] Live: submit a run → single continuous loading screen (submitting → running, free to leave) with working nav buttons; navigate away → My Runs flips to "Done" on its own + browser notification fires; reopen run; simulate expired/404 → IndexedDB cache still renders it
- [ ] Rollback: with `ASYNC_RUNS_ENABLED=false` everything hides and the watcher/endpoint are inert

🤖 Generated with [Claude Code](https://claude.com/claude-code)