### PR TITLE
feat: surface dataset names and safer controls on the My Runs page

### DIFF
--- a/apps/react-ui/client/src/CONST.ts
+++ b/apps/react-ui/client/src/CONST.ts
@@ -44,6 +44,15 @@ const CONST = {
     },
   },
 
+  // Async runs. TTL_SECONDS is the authoritative server-side DynamoDB record
+  // lifetime (set when a job is queued); the client uses TTL_MS to decide when a
+  // run that is missing from the backend is genuinely expired vs. transiently
+  // absent. Single source of truth shared by the API route and the client.
+  RUNS: {
+    TTL_SECONDS: 48 * 60 * 60, // 48h pickup buffer
+    TTL_MS: 48 * 60 * 60 * 1000,
+  },
+
   MODEL_TYPES: {
     MAIVE: "MAIVE",
     WAIVE: "WAIVE",

--- a/apps/react-ui/client/src/components/Header.tsx
+++ b/apps/react-ui/client/src/components/Header.tsx
@@ -6,6 +6,9 @@ import Link from "next/link";
 import CONST from "@src/CONST";
 import CONFIG from "@src/CONFIG";
 import ThemeToggle from "@components/ThemeToggle";
+import { useRunsStore } from "@src/store/runsStore";
+
+const PENDING_STATUSES = ["queued", "running"];
 
 type HeaderProps = {
   showHomeIcon?: boolean;
@@ -18,6 +21,12 @@ export default function Header({
   showHelpIcon = true,
   className = "",
 }: HeaderProps) {
+  const activeRunCount = useRunsStore(
+    (state) =>
+      state.runsList.filter((run) => PENDING_STATUSES.includes(run.status))
+        .length,
+  );
+
   return (
     <header
       className={`surface-elevated border-b border-primary flex justify-between items-center w-full py-4 px-4 z-50 sticky top-0 ${className}`}
@@ -36,9 +45,17 @@ export default function Header({
         {CONFIG.ASYNC_RUNS_ENABLED && (
           <Link
             href="/runs"
-            className="text-primary hover:text-primary-600 px-2 text-sm font-medium transition-colors"
+            className="text-primary hover:text-primary-600 flex items-center gap-1.5 px-2 text-sm font-medium transition-colors"
           >
             My Runs
+            {activeRunCount > 0 && (
+              <span
+                className="inline-flex min-w-[1.25rem] items-center justify-center rounded-full bg-blue-100 px-1.5 py-0.5 text-xs font-semibold text-blue-700 dark:bg-blue-900/30 dark:text-blue-400"
+                aria-label={`${activeRunCount} run${activeRunCount === 1 ? "" : "s"} in progress`}
+              >
+                {activeRunCount}
+              </span>
+            )}
           </Link>
         )}
         <ThemeToggle className="icon-header" />

--- a/apps/react-ui/client/src/components/Modals/ConfirmDialog.tsx
+++ b/apps/react-ui/client/src/components/Modals/ConfirmDialog.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import type { ReactNode } from "react";
+import ActionButton from "@src/components/Buttons/ActionButton";
+import SectionHeading from "@src/components/SectionHeading";
+import BaseModal from "./BaseModal";
+
+type ConfirmDialogProps = {
+  isOpen: boolean;
+  onClose: () => void;
+  onConfirm: () => void;
+  title: string;
+  message: ReactNode;
+  confirmLabel?: string;
+  cancelLabel?: string;
+  confirmVariant?: "primary" | "secondary" | "success" | "danger" | "purple";
+};
+
+/**
+ * Small reusable confirmation dialog for destructive or irreversible actions.
+ * Built on BaseModal + ActionButton so it inherits app theming, dark mode, and
+ * escape-to-close. The confirm handler runs, then the dialog closes.
+ */
+export default function ConfirmDialog({
+  isOpen,
+  onClose,
+  onConfirm,
+  title,
+  message,
+  confirmLabel = "Confirm",
+  cancelLabel = "Cancel",
+  confirmVariant = "danger",
+}: ConfirmDialogProps) {
+  const handleConfirm = () => {
+    onConfirm();
+    onClose();
+  };
+
+  return (
+    <BaseModal
+      isOpen={isOpen}
+      onClose={onClose}
+      maxWidth="max-w-md"
+      maxHeight="max-h-[90vh]"
+      showCloseButton={false}
+    >
+      <div className="p-6 space-y-4">
+        <SectionHeading level="h2" text={title} />
+        <div className="text-secondary text-sm">{message}</div>
+        <div className="flex justify-end gap-3 pt-2">
+          <ActionButton variant="secondary" size="sm" onClick={onClose}>
+            {cancelLabel}
+          </ActionButton>
+          <ActionButton
+            variant={confirmVariant}
+            size="sm"
+            onClick={handleConfirm}
+          >
+            {confirmLabel}
+          </ActionButton>
+        </div>
+      </div>
+    </BaseModal>
+  );
+}

--- a/apps/react-ui/client/src/components/RunsWatcher.tsx
+++ b/apps/react-ui/client/src/components/RunsWatcher.tsx
@@ -2,13 +2,19 @@
 
 import { useEffect } from "react";
 import CONFIG from "@src/CONFIG";
+import CONST from "@src/CONST";
 import { useRunsStore } from "@src/store/runsStore";
 import { modelService } from "@src/api/services/modelService";
 import { useGlobalAlert } from "@src/components/GlobalAlertProvider";
 import { notifyRunComplete } from "@src/utils/notifications";
 import type { RunStatus } from "@src/types/api";
 
-const TERMINAL_STATUSES: RunStatus[] = ["succeeded", "failed", "timedout"];
+const TERMINAL_STATUSES: RunStatus[] = [
+  "succeeded",
+  "failed",
+  "timedout",
+  "expired",
+];
 const POLL_INTERVAL_MS = 5000;
 
 const isTerminal = (status: RunStatus) => TERMINAL_STATUSES.includes(status);
@@ -73,6 +79,23 @@ export default function RunsWatcher() {
             }
           }
           updateRunStatus(run.jobId, run.status);
+        });
+
+        // Flip runs that are gone from the backend AND past the 48h TTL to a
+        // terminal "expired" status. Done in a separate pass (not driven by the
+        // response) so it never fires a "run finished" notification. The age
+        // guard means a run only transiently absent from a throttled batch
+        // response is not falsely expired — a younger missing run keeps polling
+        // until its record reappears or it genuinely ages out.
+        const returnedIds = new Set(runs.map((run) => run.jobId));
+        const now = Date.now();
+        pending.forEach((run) => {
+          if (
+            !returnedIds.has(run.jobId) &&
+            now - run.submittedAt > CONST.RUNS.TTL_MS
+          ) {
+            updateRunStatus(run.jobId, "expired");
+          }
         });
       } catch {
         // transient (network/throttle) — keep polling

--- a/apps/react-ui/client/src/hooks/useRunStatus.ts
+++ b/apps/react-ui/client/src/hooks/useRunStatus.ts
@@ -3,6 +3,7 @@ import type { ModelResults, RTMAResults, RunStatus } from "@src/types/api";
 import { modelService } from "@api/services/modelService";
 import { useRunsStore } from "@src/store/runsStore";
 import { getResult, putResult } from "@src/utils/runsCache";
+import CONST from "@src/CONST";
 
 type UseRunStatusResult = {
   status: RunStatus | null;
@@ -13,7 +14,12 @@ type UseRunStatusResult = {
   isPolling: boolean;
 };
 
-const TERMINAL_STATUSES: RunStatus[] = ["succeeded", "failed", "timedout"];
+const TERMINAL_STATUSES: RunStatus[] = [
+  "succeeded",
+  "failed",
+  "timedout",
+  "expired",
+];
 const INITIAL_INTERVAL_MS = 2000;
 const BACKOFF_INTERVAL_MS = 5000;
 const BACKOFF_AFTER_MS = 30000;
@@ -117,6 +123,19 @@ export function useRunStatus(jobId: string | null): UseRunStatusResult {
       if (cached) {
         setResult(cached);
         setStatus("succeeded");
+        setIsPolling(false);
+        return;
+      }
+      // No durable result and the run is past the 48h server TTL — its record is
+      // gone, so polling would only spin until MAX_POLL_MS. Mark it expired and
+      // stop. (The cache check above still wins, so an immutable cached result
+      // always renders regardless of age.)
+      const entry = useRunsStore
+        .getState()
+        .runsList.find((run) => run.jobId === jobId);
+      if (entry && Date.now() - entry.submittedAt > CONST.RUNS.TTL_MS) {
+        setStatus("expired");
+        updateRunStatus(jobId, "expired");
         setIsPolling(false);
         return;
       }

--- a/apps/react-ui/client/src/pages/api/runs.ts
+++ b/apps/react-ui/client/src/pages/api/runs.ts
@@ -12,6 +12,7 @@ import type {
   RunStatus,
 } from "@src/types/api";
 import { generateJobId } from "@src/utils/idUtils";
+import CONST from "@src/CONST";
 
 // Allow larger request bodies than Next.js's 1mb default so we can accept a
 // dataset and decide whether to queue it or signal the synchronous fallback.
@@ -29,7 +30,7 @@ const region =
 const tableName = process.env.RUNS_TABLE_NAME;
 const queueUrl = process.env.RUNS_QUEUE_URL;
 
-const TTL_SECONDS = 48 * 60 * 60; // 48h pickup buffer
+const TTL_SECONDS = CONST.RUNS.TTL_SECONDS; // 48h pickup buffer
 // Keep the SQS message under the 256KB hard limit; larger datasets fall back
 // to the synchronous path (which posts directly to the R Lambda).
 const MAX_QUEUE_BODY_BYTES = 200 * 1024;

--- a/apps/react-ui/client/src/pages/model/index.tsx
+++ b/apps/react-ui/client/src/pages/model/index.tsx
@@ -723,6 +723,8 @@ export default function ModelPage() {
               jobId: submission.jobId,
               modelType: parameters.modelType,
               dataId: dataId ?? null,
+              filename: uploadedData?.filename ?? "Unknown dataset",
+              rowCount: uploadedData?.data?.length ?? 0,
               parameters: JSON.stringify(parameters),
               submittedAt: Date.now(),
               status: "queued",

--- a/apps/react-ui/client/src/pages/results/index.tsx
+++ b/apps/react-ui/client/src/pages/results/index.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useSearchParams, useRouter } from "next/navigation";
-import { useState, useMemo, useEffect } from "react";
+import { useState, useMemo, useEffect, type ReactNode } from "react";
 import Head from "next/head";
 import Image from "next/image";
 import Tooltip from "@components/Tooltip";
@@ -262,34 +262,54 @@ export default function ResultsPage() {
     }
   }, [exportErrorMessage]);
 
-  // Async run still in flight (or failed) — show a loading / error state while
-  // polling, instead of the "no results" view.
+  // Async run still in flight (or terminal-but-unavailable) — show a loading /
+  // error state while polling, instead of the "no results" view.
   if (jobId && !results) {
+    const runExpired = runStatus.status === "expired";
     const runFailed =
       runStatus.status === "failed" || runStatus.status === "timedout";
+
+    let body: ReactNode;
+    if (runExpired) {
+      body = (
+        <div className="text-center">
+          <SectionHeading level="h1" text="Run expired" className="mb-4" />
+          <p className="mb-6 text-gray-600 dark:text-gray-300">
+            Results are only kept for 48 hours after a run is submitted, so this
+            run is no longer available. Please run the analysis again.
+          </p>
+          <GoBackButton
+            href={`/model?dataId=${dataId ?? ""}`}
+            text="Back to model setup"
+            variant="simple"
+          />
+        </div>
+      );
+    } else if (runFailed) {
+      body = (
+        <div className="text-center">
+          <SectionHeading level="h1" text="Run failed" className="mb-4" />
+          <p className="mb-6 text-gray-600 dark:text-gray-300">
+            {runStatus.errorMessage ??
+              "The analysis did not complete. Please try again."}
+          </p>
+          <GoBackButton
+            href={`/model?dataId=${dataId ?? ""}`}
+            text="Back to model setup"
+            variant="simple"
+          />
+        </div>
+      );
+    } else {
+      body = <RunLoading phase="running" dataId={dataId} />;
+    }
+
     return (
       <>
         <Head>
           <title>{`${CONST.APP_DISPLAY_NAME} - Results`}</title>
         </Head>
-        <main className="content-page-container">
-          {runFailed ? (
-            <div className="text-center">
-              <SectionHeading level="h1" text="Run failed" className="mb-4" />
-              <p className="mb-6 text-gray-600 dark:text-gray-300">
-                {runStatus.errorMessage ??
-                  "The analysis did not complete. Please try again."}
-              </p>
-              <GoBackButton
-                href={`/model?dataId=${dataId ?? ""}`}
-                text="Back to model setup"
-                variant="simple"
-              />
-            </div>
-          ) : (
-            <RunLoading phase="running" dataId={dataId} />
-          )}
-        </main>
+        <main className="content-page-container">{body}</main>
       </>
     );
   }

--- a/apps/react-ui/client/src/pages/runs/index.tsx
+++ b/apps/react-ui/client/src/pages/runs/index.tsx
@@ -30,6 +30,8 @@ const statusLabel = (status: RunStatus): string => {
       return "Failed";
     case "timedout":
       return "Timed out";
+    case "expired":
+      return "Expired";
     default:
       return status;
   }
@@ -43,6 +45,8 @@ const statusClasses = (status: RunStatus): string => {
     case "failed":
     case "timedout":
       return "bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400";
+    case "expired":
+      return "bg-gray-100 text-gray-600 dark:bg-gray-800/40 dark:text-gray-400";
     default:
       return "bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400";
   }

--- a/apps/react-ui/client/src/pages/runs/index.tsx
+++ b/apps/react-ui/client/src/pages/runs/index.tsx
@@ -1,14 +1,22 @@
 "use client";
 
+import { useState } from "react";
 import Head from "next/head";
 import { useRouter } from "next/navigation";
 import SectionHeading from "@src/components/SectionHeading";
 import { GoBackButton } from "@src/components/Buttons";
 import ActionButton from "@src/components/Buttons/ActionButton";
+import ConfirmDialog from "@src/components/Modals/ConfirmDialog";
 import CONST from "@src/CONST";
 import { useRunsStore } from "@src/store/runsStore";
 import { deleteResult, clearAllResults } from "@src/utils/runsCache";
 import type { RunStatus } from "@src/types/api";
+
+// Non-terminal statuses get a live "pulse" cue, since RunsWatcher updates them
+// in place while the run is still in flight.
+const PENDING_STATUSES: RunStatus[] = ["queued", "running"];
+const isPending = (status: RunStatus): boolean =>
+  PENDING_STATUSES.includes(status);
 
 const statusLabel = (status: RunStatus): string => {
   switch (status) {
@@ -45,6 +53,7 @@ export default function RunsPage() {
   const runsList = useRunsStore((state) => state.runsList);
   const removeRun = useRunsStore((state) => state.removeRun);
   const clearRuns = useRunsStore((state) => state.clearRuns);
+  const [isClearConfirmOpen, setIsClearConfirmOpen] = useState(false);
 
   const openRun = (
     jobId: string,
@@ -68,21 +77,24 @@ export default function RunsPage() {
       </Head>
       <main className="content-page-container">
         <div className="mx-auto w-full max-w-3xl">
-          <div className="mb-4 flex items-center justify-between">
+          <div className="mb-1 flex items-center justify-between">
             <SectionHeading level="h1" text="My Runs" />
             {runsList.length > 0 && (
               <ActionButton
                 variant="secondary"
                 size="sm"
-                onClick={() => {
-                  clearRuns();
-                  void clearAllResults();
-                }}
+                onClick={() => setIsClearConfirmOpen(true)}
               >
                 Clear all
               </ActionButton>
             )}
           </div>
+
+          {runsList.length > 0 && (
+            <p className="mb-4 text-sm text-gray-500 dark:text-gray-400">
+              Runs are saved on this device only.
+            </p>
+          )}
 
           {runsList.length === 0 ? (
             <div className="card text-center">
@@ -104,15 +116,29 @@ export default function RunsPage() {
                   className="surface-elevated flex items-center justify-between gap-4 rounded-lg border border-primary px-4 py-3"
                 >
                   <div className="min-w-0">
-                    <p className="font-medium">{run.modelType}</p>
-                    <p className="text-sm text-gray-500 dark:text-gray-400">
-                      {new Date(run.submittedAt).toLocaleString()}
+                    <p className="truncate font-medium" title={run.filename}>
+                      {run.filename}
                     </p>
+                    <div className="mt-0.5 flex min-w-0 items-center gap-2 text-sm text-gray-500 dark:text-gray-400">
+                      <span className="inline-flex flex-shrink-0 items-center rounded bg-gray-100 px-1.5 py-0.5 text-xs font-medium text-gray-600 dark:bg-gray-800 dark:text-gray-300">
+                        {run.modelType}
+                      </span>
+                      <span className="truncate">
+                        {new Date(run.submittedAt).toLocaleString()}
+                        {run.rowCount > 0 ? ` · ${run.rowCount} rows` : ""}
+                      </span>
+                    </div>
                   </div>
                   <div className="flex items-center gap-3">
                     <span
-                      className={`inline-flex items-center rounded-full px-2 py-1 text-xs font-semibold ${statusClasses(run.status)}`}
+                      className={`inline-flex items-center gap-1.5 rounded-full px-2 py-1 text-xs font-semibold ${statusClasses(run.status)}`}
                     >
+                      {isPending(run.status) && (
+                        <span className="relative flex h-1.5 w-1.5">
+                          <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-current opacity-75" />
+                          <span className="relative inline-flex h-1.5 w-1.5 rounded-full bg-current" />
+                        </span>
+                      )}
                       {statusLabel(run.status)}
                     </span>
                     <ActionButton
@@ -142,6 +168,18 @@ export default function RunsPage() {
           )}
         </div>
       </main>
+
+      <ConfirmDialog
+        isOpen={isClearConfirmOpen}
+        onClose={() => setIsClearConfirmOpen(false)}
+        onConfirm={() => {
+          clearRuns();
+          void clearAllResults();
+        }}
+        title="Clear all runs?"
+        message="This permanently removes every run from this device, including their cached results. This can't be undone."
+        confirmLabel="Clear all"
+      />
     </>
   );
 }

--- a/apps/react-ui/client/src/store/runsStore.ts
+++ b/apps/react-ui/client/src/store/runsStore.ts
@@ -12,12 +12,20 @@ export type RunEntry = {
   jobId: string;
   modelType: string;
   dataId: string | null;
+  // Name of the uploaded dataset, so runs of the same model are distinguishable
+  // in the My Runs list. Falls back to "Unknown dataset" for migrated entries.
+  filename: string;
+  // Number of observations (rows) in the dataset at submit time.
+  rowCount: number;
   // JSON-stringified ModelParameters, so a run can be reopened with full
   // fidelity (the results page reads `parameters` from the URL).
   parameters: string;
   submittedAt: number; // epoch ms
   status: RunStatus;
 };
+
+// Defaults applied to entries persisted before `filename`/`rowCount` existed.
+const UNKNOWN_FILENAME = "Unknown dataset";
 
 type RunsStore = {
   // State
@@ -32,6 +40,31 @@ type RunsStore = {
 
 // Cap the locally-tracked history so localStorage never grows unbounded.
 const MAX_RUNS = 50;
+
+type PersistedRunsState = { runsList?: RunEntry[] };
+
+/**
+ * Backfill persisted runs across schema versions. v1 introduced
+ * `filename`/`rowCount`; older entries are given safe defaults so the My Runs
+ * list never renders blank/undefined dataset labels. Exported for testing.
+ */
+export const migrateRunsState = (
+  persisted: unknown,
+  version: number,
+): PersistedRunsState => {
+  const state = persisted as PersistedRunsState | undefined;
+  if (!state?.runsList) {
+    return { runsList: [] };
+  }
+  if (version < 1) {
+    state.runsList = state.runsList.map((run) => ({
+      ...run,
+      filename: run.filename ?? UNKNOWN_FILENAME,
+      rowCount: run.rowCount ?? 0,
+    }));
+  }
+  return state;
+};
 
 export const useRunsStore = create<RunsStore>()(
   persist(
@@ -71,6 +104,10 @@ export const useRunsStore = create<RunsStore>()(
       name: "maive-runs-list",
       // Persist the lightweight list only (result payloads stay server-side).
       partialize: (state) => ({ runsList: state.runsList }),
+      // v1 introduced `filename`/`rowCount`; backfill older entries so the My
+      // Runs list never renders blank/undefined dataset labels.
+      version: 1,
+      migrate: migrateRunsState,
     },
   ),
 );

--- a/apps/react-ui/client/src/tests/RunsPage.test.tsx
+++ b/apps/react-ui/client/src/tests/RunsPage.test.tsx
@@ -1,0 +1,61 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, screen, fireEvent, within } from "@testing-library/react";
+import RunsPage from "@src/pages/runs";
+import { useRunsStore } from "@src/store/runsStore";
+
+// The empty-state GoBackButton uses the Pages-Router useRouter (next/router),
+// which the global setup (next/navigation only) does not cover.
+vi.mock("next/router", () => ({
+  useRouter: () => ({ push: vi.fn() }),
+}));
+
+const addRun = (jobId: string, filename: string) => {
+  useRunsStore.getState().addRun({
+    jobId,
+    modelType: "MAIVE",
+    dataId: "d1",
+    filename,
+    rowCount: 120,
+    parameters: "{}",
+    submittedAt: Date.now(),
+    status: "queued",
+  });
+};
+
+describe("RunsPage", () => {
+  beforeEach(() => {
+    useRunsStore.getState().clearRuns();
+  });
+
+  it("shows the dataset filename and the device-local note", () => {
+    addRun("job-1", "my-study.csv");
+    render(<RunsPage />);
+
+    expect(screen.getByText("my-study.csv")).toBeInTheDocument();
+    expect(screen.getByText(/saved on this device/i)).toBeInTheDocument();
+    // Model type is demoted to a secondary tag, not the primary label.
+    expect(screen.getByText("MAIVE")).toBeInTheDocument();
+  });
+
+  it("renders an empty state with no device note", () => {
+    render(<RunsPage />);
+    expect(screen.getByText(/you have no runs yet/i)).toBeInTheDocument();
+    expect(screen.queryByText(/saved on this device/i)).not.toBeInTheDocument();
+  });
+
+  it("only clears runs after confirming in the dialog", () => {
+    addRun("job-1", "my-study.csv");
+    render(<RunsPage />);
+
+    // Opening the confirm dialog must not clear anything yet.
+    fireEvent.click(screen.getByRole("button", { name: "Clear all" }));
+    expect(useRunsStore.getState().runsList).toHaveLength(1);
+
+    const dialog = screen.getByRole("dialog");
+    expect(within(dialog).getByText(/can't be undone/i)).toBeInTheDocument();
+
+    // Confirming inside the dialog clears the list.
+    fireEvent.click(within(dialog).getByRole("button", { name: "Clear all" }));
+    expect(useRunsStore.getState().runsList).toHaveLength(0);
+  });
+});

--- a/apps/react-ui/client/src/tests/RunsWatcher.test.tsx
+++ b/apps/react-ui/client/src/tests/RunsWatcher.test.tsx
@@ -4,6 +4,8 @@ import RunsWatcher from "@src/components/RunsWatcher";
 import { GlobalAlertProvider } from "@src/components/GlobalAlertProvider";
 import { useRunsStore } from "@src/store/runsStore";
 import { modelService } from "@src/api/services/modelService";
+import { notifyRunComplete } from "@src/utils/notifications";
+import CONST from "@src/CONST";
 
 vi.mock("@src/utils/notifications", () => ({
   notifyRunComplete: vi.fn(() => true),
@@ -34,6 +36,7 @@ describe("RunsWatcher", () => {
   beforeEach(() => {
     useRunsStore.getState().clearRuns();
     vi.restoreAllMocks();
+    vi.clearAllMocks();
   });
 
   it("polls pending runs and reflects their terminal status in the store", async () => {
@@ -61,5 +64,43 @@ describe("RunsWatcher", () => {
       setTimeout(resolve, 50);
     });
     expect(getRuns).not.toHaveBeenCalled();
+  });
+
+  it("flips a run gone from the backend and past the TTL to expired", async () => {
+    // Submitted beyond the 48h TTL and absent from the batch response (its
+    // record has expired) — the watcher marks it expired, without notifying.
+    useRunsStore.getState().addRun({
+      jobId: "old-1",
+      modelType: "RTMA",
+      dataId: "d1",
+      filename: "study-data.csv",
+      rowCount: 42,
+      parameters: "{}",
+      submittedAt: Date.now() - (CONST.RUNS.TTL_MS + 60_000),
+      status: "queued",
+    });
+    const getRuns = vi.spyOn(modelService, "getRuns").mockResolvedValue([]);
+
+    renderWatcher();
+
+    await waitFor(() => expect(getRuns).toHaveBeenCalledWith(["old-1"]));
+    await waitFor(() =>
+      expect(useRunsStore.getState().runsList[0].status).toBe("expired"),
+    );
+    expect(notifyRunComplete).not.toHaveBeenCalled();
+  });
+
+  it("keeps a recent run pending when it is briefly missing from the response", async () => {
+    addRun("young-1", "queued"); // submittedAt = now, within the TTL window
+    const getRuns = vi.spyOn(modelService, "getRuns").mockResolvedValue([]);
+
+    renderWatcher();
+
+    await waitFor(() => expect(getRuns).toHaveBeenCalledWith(["young-1"]));
+    // A transient miss inside the TTL window must not be expired.
+    await new Promise((resolve) => {
+      setTimeout(resolve, 50);
+    });
+    expect(useRunsStore.getState().runsList[0].status).toBe("queued");
   });
 });

--- a/apps/react-ui/client/src/tests/RunsWatcher.test.tsx
+++ b/apps/react-ui/client/src/tests/RunsWatcher.test.tsx
@@ -15,6 +15,8 @@ const addRun = (jobId: string, status: "queued" | "succeeded") => {
     jobId,
     modelType: "RTMA",
     dataId: "d1",
+    filename: "study-data.csv",
+    rowCount: 42,
     parameters: "{}",
     submittedAt: Date.now(),
     status,

--- a/apps/react-ui/client/src/tests/notifications.test.ts
+++ b/apps/react-ui/client/src/tests/notifications.test.ts
@@ -86,6 +86,17 @@ describe("notifications", () => {
       notifyRunComplete({ jobId: "j3", modelType: "RTMA", status: "timedout" });
       expect(constructed[0].title).toBe("RTMA run timed out");
     });
+
+    it("does not notify for an expired run", () => {
+      installNotification("granted");
+      const shown = notifyRunComplete({
+        jobId: "j4",
+        modelType: "RTMA",
+        status: "expired",
+      });
+      expect(shown).toBe(false);
+      expect(constructed).toHaveLength(0);
+    });
   });
 
   describe("requestNotificationPermission", () => {

--- a/apps/react-ui/client/src/tests/runsStore.test.ts
+++ b/apps/react-ui/client/src/tests/runsStore.test.ts
@@ -1,10 +1,12 @@
 import { describe, it, expect, beforeEach } from "vitest";
-import { useRunsStore } from "@src/store/runsStore";
+import { useRunsStore, migrateRunsState } from "@src/store/runsStore";
 
 const makeEntry = (jobId: string, submittedAt: number) => ({
   jobId,
   modelType: "RTMA",
   dataId: "data_1",
+  filename: "study-data.csv",
+  rowCount: 42,
   parameters: "{}",
   submittedAt,
   status: "queued" as const,
@@ -43,5 +45,40 @@ describe("runsStore", () => {
     useRunsStore.getState().addRun(makeEntry("a", 1));
     useRunsStore.getState().removeRun("a");
     expect(useRunsStore.getState().runsList).toHaveLength(0);
+  });
+});
+
+describe("migrateRunsState", () => {
+  it("backfills filename/rowCount on pre-v1 entries", () => {
+    const legacy = {
+      runsList: [
+        {
+          jobId: "a",
+          modelType: "MAIVE",
+          dataId: "data_1",
+          parameters: "{}",
+          submittedAt: 1,
+          status: "succeeded",
+        },
+      ],
+    };
+    const migrated = migrateRunsState(legacy, 0);
+    expect(migrated.runsList?.[0]).toMatchObject({
+      filename: "Unknown dataset",
+      rowCount: 0,
+    });
+  });
+
+  it("leaves existing filename/rowCount untouched", () => {
+    const current = { runsList: [makeEntry("a", 1)] };
+    const migrated = migrateRunsState(current, 1);
+    expect(migrated.runsList?.[0]).toMatchObject({
+      filename: "study-data.csv",
+      rowCount: 42,
+    });
+  });
+
+  it("returns an empty list when nothing was persisted", () => {
+    expect(migrateRunsState(undefined, 0)).toEqual({ runsList: [] });
   });
 });

--- a/apps/react-ui/client/src/types/api.ts
+++ b/apps/react-ui/client/src/types/api.ts
@@ -116,7 +116,17 @@ type PingResponse = {
 };
 
 // Async runs (queue) types -----------------------------------------------
-type RunStatus = "queued" | "running" | "succeeded" | "failed" | "timedout";
+// "expired" is a client-synthetic terminal status: the backend never writes it.
+// It is assigned locally when a non-terminal run is past the 48h server TTL and
+// its record is gone (see RunsWatcher / useRunStatus), so a stale run does not
+// appear stuck on "running" forever.
+type RunStatus =
+  | "queued"
+  | "running"
+  | "succeeded"
+  | "failed"
+  | "timedout"
+  | "expired";
 
 // Response from POST /api/runs. `tooLarge` signals the client to fall back to
 // the synchronous path (dataset too big to queue via SQS).

--- a/apps/react-ui/client/src/utils/notifications.ts
+++ b/apps/react-ui/client/src/utils/notifications.ts
@@ -35,6 +35,11 @@ export const notifyRunComplete = ({
   if (!isSupported() || Notification.permission !== "granted") {
     return false;
   }
+  // "expired" is assigned locally to stale runs, not a completion event — never
+  // surface it as a notification.
+  if (status === "expired") {
+    return false;
+  }
   const succeeded = status === "succeeded";
   const title = succeeded
     ? `${modelType} run finished`


### PR DESCRIPTION
## What & why

The **My Runs** page is the history/inbox for asynchronous MAIVE analyses. The underlying async machinery (queue, `RunsWatcher` polling, IndexedDB result cache, notifications) is solid, but the presentation had gaps:

- Every run was labeled only by **model type + timestamp**, so multiple runs of the same model on different datasets were indistinguishable — the list couldn't do its core job.
- **Clear all** wiped the store *and* IndexedDB instantly, with no confirmation.
- In-flight runs updated live but looked static.
- Nothing signaled a background run was still processing once the user navigated away.
- History is device-local but nothing said so ("where did my runs go?").

This PR ships five small, localized presentational improvements in one change.

## Changes

| # | Improvement | Notes |
|---|-------------|-------|
| 1 | **Dataset filename per run** | `RunEntry` gains `filename` + `rowCount`, captured from `uploadedData` at submit. Filename is now the row's primary label (truncated, full name on hover); model type is a small tag with timestamp + `· N rows`. A persist `version: 1` + extracted `migrateRunsState` helper backfills pre-existing local history with `"Unknown dataset"` / `0`. |
| 2 | **Confirm before "Clear all"** | New reusable `ConfirmDialog` built on the existing `BaseModal` + `ActionButton` (`danger`). Clears only on confirm. |
| 3 | **Live status indicator** | Queued/Running pills get a pulsing (`animate-ping`) dot; terminal statuses stay static. |
| 4 | **Active-run count in header** | "My Runs" link shows a badge with the number of in-flight (queued + running) runs. |
| 5 | **Device-local note** | "Runs are saved on this device only." under the heading when the list is non-empty. |

## Files

- `store/runsStore.ts` — `RunEntry` fields + `version`/`migrate` (exported `migrateRunsState`)
- `pages/model/index.tsx` — capture `filename`/`rowCount` at `addRun`
- `pages/runs/index.tsx` — filename-first rows, live pulse, device note, confirm-gated Clear all
- `components/Modals/ConfirmDialog.tsx` — **new** reusable confirm dialog
- `components/Header.tsx` — active-run count badge

## Reviewer notes

- **Back-compat:** old persisted entries (from before this change) lack `filename`/`rowCount`; the `migrate` step backfills them so nothing renders blank. Verified by a unit test.
- **No hydration mismatch in the header:** the persisted store hydrates to `[]` on first render on both server and client, so the badge simply appears after rehydration.
- Individual **Remove** stays immediate (lower stakes); only the bulk **Clear all** is confirm-gated.

## Verification

- `npm run lint` → clean
- `vitest run` → **56/56 pass** (updated `runsStore`/`RunsWatcher` fixtures, new migration test, new `RunsPage.test.tsx` covering filename render, confirm-gated clear, device note)
- `tsc --noEmit` → no new type errors (one pre-existing `import.meta.vitest` error in `results.test.tsx` predates this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Folded in: stale-run expiry (was #462)

This PR now also includes the changes from #462 so both can merge at once. A run could appear stuck on **"Running"** indefinitely once its 48h DynamoDB record aged out (the batch status endpoint only returns records that still exist, so `RunsWatcher` never reconciled it). Fix:

- New **client-synthetic terminal status `"expired"`** (backend never writes it).
- `RunsWatcher` flips a non-terminal run to `"expired"` when it's missing from the batch response **and** past the 48h TTL — in a separate pass, so no false "run finished" notification; the age guard avoids expiring runs only transiently absent.
- `useRunStatus` short-circuits an opened expired run to `"expired"` instead of polling to the 16-minute cap (the durable IndexedDB cache still wins first).
- My Runs shows a neutral gray **"Expired"** badge; the results page renders a **"Run expired"** message with a path back to model setup.
- 48h TTL is now a shared `CONST.RUNS` constant used by both the API route and the client.

Reconciled with this PR's My Runs UX changes (the `"expired"` badge slots into the same `statusLabel`/`statusClasses`; expired is terminal so it gets no live pulse and isn't counted in the header's active-run badge). **#462 can be closed in favor of this PR.**
