### PR TITLE
fix: grant gha-terraform iam:CreatePolicyVersion (foundation)

### DIFF
--- a/terraform/stacks/prod-foundation/iam.tf
+++ b/terraform/stacks/prod-foundation/iam.tf
@@ -100,6 +100,11 @@ resource "aws_iam_role_policy" "gha_terraform_policy" {
           "iam:DeletePolicy",
           "iam:GetPolicy",
           "iam:GetPolicyVersion",
+          # Needed to update an existing customer-managed policy in place
+          # (terraform creates a new default version and prunes old ones).
+          "iam:CreatePolicyVersion",
+          "iam:DeletePolicyVersion",
+          "iam:SetDefaultPolicyVersion",
           "iam:List*",
           "iam:CreateServiceLinkedRole"
         ],


### PR DESCRIPTION
## Summary

The Phase 2 runtime deploy (PR #456) failed at the terraform apply with:

> AccessDenied: gha-terraform is not authorized to perform iam:CreatePolicyVersion on policy maive-ui-lambda-runs

The CI role (`gha-terraform`) could **create**/**delete** managed policies but not **modify** an existing one. Terraform updates a customer-managed policy in place by creating a new default version (and pruning old versions), which needs `iam:CreatePolicyVersion`, `iam:DeletePolicyVersion`, and `iam:SetDefaultPolicyVersion`. Adding `dynamodb:BatchGetItem` to `ui_lambda_runs` tripped this gap.

**Foundation stack — applied manually with elevated creds, not by CI.** After this is applied, re-running the prod-runtime deploy completes the BatchGetItem grant.

## Test plan

- [ ] `terragrunt apply` on `terraform/stacks/prod-foundation` succeeds (manual)
- [ ] Re-run the failed prod-runtime deploy → `aws_iam_policy.ui_lambda_runs` updates in place
- [ ] `curl https://maive.eu/api/runs?ids=<id1>,<id2>` returns a status array (no longer 500)

🤖 Generated with [Claude Code](https://claude.com/claude-code)