### PR TITLE
fix: persist uploaded data so a reload can't submit an empty run

### DIFF
--- a/apps/react-ui/client/src/pages/model/index.tsx
+++ b/apps/react-ui/client/src/pages/model/index.tsx
@@ -28,6 +28,7 @@ import { useEnterKeyAction } from "@src/hooks/useEnterKeyAction";
 import { detectAndDispatchAlerts } from "@src/utils/parameterChangeTracking";
 import { cleanCliErrorMessage } from "@src/utils/errorMessageUtils";
 import { requestNotificationPermission } from "@src/utils/notifications";
+import { getUploadedData as getCachedUploadedData } from "@src/utils/dataCacheDb";
 
 const isModelWeight = (weight: string): weight is ModelParameters["weight"] =>
   Object.values(CONST.WEIGHT_OPTIONS).some((option) => option.VALUE === weight);
@@ -96,7 +97,7 @@ export default function ModelPage() {
     }
   });
 
-  const loadDataFromStore = () => {
+  const loadDataFromStore = async () => {
     try {
       // Try to get data from cache first
       let data = dataCache.get(dataId ?? "");
@@ -111,8 +112,23 @@ export default function ModelPage() {
         }
       }
 
+      // Durable fallback: the in-memory cache is lost on a page reload (the
+      // persisted store keeps only the dataId), so recover from IndexedDB
+      // before giving up — otherwise the run would submit with empty data.
+      if (!data && dataId) {
+        const cached = await getCachedUploadedData(dataId);
+        if (cached) {
+          data = cached;
+          dataCache.set(dataId, data);
+        }
+      }
+
       if (!data) {
         throw new Error("Data not found");
+      }
+
+      if (!isMountedRef.current) {
+        return;
       }
 
       setUploadedData(data);
@@ -133,6 +149,13 @@ export default function ModelPage() {
       }
     } catch (error) {
       console.error("Error loading data:", error);
+      if (isMountedRef.current) {
+        showAlert(
+          "We couldn't find your data — it isn't kept after a page reload. Please upload it again or re-run the demo.",
+          "error",
+        );
+        router.push("/upload");
+      }
     }
   };
 
