### PR TITLE
feat: mark stale runs as expired in My Runs

### DIFF
--- a/apps/react-ui/client/src/CONST.ts
+++ b/apps/react-ui/client/src/CONST.ts
@@ -44,6 +44,15 @@ const CONST = {
     },
   },
 
+  // Async runs. TTL_SECONDS is the authoritative server-side DynamoDB record
+  // lifetime (set when a job is queued); the client uses TTL_MS to decide when a
+  // run that is missing from the backend is genuinely expired vs. transiently
+  // absent. Single source of truth shared by the API route and the client.
+  RUNS: {
+    TTL_SECONDS: 48 * 60 * 60, // 48h pickup buffer
+    TTL_MS: 48 * 60 * 60 * 1000,
+  },
+
   MODEL_TYPES: {
     MAIVE: "MAIVE",
     WAIVE: "WAIVE",

--- a/apps/react-ui/client/src/components/RunsWatcher.tsx
+++ b/apps/react-ui/client/src/components/RunsWatcher.tsx
@@ -2,13 +2,19 @@
 
 import { useEffect } from "react";
 import CONFIG from "@src/CONFIG";
+import CONST from "@src/CONST";
 import { useRunsStore } from "@src/store/runsStore";
 import { modelService } from "@src/api/services/modelService";
 import { useGlobalAlert } from "@src/components/GlobalAlertProvider";
 import { notifyRunComplete } from "@src/utils/notifications";
 import type { RunStatus } from "@src/types/api";
 
-const TERMINAL_STATUSES: RunStatus[] = ["succeeded", "failed", "timedout"];
+const TERMINAL_STATUSES: RunStatus[] = [
+  "succeeded",
+  "failed",
+  "timedout",
+  "expired",
+];
 const POLL_INTERVAL_MS = 5000;
 
 const isTerminal = (status: RunStatus) => TERMINAL_STATUSES.includes(status);
@@ -73,6 +79,23 @@ export default function RunsWatcher() {
             }
           }
           updateRunStatus(run.jobId, run.status);
