### PR TITLE
docs: add public API OpenAPI spec and usage guide

### DIFF
--- a/docs/PUBLIC_API.md
+++ b/docs/PUBLIC_API.md
@@ -1,0 +1,308 @@
+# Public Model API — Usage Guide
+
+## Overview
+
+MAIVE exposes a public, anonymous HTTP API for running MAIVE / WAIVE / WLS
+and RTMA meta-analysis models programmatically — no accounts, no API keys.
+It's the same compute the MAIVE UI uses, given a clean, documented contract.
+
+> **Status:** this guide documents the target `/v1` contract. The branded
+> hostname (`api.maive.eu`) goes live in a later rollout phase — if it
+> doesn't resolve yet, that's expected; see
+> [`PUBLIC_API_DESIGN.md`](PUBLIC_API_DESIGN.md) for the rollout plan.
+
+The full machine-readable contract lives in
+[`docs/api/openapi.yaml`](api/openapi.yaml) (OpenAPI 3) — it is the source of
+truth for request/response shapes. This guide is a narrative companion with
+copy-paste examples.
+
+- Base URL: `https://api.maive.eu`
+- Content type: `application/json` both ways
+- Auth: none — the API is anonymous by design. Abuse is bounded by
+  server-side concurrency caps and edge rate limits, not identity.
+
+## Sync vs. async
+
+Two ways to run a model:
+
+| | Synchronous | Asynchronous |
+|---|---|---|
+| Endpoints | `POST /v1/run-model`, `POST /v1/run-rtma` | `POST /v1/runs` (submit) + `GET /v1/runs/{jobId}` (poll) |
+| Shape | One request, one response | Submit returns a `jobId` immediately; poll until terminal, then read `result` |
+| Edge cap | Subject to Cloudflare's **~100s** proxy cap on `api.maive.eu` | Not subject to the cap — no long-lived connection |
+| When to use | Typical datasets, runs finishing in well under 100s (roughly 15-60s including cold start) | **Recommended default.** Anything that might run long, batch/CI usage, or when you'd rather not hold a connection open |
+
+**Recommendation: use the async path by default.** It has no failure mode tied
+to run duration. Reach for sync only when you know the run is small and you
+want the simplicity of a single request.
+
+## Data requirements
+
+Requests take `data` as an array of row objects. Columns are resolved by
+canonical key name when present (`effect`, `se`, `n_obs`, `study_id`);
+otherwise the first 3-4 object keys are read positionally in that order.
+
+| Field | Type | Required for | Notes |
+|---|---|---|---|
+| `effect` | number | MAIVE-family, RTMA | Estimated effect size |
+| `se` | number | MAIVE-family, RTMA | Standard error; must be `> 0` |
+| `n_obs` | integer | MAIVE-family | Number of observations; must be a positive integer |
+| `study_id` | string | optional | Enables study clustering; if present, rows must be ≥ unique studies + 3 |
+
+| Endpoint | Columns | Min rows |
+|---|---|---|
+| `POST /v1/run-model` (MAIVE/WAIVE/WLS) | 3 or 4 | 4 |
+| `POST /v1/run-rtma` | 2 (`effect`, `se`) | Rows with missing/non-positive `se` are dropped with a warning |
+
+These mirror the MAIVE UI's own validation page, enforced server-side so API
+callers get a structured `400 validation_error` instead of a raw R error —
+see [`components/responses/ValidationError`](api/openapi.yaml) in the spec.
+
+All model parameters are optional; unset ones fall back to documented
+defaults (the same defaults the UI ships with). A minimal valid request is
+just `{"data": [...]}`. See the `ModelParameters` / `RTMAParameters` schemas
+in the OpenAPI spec for the full enum/default table.
+
+Plots (`funnelPlot`, `zScorePlot`, and their width/height companions) are
+**excluded by default** — each is a ~50KB base64 PNG, noise for most
+programmatic callers. Add `?include=plot` to any run or poll request to embed
+them.
+
+## Examples: synchronous run
+
+### curl
+
+```bash
+curl -s https://api.maive.eu/v1/run-model \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "data": [
+      {"effect": 0.42, "se": 0.11, "n_obs": 120},
+      {"effect": 0.31, "se": 0.06, "n_obs": 90},
+      {"effect": 0.55, "se": 0.20, "n_obs": 45},
+      {"effect": 0.12, "se": 0.04, "n_obs": 200}
+    ]
+  }'
+```
+
+### R (httr2)
+
+```r
+library(httr2)
+
+body <- list(
+  data = list(
+    list(effect = 0.42, se = 0.11, n_obs = 120),
+    list(effect = 0.31, se = 0.06, n_obs = 90),
+    list(effect = 0.55, se = 0.20, n_obs = 45),
+    list(effect = 0.12, se = 0.04, n_obs = 200)
+  )
+)
+
+resp <- request("https://api.maive.eu/v1/run-model") |>
+  req_body_json(body) |>
+  req_perform()
+
+results <- resp_body_json(resp)
+str(results)
+```
+
+### Python (requests)
+
+```python
+import requests
+
+body = {
+    "data": [
+        {"effect": 0.42, "se": 0.11, "n_obs": 120},
+        {"effect": 0.31, "se": 0.06, "n_obs": 90},
+        {"effect": 0.55, "se": 0.20, "n_obs": 45},
+        {"effect": 0.12, "se": 0.04, "n_obs": 200},
+    ]
+}
+
+resp = requests.post("https://api.maive.eu/v1/run-model", json=body, timeout=120)
+resp.raise_for_status()
+results = resp.json()
+print(results["effectEstimate"], results["standardError"])
+```
+
+## Examples: asynchronous run (submit → poll → fetch)
+
+Submit returns a `jobId` immediately. Poll `GET /v1/runs/{jobId}` every 2-5s
+until `status` is terminal (`succeeded`, `failed`, or `timedout`), then read
+`result`.
+
+### curl
+
+```bash
+# 1. Submit
+job=$(curl -s https://api.maive.eu/v1/runs \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "modelType": "MAIVE",
+    "data": [
+      {"effect": 0.42, "se": 0.11, "n_obs": 120},
+      {"effect": 0.31, "se": 0.06, "n_obs": 90},
+      {"effect": 0.55, "se": 0.20, "n_obs": 45},
+      {"effect": 0.12, "se": 0.04, "n_obs": 200}
+    ]
+  }' | jq -r '.jobId')
+
+echo "jobId: $job"
+
+# 2. Poll until terminal
+while true; do
+  status=$(curl -s "https://api.maive.eu/v1/runs/$job" | tee /tmp/run.json | jq -r '.status')
+  echo "status: $status"
+  [[ "$status" == "succeeded" || "$status" == "failed" || "$status" == "timedout" ]] && break
+  sleep 3
+done
+
+# 3. Read the result
+jq '.result' /tmp/run.json
+```
+
+### R (httr2)
+
+```r
+library(httr2)
+
+submit_body <- list(
+  modelType = "MAIVE",
+  data = list(
+    list(effect = 0.42, se = 0.11, n_obs = 120),
+    list(effect = 0.31, se = 0.06, n_obs = 90),
+    list(effect = 0.55, se = 0.20, n_obs = 45),
+    list(effect = 0.12, se = 0.04, n_obs = 200)
+  )
+)
+
+submit_resp <- request("https://api.maive.eu/v1/runs") |>
+  req_body_json(submit_body) |>
+  req_perform()
+
+job_id <- resp_body_json(submit_resp)$jobId
+cat("jobId:", job_id, "\n")
+
+terminal_statuses <- c("succeeded", "failed", "timedout")
+repeat {
+  run <- request(sprintf("https://api.maive.eu/v1/runs/%s", job_id)) |>
+    req_perform() |>
+    resp_body_json()
+
+  cat("status:", run$status, "\n")
+  if (run$status %in% terminal_statuses) break
+  Sys.sleep(3)
+}
+
+if (run$status == "succeeded") {
+  str(run$result)
+} else {
+  stop(run$errorMessage)
+}
+```
+
+### Python (requests)
+
+```python
+import time
+import requests
+
+submit_body = {
+    "modelType": "MAIVE",
+    "data": [
+        {"effect": 0.42, "se": 0.11, "n_obs": 120},
+        {"effect": 0.31, "se": 0.06, "n_obs": 90},
+        {"effect": 0.55, "se": 0.20, "n_obs": 45},
+        {"effect": 0.12, "se": 0.04, "n_obs": 200},
+    ],
+}
+
+submit_resp = requests.post("https://api.maive.eu/v1/runs", json=submit_body, timeout=30)
+submit_resp.raise_for_status()
+job_id = submit_resp.json()["jobId"]
+print("jobId:", job_id)
+
+terminal_statuses = {"succeeded", "failed", "timedout"}
+while True:
+    run = requests.get(f"https://api.maive.eu/v1/runs/{job_id}", timeout=30).json()
+    print("status:", run["status"])
+    if run["status"] in terminal_statuses:
+        break
+    time.sleep(3)
+
+if run["status"] == "succeeded":
+    print(run["result"])
+else:
+    raise RuntimeError(run.get("errorMessage"))
+```
+
+Batch status for multiple runs at once (no results, just status): `GET
+/v1/runs?ids=jobId1,jobId2,jobId3` (max 100 ids).
+
+## `jobId` semantics
+
+`jobId` is an **opaque bearer token**, not a user- or account-scoped
+identifier. Anyone holding a `jobId` can read that run's status and result —
+the same exposure model the MAIVE UI's own async runs already use. Treat it
+like a share link:
+
+- Don't submit data you wouldn't want visible to whoever might obtain the
+  `jobId`.
+- Results and job records **expire after 48 hours**; `GET
+  /v1/runs/{jobId}` returns `404 not_found` after that.
+
+## Privacy
+
+- Requests are anonymous — no accounts, no identity is collected.
+- Synchronous runs are stateless; nothing is persisted beyond the response.
+- Asynchronous runs persist the submitted parameters and the result in the
+  run store for up to 48 hours, keyed by `jobId`, then expire automatically.
+  The input dataset itself is not persisted beyond the transient queue
+  message used to dispatch the run.
+- **Do not submit confidential or personally identifiable data.** The API has
+  no data-classification or redaction layer — treat every request the same
+  way you'd treat a request to any other unauthenticated public web service.
+
+## Rate limits & errors
+
+Two independent guardrails apply, load-bearing in this order:
+
+1. A hard concurrency cap on the compute backend — once saturated, further
+   requests receive `429 rate_limited` regardless of entry path.
+2. Per-IP rate limiting at the edge on `api.maive.eu` for casual abuse
+   deterrence.
+
+Both are documented starting points and may be tuned based on observed load
+— treat any `429` as "retry with backoff," not a hard quota. Datasets that
+are too large to queue asynchronously (roughly 200KB of JSON) get `413
+payload_too_large` pointing you at the synchronous endpoint instead.
+
+All errors share one envelope:
+
+```json
+{ "error": { "code": "validation_error", "message": "Data must have 3 or 4 columns; found 6." } }
+```
+
+See [`docs/api/openapi.yaml`](api/openapi.yaml) for the full list of error
+codes and every schema referenced above.
+
+## Citation
+
+If you use MAIVE in published or reported work, please cite:
+
+> Irsova, Z., Bom, P.R.D., Havranek, T., & Rachinger, H. (2025). Spurious
+> precision in meta-analysis of observational research. Nature
+> Communications, 16, 8454. https://doi.org/10.1038/s41467-025-63261-0
+
+## See also
+
+- [`docs/api/openapi.yaml`](api/openapi.yaml) — the OpenAPI 3 contract
+  (source of truth).
+- [`PUBLIC_API_DESIGN.md`](PUBLIC_API_DESIGN.md) — the design doc this API is
+  scoped from, including rollout phases and abuse/cost controls.
+- [`SERVER_SIDE_API_ARCHITECTURE.md`](SERVER_SIDE_API_ARCHITECTURE.md) —
+  current serving topology (UI Lambda, R Lambda, Cloudflare).
+- [`ASYNC_RUNS_DESIGN.md`](ASYNC_RUNS_DESIGN.md) — the async runs
+  infrastructure this API's `/v1/runs*` routes wrap.

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -1,0 +1,854 @@
+openapi: 3.0.3
+info:
+  title: MAIVE Public Model API
+  version: "1.0.0"
+  description: |
+    Public, anonymous HTTP API for running MAIVE / WAIVE / WLS and RTMA
+    meta-analysis models programmatically, without going through the MAIVE UI.
+
+    This is the `/v1` contract described in
+    [`docs/PUBLIC_API_DESIGN.md`](../PUBLIC_API_DESIGN.md) (§6). See
+    [`docs/PUBLIC_API.md`](../PUBLIC_API.md) for a usage guide with copy-paste
+    curl / R / Python examples.
+
+    **Status:** this spec documents the target contract. The branded hostname
+    (`api.maive.eu`) goes live in a later rollout phase (Phase 2 of the design
+    doc) — it may not resolve yet.
+
+    **Access:** anonymous — no accounts, no API keys. Abuse is bounded by
+    server-side concurrency caps and edge rate limits, not identity.
+
+    **Citation:** if you use MAIVE in published or reported work, please cite:
+
+    > Irsova, Z., Bom, P.R.D., Havranek, T., & Rachinger, H. (2025). Spurious
+    > precision in meta-analysis of observational research. Nature
+    > Communications, 16, 8454. https://doi.org/10.1038/s41467-025-63261-0
+  license:
+    name: See repository LICENSE
+    url: https://github.com/PetrCala/maive-ui/blob/master/LICENSE
+
+servers:
+  - url: https://api.maive.eu
+    description: Production
+
+# Anonymous by design (D1) — no accounts, no API keys. Documented explicitly
+# rather than omitted, so linters don't flag a missing security definition.
+security: []
+
+tags:
+  - name: sync
+    description: Synchronous model runs (single request/response round trip).
+  - name: async
+    description: Asynchronous model runs (submit, then poll for a result).
+  - name: meta
+    description: Service metadata.
+
+paths:
+  /v1/run-model:
+    post:
+      tags: [sync]
+      operationId: runModel
+      summary: Run MAIVE, WAIVE, or WLS synchronously
+      description: |
+        Runs the requested model and returns the result in the same HTTP
+        response. Subject to Cloudflare's ~100s proxy cap at the edge — fine
+        for typical runs (roughly 15-60s including cold start), but
+        unsuitable for large or slow datasets. Prefer `POST /v1/runs` (async)
+        for anything that might run long. See §6.3 of the design doc.
+      parameters:
+        - $ref: "#/components/parameters/Include"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/RunModelRequest"
+            examples:
+              minimal:
+                summary: Minimal request (all parameters default)
+                value:
+                  data:
+                    - effect: 0.42
+                      se: 0.11
+                      n_obs: 120
+                    - effect: 0.31
+                      se: 0.06
+                      n_obs: 90
+                    - effect: 0.55
+                      se: 0.2
+                      n_obs: 45
+                    - effect: 0.12
+                      se: 0.04
+                      n_obs: 200
+              full:
+                summary: Explicit parameters
+                value:
+                  data:
+                    - effect: 0.42
+                      se: 0.11
+                      n_obs: 120
+                      study_id: Smith2020
+                    - effect: 0.31
+                      se: 0.06
+                      n_obs: 90
+                      study_id: Smith2020
+                    - effect: 0.55
+                      se: 0.2
+                      n_obs: 45
+                      study_id: Jones2019
+                    - effect: 0.12
+                      se: 0.04
+                      n_obs: 200
+                      study_id: Jones2019
+                  parameters:
+                    modelType: MAIVE
+                    maiveMethod: PET-PEESE
+                    weight: equal_weights
+                    standardErrorTreatment: clustered_cr2
+                    includeStudyDummies: false
+                    includeStudyClustering: false
+                    computeAndersonRubin: false
+                    useLogFirstStage: false
+                    winsorize: 0
+      responses:
+        "200":
+          description: Model results.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ModelResults"
+        "400":
+          $ref: "#/components/responses/ValidationError"
+        "405":
+          $ref: "#/components/responses/MethodNotAllowed"
+        "429":
+          $ref: "#/components/responses/RateLimited"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /v1/run-rtma:
+    post:
+      tags: [sync]
+      operationId: runRtma
+      summary: Run RTMA (Right-Truncated Meta-Analysis) synchronously
+      description: |
+        Same synchronous envelope and edge-cap caveat as `POST /v1/run-model`.
+        See §6.4 of the design doc.
+      parameters:
+        - $ref: "#/components/parameters/Include"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/RunRtmaRequest"
+            examples:
+              minimal:
+                summary: Minimal request (all parameters default)
+                value:
+                  data:
+                    - effect: 0.42
+                      se: 0.11
+                    - effect: 0.31
+                      se: 0.06
+                    - effect: 0.55
+                      se: 0.2
+                    - effect: 0.12
+                      se: 0.04
+      responses:
+        "200":
+          description: RTMA results.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RTMAResults"
+        "400":
+          $ref: "#/components/responses/ValidationError"
+        "405":
+          $ref: "#/components/responses/MethodNotAllowed"
+        "429":
+          $ref: "#/components/responses/RateLimited"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /v1/runs:
+    post:
+      tags: [async]
+      operationId: submitRun
+      summary: Submit an asynchronous run
+      description: |
+        Queues a model run and returns immediately with a `jobId`. Poll
+        `GET /v1/runs/{jobId}` until the status is terminal, then read
+        `result`. Recommended as the default integration path — immune to the
+        edge's ~100s proxy cap. See §6.5 of the design doc.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SubmitRunRequest"
+            examples:
+              maive:
+                summary: Submit a MAIVE run
+                value:
+                  modelType: MAIVE
+                  data:
+                    - effect: 0.42
+                      se: 0.11
+                      n_obs: 120
+                    - effect: 0.31
+                      se: 0.06
+                      n_obs: 90
+                    - effect: 0.55
+                      se: 0.2
+                      n_obs: 45
+                    - effect: 0.12
+                      se: 0.04
+                      n_obs: 200
+              rtma:
+                summary: Submit an RTMA run
+                value:
+                  modelType: RTMA
+                  data:
+                    - effect: 0.42
+                      se: 0.11
+                    - effect: 0.31
+                      se: 0.06
+                    - effect: 0.55
+                      se: 0.2
+                    - effect: 0.12
+                      se: 0.04
+      responses:
+        "200":
+          description: Run queued.
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [jobId]
+                properties:
+                  jobId:
+                    type: string
+                    description: >-
+                      Opaque bearer token. Anyone holding it can read the run
+                      for 48h — treat it like a share link.
+                    example: "8f14e45f-ceea-467e-9e42-1c0e0f5a4e3e"
+        "400":
+          $ref: "#/components/responses/ValidationError"
+        "405":
+          $ref: "#/components/responses/MethodNotAllowed"
+        "413":
+          $ref: "#/components/responses/PayloadTooLarge"
+        "429":
+          $ref: "#/components/responses/RateLimited"
+        "500":
+          $ref: "#/components/responses/InternalError"
+        "503":
+          $ref: "#/components/responses/NotConfigured"
+    get:
+      tags: [async]
+      operationId: listRunStatuses
+      summary: Batch status lookup
+      description: |
+        Returns status (no `result`) for up to 100 job ids in one call. Used
+        for polling multiple runs at once (e.g. a "my runs" list). Unknown ids
+        are silently omitted from the response — this endpoint never 404s.
+      parameters:
+        - name: ids
+          in: query
+          required: false
+          description: Comma-separated list of job ids (max 100).
+          schema:
+            type: string
+          example: "8f14e45f-ceea-467e-9e42-1c0e0f5a4e3e,3c9e2f10-9b7a-4b1a-9a1a-2f6b8e7c1d2a"
+      responses:
+        "200":
+          description: Status for each recognized id (may be empty).
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/RunStatusSummary"
+        "405":
+          $ref: "#/components/responses/MethodNotAllowed"
+        "500":
+          $ref: "#/components/responses/InternalError"
+        "503":
+          $ref: "#/components/responses/NotConfigured"
+
+  /v1/runs/{jobId}:
+    get:
+      tags: [async]
+      operationId: getRun
+      summary: Poll a run / fetch its result
+      description: |
+        Returns the run's current status. Once `status` is `succeeded`,
+        `result` is populated with the parsed `ModelResults` or `RTMAResults`
+        object (never a JSON-encoded string). Suggested polling interval:
+        every 2-5s. Runs expire and start 404ing 48h after submission.
+      parameters:
+        - name: jobId
+          in: path
+          required: true
+          schema:
+            type: string
+          example: "8f14e45f-ceea-467e-9e42-1c0e0f5a4e3e"
+        - $ref: "#/components/parameters/Include"
+      responses:
+        "200":
+          description: Run status (and result, once terminal-successful).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Run"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "405":
+          $ref: "#/components/responses/MethodNotAllowed"
+        "500":
+          $ref: "#/components/responses/InternalError"
+        "503":
+          $ref: "#/components/responses/NotConfigured"
+
+  /v1/health:
+    get:
+      tags: [meta]
+      operationId: health
+      summary: Health check
+      description: Alias of the existing `/health` route. No auth, no rate limiting.
+      responses:
+        "200":
+          description: Service is healthy.
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [status, time]
+                properties:
+                  status:
+                    type: string
+                    example: ok
+                  time:
+                    type: string
+                    description: Server time (UTC).
+                    example: "2026-07-08 12:34:56 UTC"
+        "405":
+          $ref: "#/components/responses/MethodNotAllowed"
+
+components:
+  parameters:
+    Include:
+      name: include
+      in: query
+      required: false
+      description: >-
+        Set to `plot` to embed the base64-encoded plot image(s) in the
+        response. Omitted by default (D7) — the plot is ~50KB and most
+        programmatic callers don't need it.
+      schema:
+        type: string
+        enum: [plot]
+
+  responses:
+    ValidationError:
+      description: The request body failed validation.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Error"
+          example:
+            error:
+              code: validation_error
+              message: "Data must have 3 or 4 columns; found 6."
+    NotFound:
+      description: The requested resource does not exist or has expired.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Error"
+          example:
+            error:
+              code: not_found
+              message: "Run not found or expired."
+    MethodNotAllowed:
+      description: The HTTP method is not supported on this route.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Error"
+          example:
+            error:
+              code: method_not_allowed
+              message: "Method Not Allowed"
+    PayloadTooLarge:
+      description: >-
+        The dataset is too large to queue (SQS message budget, ~200KB). Use
+        the synchronous endpoint instead.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Error"
+          example:
+            error:
+              code: payload_too_large
+              message: "Dataset too large to queue; use POST /v1/run-model or /v1/run-rtma instead."
+    RateLimited:
+      description: >-
+        Too many requests — either the edge rate limit or the server-side
+        concurrency cap was hit. Retry with backoff.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Error"
+          example:
+            error:
+              code: rate_limited
+              message: "Too many requests. Please retry after a short delay."
+    InternalError:
+      description: An unexpected server-side error occurred.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Error"
+          example:
+            error:
+              code: internal_error
+              message: "Internal server error."
+    NotConfigured:
+      description: This deployment does not have the async runs infrastructure configured.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Error"
+          example:
+            error:
+              code: not_configured
+              message: "Async runs are not configured."
+
+  schemas:
+    Error:
+      type: object
+      required: [error]
+      properties:
+        error:
+          type: object
+          required: [code, message]
+          properties:
+            code:
+              type: string
+              enum:
+                - validation_error
+                - not_found
+                - method_not_allowed
+                - payload_too_large
+                - rate_limited
+                - internal_error
+                - not_configured
+            message:
+              type: string
+
+    DataRow:
+      type: object
+      description: |
+        One row of meta-analysis input data. Columns are resolved by the
+        canonical keys below when present; otherwise the first 3-4 keys of
+        the object are taken positionally as (effect, se, n_obs[, study_id])
+        for MAIVE-family endpoints, or (effect, se) for RTMA (D5).
+      properties:
+        effect:
+          type: number
+          description: Estimated effect size.
+        se:
+          type: number
+          description: Standard error of the effect estimate. Must be > 0.
+        n_obs:
+          type: integer
+          description: >-
+            Number of observations underlying the estimate. Required for
+            MAIVE-family endpoints (not used by RTMA). Must be a positive
+            integer.
+        study_id:
+          type: string
+          description: >-
+            Optional study identifier, used for clustering. If present across
+            rows, the number of rows must be at least the number of unique
+            study ids plus 3.
+      additionalProperties: true
+      example:
+        effect: 0.42
+        se: 0.11
+        n_obs: 120
+        study_id: Smith2020
+
+    ModelParameters:
+      type: object
+      description: >-
+        All parameters are optional; defaults match the UI's
+        `CONFIG.DEFAULT_MODEL_PARAMETERS`. A minimal valid request is just
+        `{"data": [...]}` (D6).
+      properties:
+        modelType:
+          type: string
+          enum: [MAIVE, WAIVE, WLS]
+          default: MAIVE
+        maiveMethod:
+          type: string
+          enum: [PET, PEESE, PET-PEESE, EK]
+          default: PET-PEESE
+        weight:
+          type: string
+          enum:
+            [
+              equal_weights,
+              standard_weights,
+              adjusted_weights,
+              study_weights,
+            ]
+          default: equal_weights
+        standardErrorTreatment:
+          type: string
+          enum: [not_clustered, clustered, clustered_cr2, bootstrap]
+          default: clustered_cr2
+        includeStudyDummies:
+          type: boolean
+          default: false
+        includeStudyClustering:
+          type: boolean
+          default: false
+        computeAndersonRubin:
+          type: boolean
+          default: false
+        useLogFirstStage:
+          type: boolean
+          default: false
+        winsorize:
+          type: number
+          description: Winsorization percentage applied to effect sizes and standard errors. 0 disables it.
+          default: 0
+        shouldUseInstrumenting:
+          type: boolean
+          description: >-
+            Internal parameter, not required knowledge for callers. Derived
+            from `modelType` unless explicitly set: `false` when `modelType`
+            is `WLS`, `true` otherwise.
+
+    RTMAParameters:
+      type: object
+      description: All parameters are optional. See §6.4 of the design doc.
+      properties:
+        favorPositive:
+          type: boolean
+          default: true
+        alphaSelect:
+          type: number
+          default: 0.05
+        ciLevel:
+          type: number
+          default: 0.95
+        winsorize:
+          type: number
+          description: Winsorization percentage applied to effect sizes and standard errors. 0 disables it.
+          default: 0
+
+    RunModelRequest:
+      type: object
+      required: [data]
+      properties:
+        data:
+          type: array
+          minItems: 4
+          description: >-
+            3 or 4 columns; at least 4 rows; `effect`/`se`/`n_obs` numeric;
+            `se > 0`; `n_obs` positive integers; if `study_id` is present,
+            rows must be >= unique studies + 3 (§6.2).
+          items:
+            $ref: "#/components/schemas/DataRow"
+        parameters:
+          $ref: "#/components/schemas/ModelParameters"
+
+    RunRtmaRequest:
+      type: object
+      required: [data]
+      properties:
+        data:
+          type: array
+          minItems: 2
+          description: >-
+            At least 2 columns (`effect`, `se`). Rows with missing or
+            non-positive `se` are dropped with a warning (§6.2).
+          items:
+            $ref: "#/components/schemas/DataRow"
+        parameters:
+          $ref: "#/components/schemas/RTMAParameters"
+
+    SubmitRunRequest:
+      type: object
+      required: [data]
+      properties:
+        data:
+          type: array
+          items:
+            $ref: "#/components/schemas/DataRow"
+        parameters:
+          description: >-
+            `ModelParameters` if `modelType` is `MAIVE`/`WAIVE`/`WLS`, or
+            `RTMAParameters` if `modelType` is `RTMA`.
+          oneOf:
+            - $ref: "#/components/schemas/ModelParameters"
+            - $ref: "#/components/schemas/RTMAParameters"
+        modelType:
+          type: string
+          enum: [MAIVE, WAIVE, WLS, RTMA]
+          default: MAIVE
+          description: Routes the queued run to the MAIVE-family or RTMA compute path.
+
+    CIInterval:
+      description: A `[lower, upper]` confidence interval, or `"NA"` when not computed.
+      oneOf:
+        - type: array
+          items:
+            type: number
+          minItems: 2
+          maxItems: 2
+        - type: string
+          enum: ["NA"]
+
+    ModelResults:
+      type: object
+      description: >-
+        Result of `POST /v1/run-model`. Field names mirror the internal R
+        result object 1:1 (`maive_model.R`, `run_maive_model`) — they are
+        already the de-facto contract for the UI and reproducibility
+        packages, and are frozen as-is (§11).
+      required:
+        - effectEstimate
+        - standardError
+        - isSignificant
+        - andersonRubinCI
+        - publicationBias
+        - firstStageFStatistic
+        - hausmanTest
+        - seInstrumented
+        - bootSE
+        - bootCI
+      properties:
+        effectEstimate:
+          type: number
+        standardError:
+          type: number
+        isSignificant:
+          type: boolean
+        andersonRubinCI:
+          $ref: "#/components/schemas/CIInterval"
+        publicationBias:
+          type: object
+          required: [eggerCoef, eggerSE, isSignificant, eggerBootCI, eggerAndersonRubinCI]
+          properties:
+            eggerCoef:
+              type: number
+            eggerSE:
+              type: number
+            isSignificant:
+              type: boolean
+            eggerBootCI:
+              $ref: "#/components/schemas/CIInterval"
+            eggerAndersonRubinCI:
+              $ref: "#/components/schemas/CIInterval"
+            pValue:
+              type: number
+        firstStageFStatistic:
+          description: Numeric F-statistic, or `"NA"` when not computed (e.g. no instrumenting).
+          oneOf:
+            - type: number
+            - type: string
+              enum: ["NA"]
+        hausmanTest:
+          type: object
+          required: [statistic, criticalValue, rejectsNull]
+          properties:
+            statistic:
+              type: number
+            criticalValue:
+              type: number
+            rejectsNull:
+              type: boolean
+        seInstrumented:
+          type: array
+          items:
+            type: number
+        bootSE:
+          description: '`[se_lower, se_upper]`, or `"NA"` when bootstrap SE was not requested/computed.'
+          oneOf:
+            - type: array
+              items:
+                type: number
+              minItems: 2
+              maxItems: 2
+            - type: string
+              enum: ["NA"]
+        bootCI:
+          description: A pair of confidence intervals `[[lo, hi], [lo, hi]]`, or `"NA"`.
+          oneOf:
+            - type: array
+              items:
+                type: array
+                items:
+                  type: number
+                minItems: 2
+                maxItems: 2
+              minItems: 2
+              maxItems: 2
+            - type: string
+              enum: ["NA"]
+        firstStage:
+          nullable: true
+          type: object
+          properties:
+            mode:
+              type: string
+              enum: [levels, log]
+            description:
+              type: string
+            fStatisticLabel:
+              type: string
+        petpeese_selected:
+          nullable: true
+          type: string
+          enum: [PET, PEESE]
+        peese_se2_coef:
+          nullable: true
+          type: number
+        peese_se2_se:
+          nullable: true
+          type: number
+        slope_coef:
+          description: A single slope coefficient, or a kink description when the fit is piecewise.
+          oneOf:
+            - type: number
+            - type: object
+              properties:
+                kink_effect:
+                  type: number
+                kink_location:
+                  type: number
+        is_quadratic_fit:
+          type: object
+          properties:
+            quadratic:
+              type: boolean
+            slope_type:
+              type: string
+            slope_detail:
+              nullable: true
+              type: object
+              properties:
+                kink_location:
+                  type: number
+                kink_effect:
+                  type: number
+        funnelPlot:
+          type: string
+          description: 'Base64-encoded PNG data URI. Only present with `?include=plot`.'
+        funnelPlotWidth:
+          type: number
+          description: Only present with `?include=plot`.
+        funnelPlotHeight:
+          type: number
+          description: Only present with `?include=plot`.
+
+    RTMAResults:
+      type: object
+      description: >-
+        Result of `POST /v1/run-rtma`. Field names mirror the internal R
+        result object 1:1 (`rtma_model.R`, `run_rtma_model`).
+      required:
+        - mu
+        - muCI
+        - tau
+        - tauCI
+        - nonaffirmativeCount
+        - nonaffirmativeProportion
+      properties:
+        mu:
+          type: number
+        muCI:
+          type: array
+          items:
+            type: number
+          minItems: 2
+          maxItems: 2
+        tau:
+          type: number
+        tauCI:
+          type: array
+          items:
+            type: number
+          minItems: 2
+          maxItems: 2
+        nonaffirmativeCount:
+          type: integer
+        nonaffirmativeProportion:
+          type: number
+        zScorePlot:
+          type: string
+          description: 'Base64-encoded PNG data URI. Only present with `?include=plot`.'
+        zScorePlotWidth:
+          type: number
+          description: Only present with `?include=plot`.
+        zScorePlotHeight:
+          type: number
+          description: Only present with `?include=plot`.
+
+    RunStatus:
+      type: string
+      enum: [queued, running, succeeded, failed, timedout]
+
+    RunStatusSummary:
+      type: object
+      description: Status-only view returned by the batch `GET /v1/runs?ids=` lookup (no `result`).
+      required: [jobId, status]
+      properties:
+        jobId:
+          type: string
+        status:
+          $ref: "#/components/schemas/RunStatus"
+        modelType:
+          type: string
+          enum: [MAIVE, WAIVE, WLS, RTMA]
+        errorMessage:
+          type: string
+        runDurationMs:
+          type: number
+        runTimestamp:
+          type: string
+          format: date-time
+
+    Run:
+      type: object
+      description: Full run object returned by `GET /v1/runs/{jobId}`.
+      required: [jobId, status]
+      properties:
+        jobId:
+          type: string
+        status:
+          $ref: "#/components/schemas/RunStatus"
+        modelType:
+          type: string
+          enum: [MAIVE, WAIVE, WLS, RTMA]
+        runDurationMs:
+          type: number
+        runTimestamp:
+          type: string
+          format: date-time
+        result:
+          description: >-
+            Parsed result object, present once `status` is `succeeded`.
+            `ModelResults` for `MAIVE`/`WAIVE`/`WLS` runs, `RTMAResults` for
+            `RTMA` runs.
+          oneOf:
+            - $ref: "#/components/schemas/ModelResults"
+            - $ref: "#/components/schemas/RTMAResults"
+        errorMessage:
+          type: string
+          description: Present on `failed`/`timedout`.


