### PR TITLE
feat: prioritize 'Revise your model setup' on the running loading screen

### DIFF
--- a/apps/react-ui/client/src/components/RunLoading.tsx
+++ b/apps/react-ui/client/src/components/RunLoading.tsx
@@ -54,24 +54,25 @@ export default function RunLoading({
       <LoadingCard title={title} subtitle={subtitle}>
         {phase === "running" && (
           <div className="mt-6 flex flex-wrap items-center justify-center gap-3">
-            <ActionButton
-              variant="primary"
-              size="sm"
-              onClick={() => router.push("/upload")}
-            >
-              Run another analysis
-            </ActionButton>
             {dataId ? (
               <ActionButton
-                variant="secondary"
+                variant="primary"
                 size="sm"
                 onClick={() =>
                   router.push(`/model?dataId=${encodeURIComponent(dataId)}`)
                 }
               >
-                Model setup
+                Revise your model setup
               </ActionButton>
             ) : null}
+            <ActionButton
+              // Prominent only when there's no model setup to return to.
+              variant={dataId ? "secondary" : "primary"}
+              size="sm"
+              onClick={() => router.push("/upload")}
+            >
+              Analyze a new dataset
+            </ActionButton>
             <ActionButton
               variant="secondary"
               size="sm"


### PR DESCRIPTION
## Summary

On the async **"Your analysis is running"** screen, the most likely next action is to return to the model setup, tweak parameters, and re-run on the **same data** — not to start over with new data. This reorders and re-weights the action buttons to match that intent.

- **`Revise your model setup`** — now first and **primary (blue)** → `/model?dataId=…`
- **`Analyze a new dataset`** — now **secondary** → `/upload` (becomes primary only when there's no `dataId` to return to, so there's always one prominent action)
- **`View My Runs`** — unchanged

Pure UI copy/prominence change; no behavioral/logic changes beyond button ordering and variant.

## Test plan

- [x] `npm run ui:lint` clean
- [ ] Live: submit an async run → on the running screen, "Revise your model setup" is the prominent first button and returns to the model page with the same dataset; "Analyze a new dataset" is secondary and goes to upload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)