+        });
+
+        // Flip runs that are gone from the backend AND past the 48h TTL to a
+        // terminal "expired" status. Done in a separate pass (not driven by the
+        // response) so it never fires a "run finished" notification. The age
+        // guard means a run only transiently absent from a throttled batch
+        // response is not falsely expired — a younger missing run keeps polling
+        // until its record reappears or it genuinely ages out.
+        const returnedIds = new Set(runs.map((run) => run.jobId));
+        const now = Date.now();
+        pending.forEach((run) => {
+          if (
+            !returnedIds.has(run.jobId) &&
+            now - run.submittedAt > CONST.RUNS.TTL_MS
+          ) {
+            updateRunStatus(run.jobId, "expired");
+          }
         });
       } catch {
         // transient (network/throttle) — keep polling

--- a/apps/react-ui/client/src/hooks/useRunStatus.ts
+++ b/apps/react-ui/client/src/hooks/useRunStatus.ts
@@ -3,6 +3,7 @@ import type { ModelResults, RTMAResults, RunStatus } from "@src/types/api";
 import { modelService } from "@api/services/modelService";
 import { useRunsStore } from "@src/store/runsStore";
 import { getResult, putResult } from "@src/utils/runsCache";
+import CONST from "@src/CONST";
 
 type UseRunStatusResult = {
   status: RunStatus | null;
@@ -13,7 +14,12 @@ type UseRunStatusResult = {
   isPolling: boolean;
 };
 
-const TERMINAL_STATUSES: RunStatus[] = ["succeeded", "failed", "timedout"];
+const TERMINAL_STATUSES: RunStatus[] = [
+  "succeeded",
+  "failed",
+  "timedout",
+  "expired",
+];
 const INITIAL_INTERVAL_MS = 2000;
 const BACKOFF_INTERVAL_MS = 5000;
 const BACKOFF_AFTER_MS = 30000;
@@ -117,6 +123,19 @@ export function useRunStatus(jobId: string | null): UseRunStatusResult {
       if (cached) {
         setResult(cached);
         setStatus("succeeded");
+        setIsPolling(false);
+        return;
+      }
+      // No durable result and the run is past the 48h server TTL — its record is
+      // gone, so polling would only spin until MAX_POLL_MS. Mark it expired and
+      // stop. (The cache check above still wins, so an immutable cached result
+      // always renders regardless of age.)
+      const entry = useRunsStore
+        .getState()
+        .runsList.find((run) => run.jobId === jobId);
+      if (entry && Date.now() - entry.submittedAt > CONST.RUNS.TTL_MS) {
+        setStatus("expired");
+        updateRunStatus(jobId, "expired");
         setIsPolling(false);
         return;
       }

--- a/apps/react-ui/client/src/pages/api/runs.ts
+++ b/apps/react-ui/client/src/pages/api/runs.ts
@@ -12,6 +12,7 @@ import type {
   RunStatus,
 } from "@src/types/api";
 import { generateJobId } from "@src/utils/idUtils";
+import CONST from "@src/CONST";
 
 // Allow larger request bodies than Next.js's 1mb default so we can accept a
 // dataset and decide whether to queue it or signal the synchronous fallback.
@@ -29,7 +30,7 @@ const region =
 const tableName = process.env.RUNS_TABLE_NAME;
 const queueUrl = process.env.RUNS_QUEUE_URL;
 
-const TTL_SECONDS = 48 * 60 * 60; // 48h pickup buffer
+const TTL_SECONDS = CONST.RUNS.TTL_SECONDS; // 48h pickup buffer
 // Keep the SQS message under the 256KB hard limit; larger datasets fall back
 // to the synchronous path (which posts directly to the R Lambda).
 const MAX_QUEUE_BODY_BYTES = 200 * 1024;

--- a/apps/react-ui/client/src/pages/results/index.tsx
+++ b/apps/react-ui/client/src/pages/results/index.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useSearchParams, useRouter } from "next/navigation";
-import { useState, useMemo, useEffect } from "react";
+import { useState, useMemo, useEffect, type ReactNode } from "react";
 import Head from "next/head";
 import Image from "next/image";
 import Tooltip from "@components/Tooltip";
@@ -262,34 +262,54 @@ export default function ResultsPage() {
     }
   }, [exportErrorMessage]);
 
-  // Async run still in flight (or failed) — show a loading / error state while
-  // polling, instead of the "no results" view.
+  // Async run still in flight (or terminal-but-unavailable) — show a loading /
+  // error state while polling, instead of the "no results" view.
   if (jobId && !results) {
+    const runExpired = runStatus.status === "expired";
     const runFailed =
       runStatus.status === "failed" || runStatus.status === "timedout";
+
+    let body: ReactNode;
+    if (runExpired) {
+      body = (
+        <div className="text-center">
+          <SectionHeading level="h1" text="Run expired" className="mb-4" />
+          <p className="mb-6 text-gray-600 dark:text-gray-300">
+            Results are only kept for 48 hours after a run is submitted, so this
+            run is no longer available. Please run the analysis again.
+          </p>
+          <GoBackButton
+            href={`/model?dataId=${dataId ?? ""}`}
+            text="Back to model setup"
+            variant="simple"
+          />
+        </div>
+      );
+    } else if (runFailed) {
+      body = (
+        <div className="text-center">
+          <SectionHeading level="h1" text="Run failed" className="mb-4" />
+          <p className="mb-6 text-gray-600 dark:text-gray-300">
+            {runStatus.errorMessage ??
+              "The analysis did not complete. Please try again."}
+          </p>
+          <GoBackButton
+            href={`/model?dataId=${dataId ?? ""}`}
+            text="Back to model setup"
+            variant="simple"
+          />
+        </div>
+      );
+    } else {
+      body = <RunLoading phase="running" dataId={dataId} />;
+    }
+
     return (
       <>
         <Head>
           <title>{`${CONST.APP_DISPLAY_NAME} - Results`}</title>
         </Head>
-        <main className="content-page-container">
-          {runFailed ? (
-            <div className="text-center">
-              <SectionHeading level="h1" text="Run failed" className="mb-4" />
-              <p className="mb-6 text-gray-600 dark:text-gray-300">
-                {runStatus.errorMessage ??
-                  "The analysis did not complete. Please try again."}
-              </p>
-              <GoBackButton
-                href={`/model?dataId=${dataId ?? ""}`}
-                text="Back to model setup"
-                variant="simple"
-              />
-            </div>
-          ) : (
-            <RunLoading phase="running" dataId={dataId} />
-          )}
-        </main>
+        <main className="content-page-container">{body}</main>
       </>
     );
   }