@@ -141,7 +164,7 @@ export default function ModelPage() {
     if (dataId) {
       // Reset search params applied flag when navigating to different data
       searchParamsAppliedRef.current = false;
-      loadDataFromStore();
+      void loadDataFromStore();
     } else {
       showAlert("No data selected", "error");
       router.push("/upload");
@@ -630,6 +653,16 @@ export default function ModelPage() {
 
   const handleRunModel = useCallback(() => {
     void (async () => {
+      // Never submit an empty-data run — without this the backend fails with a
+      // confusing "Data must have exactly 3 or 4 columns. Found 0 columns."
+      if (!uploadedData || uploadedData.data.length === 0) {
+        showAlert(
+          "Your data isn't loaded — please upload it again or re-run the demo.",
+          "error",
+        );
+        return;
+      }
+
       const isAsyncRun = CONFIG.ASYNC_RUNS_ENABLED && !shouldUseMockResults();
       setLoadingPhase(isAsyncRun ? "submitting" : "blocking");
       setLoading(true);

--- a/apps/react-ui/client/src/pages/validation/index.tsx
+++ b/apps/react-ui/client/src/pages/validation/index.tsx
@@ -18,6 +18,7 @@ import CONFIG from "@src/CONFIG";
 import { useGlobalAlert } from "@src/components/GlobalAlertProvider";
 import { dataCache, useDataStore } from "@store/dataStore";
 import type { ColumnMapping, UploadedData } from "@store/dataStore";
+import { getUploadedData as getCachedUploadedData } from "@src/utils/dataCacheDb";
 import type {
   AlertType,
   DataArray,
@@ -578,6 +579,30 @@ export default function ValidationPage() {
   const [filterGroup, setFilterGroup] =
     useState<SubsampleFilterGroupNode>(createEmptyGroup());
   const continueButtonRef = useRef<HTMLButtonElement>(null);
+  // Gate: hydrate the in-memory cache from IndexedDB before the loader below
+  // reads it, so the data survives a page reload (the in-memory cache does not,
+  // and the persisted store keeps only the dataId).
+  const [cacheHydrated, setCacheHydrated] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    setCacheHydrated(false);
+    const hydrate = async () => {
+      if (dataId && !dataCache.get(dataId)) {
+        const cached = await getCachedUploadedData(dataId);
+        if (!cancelled && cached) {
+          dataCache.set(dataId, cached);
+        }
+      }
+      if (!cancelled) {
+        setCacheHydrated(true);
+      }
+    };
+    void hydrate();
+    return () => {
+      cancelled = true;
+    };
+  }, [dataId]);
 
   useEnterKeyAction(() => {
     const button = continueButtonRef.current;
@@ -597,6 +622,12 @@ export default function ValidationPage() {
       setIsFilterEnabled(false);
       setFilterGroup(createEmptyGroup());
       setLoading(false);
+      return;
+    }
+
+    // Wait until the IndexedDB → in-memory cache hydration has run, so a
+    // reloaded page recovers its data instead of flashing a "data not found".
+    if (!cacheHydrated) {
       return;
     }
 
@@ -695,7 +726,7 @@ export default function ValidationPage() {
     } finally {
       setLoading(false);
     }
-  }, [dataId, showAlert]);
+  }, [dataId, showAlert, cacheHydrated]);
 
   const mappingComplete = useMemo(() => {
     return REQUIRED_FIELDS.every((field) => Boolean(mapping[field]));

--- a/apps/react-ui/client/src/services/dataProcessingService.ts
+++ b/apps/react-ui/client/src/services/dataProcessingService.ts
@@ -8,6 +8,7 @@ import type { SubsampleFilterState } from "@src/types";
 import { generateDataId, processUploadedFile } from "@utils/dataUtils";
 import { mockCsvFiles } from "@utils/mockCsvFiles";
 import { generateMockCSVFile } from "@utils/mockData";
+import { putUploadedData } from "@utils/dataCacheDb";
 
 /**
  * Service for processing data.
@@ -113,6 +114,9 @@ export class DataProcessingService {
     // Store in Zustand store and cache
     setUploadedData(uploadedData);
     dataCache.set(uploadedData.id, uploadedData);
+    // Durable copy so the data survives a page reload (the in-memory cache
+    // does not, and the persisted store keeps only the dataId).
+    void putUploadedData(uploadedData.id, uploadedData);
   }
 
   /**
@@ -123,6 +127,7 @@ export class DataProcessingService {
     const { setUploadedData } = useDataStore.getState();
     setUploadedData(uploadedData);
     dataCache.set(uploadedData.id, uploadedData);
+    void putUploadedData(uploadedData.id, uploadedData);
   }
 
   /**

--- a/apps/react-ui/client/src/tests/dataCacheDb.test.ts
+++ b/apps/react-ui/client/src/tests/dataCacheDb.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import type { UploadedData } from "@store/dataStore";
+
+// In-memory store backing a mocked idb database, so we can exercise the
+// dataCacheDb wrapper without a real IndexedDB (jsdom has none).
+const store = new Map<string, unknown>();
+
+vi.mock("idb", () => ({
+  openDB: vi.fn(() =>
+    Promise.resolve({
+      put: (_storeName: string, value: unknown, key: string) => {
+        store.set(key, value);
+        return Promise.resolve();
+      },
+      get: (_storeName: string, key: string) => Promise.resolve(store.get(key)),
+      delete: (_storeName: string, key: string) => {
+        store.delete(key);
+        return Promise.resolve();
+      },
+      objectStoreNames: { contains: () => true },
+      createObjectStore: () => undefined,
+    }),
+  ),
+}));
+
+// eslint-disable-next-line import/first
+import {
+  putUploadedData,
+  getUploadedData,
+  deleteUploadedData,
+} from "@src/utils/dataCacheDb";
+
+const sample = {
+  id: "data_1",
+  filename: "study.csv",
+  data: [{ effect: 0.2, se: 0.05, n: 100 }],
+  rawData: [{ effect: 0.2, se: 0.05, n: 100 }],
+  columnNames: ["effect", "se", "n"],
+  hasHeaders: true,
+  base64Data: "",
+  uploadedAt: new Date(),
+  subsampleFilter: null,
+} as unknown as UploadedData;
+
+describe("dataCacheDb", () => {
+  beforeEach(() => {
+    store.clear();
+    // Satisfy the `typeof indexedDB === "undefined"` guard; idb is mocked above.
+    vi.stubGlobal("indexedDB", {});
+  });
+
+  it("stores and retrieves an uploaded dataset by id", async () => {
+    await putUploadedData("data_1", sample);
+    expect(await getUploadedData("data_1")).toEqual(sample);
+  });
+
+  it("returns undefined for a missing id", async () => {
+    expect(await getUploadedData("missing")).toBeUndefined();
+  });
+
+  it("deletes a cached dataset", async () => {
+    await putUploadedData("data_1", sample);
+    await deleteUploadedData("data_1");
+    expect(await getUploadedData("data_1")).toBeUndefined();
+  });
+});

--- a/apps/react-ui/client/src/utils/dataCacheDb.ts
+++ b/apps/react-ui/client/src/utils/dataCacheDb.ts
@@ -1,0 +1,74 @@
+import { openDB, type IDBPDatabase } from "idb";
+import type { UploadedData } from "@store/dataStore";
+
+// Durable, client-side cache of uploaded/demo datasets (IndexedDB). The
+// in-memory `dataCache` Map is lost on a full page reload, which previously
+// left the model page with no data and let a run be submitted empty (the R
+// backend then reported "Found 0 columns"). Persisting here lets the data be
+// recovered after a reload / browser restart. Browser-only → no infra cost.
+
+const DB_NAME = "maive-data-cache";
+const STORE = "uploads";
+const DB_VERSION = 1;
+
+let dbPromise: Promise<IDBPDatabase> | undefined;
+
+const getDb = (): Promise<IDBPDatabase> | undefined => {
+  if (typeof indexedDB === "undefined") {
+    return undefined;
+  }
+  if (!dbPromise) {
+    dbPromise = openDB(DB_NAME, DB_VERSION, {
+      upgrade(db) {
+        if (!db.objectStoreNames.contains(STORE)) {
+          db.createObjectStore(STORE);
+        }
+      },
+    });
+  }
+  return dbPromise;
+};
+
+export const putUploadedData = async (
+  id: string,
+  data: UploadedData,
+): Promise<void> => {
+  const dbp = getDb();
+  if (!dbp) {
+    return;
+  }
+  try {
+    const db = await dbp;
+    await db.put(STORE, data, id);
+  } catch {
+    // cache write failures are non-fatal
+  }
+};
+
+export const getUploadedData = async (
+  id: string,
+): Promise<UploadedData | undefined> => {
+  const dbp = getDb();
+  if (!dbp) {
+    return undefined;
+  }
+  try {
+    const db = await dbp;
+    return (await db.get(STORE, id)) as UploadedData | undefined;
+  } catch {
+    return undefined;
+  }
+};
+
+export const deleteUploadedData = async (id: string): Promise<void> => {
+  const dbp = getDb();
+  if (!dbp) {
+    return;
+  }
+  try {
+    const db = await dbp;
+    await db.delete(STORE, id);
+  } catch {
+    // non-fatal
+  }
+};


### PR DESCRIPTION
## Summary

Fixes the **"Run failed — Data must have exactly 3 or 4 columns. Found 0 columns."** error seen when running the demo.

**Root cause:** uploaded/demo data was held only in an in-memory `Map` (`dataCache`); the persisted Zustand store keeps just the `dataId` (to avoid localStorage bloat). After a full page reload, the model page couldn't find the data, the lookup error was silently swallowed, and clicking **Run** submitted `uploadedData?.data ?? []` = `[]`. An empty array passes the API's `!data` check (empty arrays are truthy), so a job was created and then failed at the R backend with `ncol(df) == 0`. (Deductively: a non-empty array of objects always yields ≥1 column, so "0 columns" can *only* be empty data.)

**Fix:**
- Persist `UploadedData` to **IndexedDB** on store/update — browser-only, $0 infra (reuses the Phase 2 idb pattern).
- Recover from IndexedDB in the **model** and **validation** page loaders after a reload, repopulating the in-memory cache.
- Guard `handleRunModel` to never submit an empty-data run, showing a clear "re-upload / re-run the demo" message instead (defense-in-depth for both sync and async paths).

## Test plan

- [x] `npm run ui:lint` clean, `tsc` clean for changed files
- [x] `npm run ui:test` — 50 passing (added `dataCacheDb` put/get/delete)
- [ ] Live: load the demo, **reload** `/model?dataId=…`, run → completes (data recovered from IndexedDB) instead of "0 columns"
- [ ] Live: clear IndexedDB, reload model page → clear "data isn't loaded" message + redirect to upload (no empty run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)