### PR DESCRIPTION
## Summary

- `docs/api/openapi.yaml` — OpenAPI 3 spec for the `/v1` public API contract locked in `docs/PUBLIC_API_DESIGN.md` §6 (D10: the in-repo source of truth). Covers `POST /v1/run-model`, `POST /v1/run-rtma`, `POST /v1/runs`, `GET /v1/runs` (batch), `GET /v1/runs/{jobId}`, `GET /v1/health`. Schemas for the data row contract, `ModelParameters`/`RTMAParameters` (enums/defaults matching `CONFIG.DEFAULT_MODEL_PARAMETERS`), `ModelResults`/`RTMAResults` (field names verified against `apps/react-ui/client/src/types/api.ts` and the R result objects in `maive_model.R`/`rtma_model.R`), the async `Run` object, and the shared error envelope. Validated with `@redocly/cli lint` — zero errors, zero warnings.
- `docs/PUBLIC_API.md` — usage guide: sync-vs-async guidance (async recommended by default; sync capped by Cloudflare's ~100s proxy limit), data requirements table, copy-paste curl/R (`httr2`)/Python (`requests`) examples for both a synchronous run and a full async submit→poll→fetch cycle, `jobId` bearer-token/48h-TTL semantics, privacy notes, rate-limit expectations, and the mandatory Nature Communications (2025) citation.

Docs-only — no application code changes. Both files note that `api.maive.eu` is not yet live (Phase 2 of the design doc) so early readers aren't confused.

## Test plan

- [x] `npx @redocly/cli lint docs/api/openapi.yaml` passes with 0 errors, 0 warnings
- [x] Result field names cross-checked against `apps/react-ui/client/src/types/api.ts` (`ModelResults`, `RTMAResults`) and `run_maive_model`/`run_rtma_model` in the R backend
- [x] Parameter enums/defaults cross-checked against `CONFIG.DEFAULT_MODEL_PARAMETERS`
- [x] Data constraints (3-4 cols / ≥4 rows for MAIVE-family, ≥2 cols for RTMA, `study_id` clustering rule) cross-checked against `pages/validation/index.tsx`
- [x] Citation text matches `citationUtils.ts` verbatim

🤖 Generated with [Claude Code](https://claude.com/claude-code)