--- a/apps/react-ui/client/src/pages/runs/index.tsx
+++ b/apps/react-ui/client/src/pages/runs/index.tsx
@@ -22,6 +22,8 @@ const statusLabel = (status: RunStatus): string => {
       return "Failed";
     case "timedout":
       return "Timed out";
+    case "expired":
+      return "Expired";
     default:
       return status;
   }
@@ -35,6 +37,8 @@ const statusClasses = (status: RunStatus): string => {
     case "failed":
     case "timedout":
       return "bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400";
+    case "expired":
+      return "bg-gray-100 text-gray-600 dark:bg-gray-800/40 dark:text-gray-400";
     default:
       return "bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400";
   }

--- a/apps/react-ui/client/src/tests/RunsWatcher.test.tsx
+++ b/apps/react-ui/client/src/tests/RunsWatcher.test.tsx
@@ -4,6 +4,8 @@ import RunsWatcher from "@src/components/RunsWatcher";
 import { GlobalAlertProvider } from "@src/components/GlobalAlertProvider";
 import { useRunsStore } from "@src/store/runsStore";
 import { modelService } from "@src/api/services/modelService";
+import { notifyRunComplete } from "@src/utils/notifications";
+import CONST from "@src/CONST";
 
 vi.mock("@src/utils/notifications", () => ({
   notifyRunComplete: vi.fn(() => true),
@@ -32,6 +34,7 @@ describe("RunsWatcher", () => {
   beforeEach(() => {
     useRunsStore.getState().clearRuns();
     vi.restoreAllMocks();
+    vi.clearAllMocks();
   });
 
   it("polls pending runs and reflects their terminal status in the store", async () => {
@@ -59,5 +62,41 @@ describe("RunsWatcher", () => {
       setTimeout(resolve, 50);
     });
     expect(getRuns).not.toHaveBeenCalled();
+  });
+
+  it("flips a run gone from the backend and past the TTL to expired", async () => {
+    // Submitted beyond the 48h TTL and absent from the batch response (its
+    // record has expired) — the watcher marks it expired, without notifying.
+    useRunsStore.getState().addRun({
+      jobId: "old-1",
+      modelType: "RTMA",
+      dataId: "d1",
+      parameters: "{}",
+      submittedAt: Date.now() - (CONST.RUNS.TTL_MS + 60_000),
+      status: "queued",
+    });
+    const getRuns = vi.spyOn(modelService, "getRuns").mockResolvedValue([]);
+
+    renderWatcher();
+
+    await waitFor(() => expect(getRuns).toHaveBeenCalledWith(["old-1"]));
+    await waitFor(() =>
+      expect(useRunsStore.getState().runsList[0].status).toBe("expired"),
+    );
+    expect(notifyRunComplete).not.toHaveBeenCalled();
+  });
+
+  it("keeps a recent run pending when it is briefly missing from the response", async () => {
+    addRun("young-1", "queued"); // submittedAt = now, within the TTL window
+    const getRuns = vi.spyOn(modelService, "getRuns").mockResolvedValue([]);
+
+    renderWatcher();
+
+    await waitFor(() => expect(getRuns).toHaveBeenCalledWith(["young-1"]));
+    // A transient miss inside the TTL window must not be expired.
+    await new Promise((resolve) => {
+      setTimeout(resolve, 50);
+    });
+    expect(useRunsStore.getState().runsList[0].status).toBe("queued");
   });
 });

--- a/apps/react-ui/client/src/tests/notifications.test.ts
+++ b/apps/react-ui/client/src/tests/notifications.test.ts
@@ -86,6 +86,17 @@ describe("notifications", () => {
       notifyRunComplete({ jobId: "j3", modelType: "RTMA", status: "timedout" });
       expect(constructed[0].title).toBe("RTMA run timed out");
     });
+
+    it("does not notify for an expired run", () => {
+      installNotification("granted");
+      const shown = notifyRunComplete({
+        jobId: "j4",
+        modelType: "RTMA",
+        status: "expired",
+      });
+      expect(shown).toBe(false);
+      expect(constructed).toHaveLength(0);
+    });
   });
 
   describe("requestNotificationPermission", () => {

--- a/apps/react-ui/client/src/types/api.ts
+++ b/apps/react-ui/client/src/types/api.ts
@@ -116,7 +116,17 @@ type PingResponse = {
 };
 
 // Async runs (queue) types -----------------------------------------------
-type RunStatus = "queued" | "running" | "succeeded" | "failed" | "timedout";
+// "expired" is a client-synthetic terminal status: the backend never writes it.
+// It is assigned locally when a non-terminal run is past the 48h server TTL and
+// its record is gone (see RunsWatcher / useRunStatus), so a stale run does not
+// appear stuck on "running" forever.
+type RunStatus =
+  | "queued"
+  | "running"
+  | "succeeded"
+  | "failed"
+  | "timedout"
+  | "expired";
 
 // Response from POST /api/runs. `tooLarge` signals the client to fall back to
 // the synchronous path (dataset too big to queue via SQS).

--- a/apps/react-ui/client/src/utils/notifications.ts
+++ b/apps/react-ui/client/src/utils/notifications.ts
@@ -35,6 +35,11 @@ export const notifyRunComplete = ({
   if (!isSupported() || Notification.permission !== "granted") {
     return false;
   }
+  // "expired" is assigned locally to stale runs, not a completion event — never
+  // surface it as a notification.
+  if (status === "expired") {
+    return false;
+  }
   const succeeded = status === "succeeded";
   const title = succeeded
     ? `${modelType} run finished`


### PR DESCRIPTION
## Problem

A run could appear stuck on **"Running"** in *My Runs* indefinitely. For example, a run submitted ~2 weeks ago still shows as running.

The cause is a reconciliation gap, not a zombie job:

- *My Runs* is a per-browser history in `localStorage` ([`runsStore.ts`](apps/react-ui/client/src/store/runsStore.ts)). Each entry caches a `status` that is only updated to a terminal value while the app is open and actively polling **at the moment** the run finishes.
- The backend keeps each run record for only **48h** (DynamoDB TTL), and the batch status endpoint (`BatchGetCommand`) returns **only records that still exist**.
- Once a run's record expires, it is simply absent from the response, so [`RunsWatcher`](apps/react-ui/client/src/components/RunsWatcher.tsx) never calls `updateRunStatus` for it — the cached `"running"`/`"queued"` status is frozen forever.

## Fix

Introduce a **client-synthetic terminal status `"expired"`** (the backend never writes it) and reconcile stale runs to it.

- **`RunsWatcher`** — after each batch poll, flip any non-terminal run that is **missing from the response AND older than the 48h TTL** to `"expired"`, in a separate pass so it never fires a "run finished" notification. The age guard avoids falsely expiring a run that is only transiently absent from a throttled response.
- **`useRunStatus`** — when an expired run is opened (past TTL, no cached result), short-circuit to `"expired"` immediately instead of spinning until the 16-minute `MAX_POLL_MS` timeout. The durable IndexedDB cache check still wins first, so an already-computed result always renders regardless of age.
- **UI** — *My Runs* shows a neutral gray **"Expired"** badge; the results page renders a **"Run expired"** message with a path back to model setup.
- **Shared constant** — the 48h TTL is now `CONST.RUNS` (`TTL_SECONDS` / `TTL_MS`), used by both the API route and the client (single source of truth).

## Tests

- `RunsWatcher.test.tsx` — a run past the TTL and absent from the response flips to `"expired"` and does **not** notify; a recent run briefly missing from the response stays `"queued"`.
- `notifications.test.ts` — `notifyRunComplete` shows nothing for an `"expired"` status.
- Full suite: **53 tests pass**, ESLint clean, `tsc` clean (one pre-existing unrelated `import.meta.vitest` error).

🤖 Generated with [Claude Code](https://claude.com/claude-code)