### PR TITLE
feat: add public /api/v1/runs async routes

### DIFF
--- a/apps/react-ui/client/src/api/server/datasetValidation.ts
+++ b/apps/react-ui/client/src/api/server/datasetValidation.ts
@@ -1,0 +1,182 @@
+import CONST from "@src/CONST";
+
+// Server-side validation for the public `/v1/runs` submit endpoint (design
+// §6.2). Mirrors the rules on the UI's validation page
+// (`src/pages/validation/index.tsx`), adapted for arbitrary JSON row objects
+// resolved by canonical column name with positional fallback (D5), since API
+// callers don't go through the UI's interactive column-mapping step.
+
+export const MIN_MAIVE_ROWS = 4;
+
+export type ResolvedColumns = {
+  effect: string;
+  se: string;
+  nObs?: string;
+  studyId?: string;
+};
+
+export type ValidationError = { message: string };
+
+const findKeyCaseInsensitive = (
+  row: Record<string, unknown>,
+  name: string,
+): string | undefined =>
+  Object.keys(row).find((key) => key.toLowerCase() === name);
+
+/**
+ * Resolves the effect/se/n_obs/study_id columns from the first row: by
+ * canonical name when `effect`, `se`, and `n_obs` are all present; otherwise
+ * positionally, taking the first 3-4 keys in order (D5). Positional fallback
+ * also covers RTMA's 2-column (effect, se) shape.
+ */
+export const resolveColumns = (
+  rows: Array<Record<string, unknown>>,
+): ResolvedColumns | null => {
+  const first = rows[0];
+  if (!first) {
+    return null;
+  }
+
+  const effectKey = findKeyCaseInsensitive(first, "effect");
+  const seKey = findKeyCaseInsensitive(first, "se");
+  const nObsKey = findKeyCaseInsensitive(first, "n_obs");
+  const studyIdKey = findKeyCaseInsensitive(first, "study_id");
+
+  if (effectKey && seKey && nObsKey) {
+    return { effect: effectKey, se: seKey, nObs: nObsKey, studyId: studyIdKey };
+  }
+
+  const keys = Object.keys(first);
+  if (keys.length < 2) {
+    return null;
+  }
+  return { effect: keys[0], se: keys[1], nObs: keys[2], studyId: keys[3] };
+};
+
+const isFiniteNumber = (value: unknown): boolean => {
+  if (typeof value === "number") {
+    return Number.isFinite(value);
+  }
+  if (typeof value === "string" && value.trim() !== "") {
+    return Number.isFinite(Number(value));
+  }
+  return false;
+};
+
+const toNumber = (value: unknown): number =>
+  typeof value === "number" ? value : Number(value);
+
+export const validateDataset = (
+  data: unknown,
+  modelType: string,
+): ValidationError | null => {
+  if (!Array.isArray(data) || data.length === 0) {
+    return { message: "`data` must be a non-empty array of row objects." };
+  }
+
+  const hasInvalidRow = data.some(
+    (row) => typeof row !== "object" || row === null || Array.isArray(row),
+  );
+  if (hasInvalidRow) {
+    return { message: "Each row in `data` must be a JSON object." };
+  }
+
+  const rows = data as Array<Record<string, unknown>>;
+  const columns = resolveColumns(rows);
+  const isRtma = modelType === CONST.MODEL_TYPES.RTMA;
+
+  if (!columns?.effect || !columns.se) {
+    return {
+      message:
+        "Could not resolve `effect` and `se` columns from `data`. Use canonical names (effect, se[, n_obs, study_id]) or provide them positionally.",
+    };
+  }
+
+  if (!isRtma) {
+    const resolvedCount = [
+      columns.effect,
+      columns.se,
+      columns.nObs,
+      columns.studyId,
+    ].filter(Boolean).length;
+
+    if (!columns.nObs || resolvedCount < 3 || resolvedCount > 4) {
+      return {
+        message: `Data must have 3 or 4 columns; found ${resolvedCount}.`,
+      };
+    }
+
+    if (rows.length < MIN_MAIVE_ROWS) {
+      return {
+        message: `Data must contain at least ${MIN_MAIVE_ROWS} rows; found ${rows.length}.`,
+      };
+    }
+  }
+
+  const nonNumericColumn = (
+    key: string,
+    label: string,
+  ): ValidationError | null =>
+    rows.some((row) => !isFiniteNumber(row[key]))
+      ? { message: `The \`${label}\` column contains non-numeric values.` }
+      : null;
+
+  const effectError = nonNumericColumn(columns.effect, "effect");
+  if (effectError) {
+    return effectError;
+  }
+
+  const seError = nonNumericColumn(columns.se, "se");
+  if (seError) {
+    return seError;
+  }
+
+  if (!isRtma && columns.nObs) {
+    const nObsError = nonNumericColumn(columns.nObs, "n_obs");
+    if (nObsError) {
+      return nObsError;
+    }
+  }
+
+  const hasNonPositiveSe = rows.some((row) => toNumber(row[columns.se]) <= 0);
+  if (hasNonPositiveSe) {
+    return {
+      message:
+        "The `se` column must contain only positive values (greater than 0).",
+    };
+  }
+
+  if (!isRtma && columns.nObs) {
+    const nObsKey = columns.nObs;
+    const hasInvalidNObs = rows.some((row) => {
+      const value = toNumber(row[nObsKey]);
+      return value <= 0 || !Number.isInteger(value);
+    });
+    if (hasInvalidNObs) {
+      return {
+        message:
+          "The `n_obs` column must contain only positive integers (greater than 0).",
+      };
+    }
+  }
+
+  if (!isRtma && columns.studyId) {
+    const studyIdKey = columns.studyId;
+    const uniqueStudyIds = new Set(
+      rows
+        .map((row) => row[studyIdKey])
+        .filter(
+          (value) => value !== undefined && value !== null && value !== "",
+        ),
+    ).size;
+
+    if (rows.length < uniqueStudyIds + 3) {
+      return {
+        message:
+          "The number of rows must be larger than the number of unique study IDs plus 3.",
+      };
+    }
+  }
+
+  return null;
+};

--- a/apps/react-ui/client/src/api/server/errorEnvelope.ts
+++ b/apps/react-ui/client/src/api/server/errorEnvelope.ts
@@ -1,0 +1,37 @@
+import type { NextApiResponse } from "next";
+
+// Structured error envelope for the public `/v1` API (design §6.1). The
+// legacy `/api/runs*` routes intentionally keep their plain `{ error: string }`
+// shape and do not use this helper.
+
+export type ApiErrorCode =
+  | "validation_error"
+  | "not_found"
+  | "method_not_allowed"
+  | "payload_too_large"
+  | "rate_limited"
+  | "internal_error"
+  | "not_configured";
+
+export type ApiErrorBody = {
+  error: {
+    code: ApiErrorCode;
+    message: string;
+  };
+};
+
+const STATUS_BY_CODE: Record<ApiErrorCode, number> = {
+  validation_error: 400,
+  not_found: 404,
+  method_not_allowed: 405,
+  payload_too_large: 413,
+  rate_limited: 429,
+  internal_error: 500,
+  not_configured: 503,
+};
+
+export const sendApiError = (
+  res: NextApiResponse<ApiErrorBody>,
+  code: ApiErrorCode,
+  message: string,
+) => res.status(STATUS_BY_CODE[code]).json({ error: { code, message } });

--- a/apps/react-ui/client/src/api/server/modelParameterDefaults.ts
+++ b/apps/react-ui/client/src/api/server/modelParameterDefaults.ts
@@ -1,0 +1,77 @@
+import CONST from "@src/CONST";
+import CONFIG from "@src/CONFIG";
+import type { ModelParameters, RTMAParameters } from "@src/types/api";
+
+// Applies the `/v1/runs` parameter defaults (design D6, §6.5): a minimal
+// valid request is `{ "data": [...] }` — `modelType` defaults to the UI's
+// default model type, and unset parameters fall back to
+// `CONFIG.DEFAULT_MODEL_PARAMETERS`. `modelType: "RTMA"` routes to the RTMA
+// defaults instead, since RTMA has its own parameter shape.
+
+const RTMA_DEFAULTS: Omit<RTMAParameters, "modelType"> = {
+  favorPositive: true,
+  alphaSelect: 0.05,
+  ciLevel: 0.95,
+  winsorize: 0,
+};
+
+export type ResolvedRunParameters = {
+  modelType: string;
+  parameters: ModelParameters | RTMAParameters;
+};
+
+const asOverrides = (parametersInput: unknown): Record<string, unknown> =>
+  parametersInput &&
+  typeof parametersInput === "object" &&
+  !Array.isArray(parametersInput)
+    ? (parametersInput as Record<string, unknown>)
+    : {};
+
+export const resolveRunParameters = (
+  modelTypeInput: unknown,
+  parametersInput: unknown,
+): ResolvedRunParameters => {
+  const overrides = asOverrides(parametersInput);
+
+  const requestedModelType =
+    typeof modelTypeInput === "string" && modelTypeInput.length > 0
+      ? modelTypeInput
+      : CONFIG.DEFAULT_MODEL_PARAMETERS.modelType;
+
+  if (requestedModelType === CONST.MODEL_TYPES.RTMA) {
+    const parameters: RTMAParameters = {
+      modelType: "RTMA",
+      favorPositive:
+        typeof overrides.favorPositive === "boolean"
+          ? overrides.favorPositive
+          : RTMA_DEFAULTS.favorPositive,
+      alphaSelect:
+        typeof overrides.alphaSelect === "number"
+          ? overrides.alphaSelect
+          : RTMA_DEFAULTS.alphaSelect,
+      ciLevel:
+        typeof overrides.ciLevel === "number"
+          ? overrides.ciLevel
+          : RTMA_DEFAULTS.ciLevel,
+      winsorize:
+        typeof overrides.winsorize === "number"
+          ? overrides.winsorize
+          : RTMA_DEFAULTS.winsorize,
+    };
+    return { modelType: "RTMA", parameters };
+  }
+
+  const shouldUseInstrumenting =
+    typeof overrides.shouldUseInstrumenting === "boolean"
+      ? overrides.shouldUseInstrumenting
+      : requestedModelType !== CONST.MODEL_TYPES.WLS;
+
+  const parameters: ModelParameters = {
+    ...CONFIG.DEFAULT_MODEL_PARAMETERS,
+    ...overrides,
+    modelType: requestedModelType as ModelParameters["modelType"],
+    shouldUseInstrumenting,
+  };
+
+  return { modelType: requestedModelType, parameters };
+};

--- a/apps/react-ui/client/src/api/server/runsService.ts
+++ b/apps/react-ui/client/src/api/server/runsService.ts
@@ -1,0 +1,239 @@
+import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
+import {
+  DynamoDBDocumentClient,
+  PutCommand,
+  GetCommand,
+  BatchGetCommand,
+} from "@aws-sdk/lib-dynamodb";
+import { SQSClient, SendMessageCommand } from "@aws-sdk/client-sqs";
+import type { GetRunResponse, RunStatus } from "@src/types/api";
+import { generateJobId } from "@src/utils/idUtils";
+import CONST from "@src/CONST";
+
+// Shared DynamoDB/SQS access for the async runs pipeline. Reused by the
+// legacy `/api/runs*` routes and the public `/api/v1/runs*` routes so both
+// surfaces talk to the same queue/table without duplicating client setup.
+
+const region =
+  process.env.AWS_REGION ?? process.env.AWS_DEFAULT_REGION ?? undefined;
+export const runsTableName = process.env.RUNS_TABLE_NAME;
+export const runsQueueUrl = process.env.RUNS_QUEUE_URL;
+
+export const TTL_SECONDS = CONST.RUNS.TTL_SECONDS; // 48h pickup buffer
+// Keep the SQS message under the 256KB hard limit; larger datasets fall back
+// to the synchronous path (which posts directly to the R Lambda).
+export const MAX_QUEUE_BODY_BYTES = 200 * 1024;
+export const MAX_BATCH_IDS = 100; // DynamoDB BatchGetItem caps at 100 keys
+
+let ddbDocClient: DynamoDBDocumentClient | undefined;
+let sqsClient: SQSClient | undefined;
+
+export const getDdbDocClient = (): DynamoDBDocumentClient | undefined => {
+  if (!region) {
+    return undefined;
+  }
+  if (!ddbDocClient) {
+    ddbDocClient = DynamoDBDocumentClient.from(new DynamoDBClient({ region }));
+  }
+  return ddbDocClient;
+};
+
+export const getSqsClient = (): SQSClient | undefined => {
+  if (!region) {
+    return undefined;
+  }
+  if (!sqsClient) {
+    sqsClient = new SQSClient({ region });
+  }
+  return sqsClient;
+};
+
+export type RunsStoreConfig = {
+  ddb: DynamoDBDocumentClient;
+  tableName: string;
+};
+
+export const getRunsStoreConfig = (): RunsStoreConfig | undefined => {
+  if (!runsTableName) {
+    return undefined;
+  }
+  const ddb = getDdbDocClient();
+  if (!ddb) {
+    return undefined;
+  }
+  return { ddb, tableName: runsTableName };
+};
+
+export type RunsQueueConfig = {
+  sqs: SQSClient;
+  queueUrl: string;
+};
+
+export const getRunsQueueConfig = (): RunsQueueConfig | undefined => {
+  if (!runsQueueUrl) {
+    return undefined;
+  }
+  const sqs = getSqsClient();
+  if (!sqs) {
+    return undefined;
+  }
+  return { sqs, queueUrl: runsQueueUrl };
+};
+
+export const parseIdsParam = (
+  idsParam: string | string[] | undefined,
+  max: number = MAX_BATCH_IDS,
+): string[] => {
+  const idsRaw = Array.isArray(idsParam)
+    ? idsParam.join(",")
+    : (idsParam ?? "");
+  return idsRaw
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean)
+    .slice(0, max);
+};
+
+export const batchGetRunStatuses = async (
+  ddb: DynamoDBDocumentClient,
+  tableName: string,
+  ids: string[],
+): Promise<GetRunResponse[]> => {
+  if (ids.length === 0) {
+    return [];
+  }
+
+  const out = await ddb.send(
+    new BatchGetCommand({
+      RequestItems: {
+        [tableName]: {
+          Keys: ids.map((id) => ({ jobId: id })),
+          // Status-only projection (no heavy `result`) — the list/watcher
+          // only needs status; the full result is fetched per-run elsewhere.
+          ProjectionExpression:
+            "jobId, #status, modelType, errorMessage, runDurationMs, submittedAt",
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          ExpressionAttributeNames: { "#status": "status" },
+        },
+      },
+    }),
+  );
+
+  const items = out.Responses?.[tableName] ?? [];
+  return items.map((item) => ({
+    jobId: item.jobId as string,
+    status: item.status as RunStatus,
+    modelType: item.modelType as GetRunResponse["modelType"],
+    errorMessage: (item.errorMessage as string | undefined) ?? undefined,
+    runDurationMs:
+      typeof item.runDurationMs === "number" ? item.runDurationMs : undefined,
+    runTimestamp:
+      typeof item.submittedAt === "number"
+        ? new Date(item.submittedAt).toISOString()
+        : undefined,
+  }));
+};
+
+export type RunItem = {
+  jobId: string;
+  status: RunStatus;
+  modelType?: GetRunResponse["modelType"];
+  result?: string;
+  errorMessage?: string;
+  runDurationMs?: number;
+  submittedAt?: number;
+};
+
+export const getRunItem = async (
+  ddb: DynamoDBDocumentClient,
+  tableName: string,
+  jobId: string,
+): Promise<RunItem | undefined> => {
+  // Single GetItem with a projection. While the run is non-terminal the
+  // `result` attribute doesn't exist yet (cheap read); callers stop polling
+  // on a terminal status, so the heavy result is read exactly once.
+  const { Item } = await ddb.send(
+    new GetCommand({
+      TableName: tableName,
+      Key: { jobId },
+      ProjectionExpression:
+        "jobId, #status, modelType, #result, errorMessage, runDurationMs, submittedAt",
+      ExpressionAttributeNames: {
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        "#status": "status",
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        "#result": "result",
+      },
+    }),
+  );
+
+  if (!Item) {
+    return undefined;
+  }
+
+  return Item as RunItem;
+};
+
+export type SubmitRunParams = {
+  data: unknown;
+  parameters: unknown;
+  modelType: string;
+  dataId?: string | null;
+};
+
+export type SubmitRunOutcome =
+  | { outcome: "ok"; jobId: string }
+  | { outcome: "too_large" }
+  | { outcome: "error"; error: unknown };
+
+export const submitRun = async (
+  ddb: DynamoDBDocumentClient,
+  sqs: SQSClient,
+  tableName: string,
+  queueUrl: string,
+  params: SubmitRunParams,
+): Promise<SubmitRunOutcome> => {
+  const jobId = generateJobId();
+  const messageBody = JSON.stringify({
+    jobId,
+    modelType: params.modelType,
+    data: params.data,
+    parameters: params.parameters,
+  });
+
+  // Too large to queue via SQS — caller falls back to the synchronous path.
+  if (Buffer.byteLength(messageBody, "utf8") > MAX_QUEUE_BODY_BYTES) {
+    return { outcome: "too_large" };
+  }
+
+  const now = Date.now();
+  const ttl = Math.floor(now / 1000) + TTL_SECONDS;
+
+  try {
+    await ddb.send(
+      new PutCommand({
+        TableName: tableName,
+        Item: {
+          jobId,
+          status: "queued",
+          modelType: params.modelType,
+          parameters: JSON.stringify(params.parameters),
+          dataId: params.dataId ?? null,
+          submittedAt: now,
+          ttl,
+        },
+      }),
+    );
+
+    await sqs.send(
+      new SendMessageCommand({
+        QueueUrl: queueUrl,
+        MessageBody: messageBody,
+      }),
+    );
+
+    return { outcome: "ok", jobId };
+  } catch (error) {
+    return { outcome: "error", error };
+  }
+};

--- a/apps/react-ui/client/src/pages/api/runs.ts
+++ b/apps/react-ui/client/src/pages/api/runs.ts
@@ -1,18 +1,13 @@
 import type { NextApiRequest, NextApiResponse } from "next";
-import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
+import type { SubmitRunResponse, GetRunResponse } from "@src/types/api";
 import {
-  DynamoDBDocumentClient,
-  PutCommand,
-  BatchGetCommand,
-} from "@aws-sdk/lib-dynamodb";
-import { SQSClient, SendMessageCommand } from "@aws-sdk/client-sqs";
-import type {
-  SubmitRunResponse,
-  GetRunResponse,
-  RunStatus,
-} from "@src/types/api";
-import { generateJobId } from "@src/utils/idUtils";
-import CONST from "@src/CONST";
+  MAX_BATCH_IDS,
+  batchGetRunStatuses,
+  getRunsQueueConfig,
+  getRunsStoreConfig,
+  parseIdsParam,
+  submitRun,
+} from "@api/server/runsService";
 
 // Allow larger request bodies than Next.js's 1mb default so we can accept a
 // dataset and decide whether to queue it or signal the synchronous fallback.
@@ -25,100 +20,25 @@ export const config = {
   },
 };
 
-const region =
-  process.env.AWS_REGION ?? process.env.AWS_DEFAULT_REGION ?? undefined;
-const tableName = process.env.RUNS_TABLE_NAME;
-const queueUrl = process.env.RUNS_QUEUE_URL;
-
-const TTL_SECONDS = CONST.RUNS.TTL_SECONDS; // 48h pickup buffer
-// Keep the SQS message under the 256KB hard limit; larger datasets fall back
-// to the synchronous path (which posts directly to the R Lambda).
-const MAX_QUEUE_BODY_BYTES = 200 * 1024;
-const MAX_BATCH_IDS = 100; // DynamoDB BatchGetItem caps at 100 keys
-
-let ddbDocClient: DynamoDBDocumentClient | undefined;
-let sqsClient: SQSClient | undefined;
-
-const getDdbDocClient = () => {
-  if (!region) {
-    return undefined;
-  }
-  if (!ddbDocClient) {
-    ddbDocClient = DynamoDBDocumentClient.from(new DynamoDBClient({ region }));
-  }
-  return ddbDocClient;
-};
-
-const getSqsClient = () => {
-  if (!region) {
-    return undefined;
-  }
-  if (!sqsClient) {
-    sqsClient = new SQSClient({ region });
-  }
-  return sqsClient;
-};
-
 const handler = async (
   req: NextApiRequest,
   res: NextApiResponse<
     SubmitRunResponse | GetRunResponse[] | { error: string }
   >,
 ) => {
-  if (!tableName) {
-    return res.status(503).json({ error: "Async runs are not configured." });
-  }
-
-  const ddb = getDdbDocClient();
-  if (!ddb) {
+  const store = getRunsStoreConfig();
+  if (!store) {
     return res.status(503).json({ error: "Async runs are not configured." });
   }
 
   // GET /api/runs?ids=a,b,c — batch status lookup for the My Runs list / watcher.
   if (req.method === "GET") {
-    const idsParam = req.query.ids;
-    const idsRaw = Array.isArray(idsParam)
-      ? idsParam.join(",")
-      : (idsParam ?? "");
-    const ids = idsRaw
-      .split(",")
-      .map((s) => s.trim())
-      .filter(Boolean)
-      .slice(0, MAX_BATCH_IDS);
+    const ids = parseIdsParam(req.query.ids, MAX_BATCH_IDS);
     if (ids.length === 0) {
       return res.status(200).json([]);
     }
     try {
-      const out = await ddb.send(
-        new BatchGetCommand({
-          RequestItems: {
-            [tableName]: {
-              Keys: ids.map((id) => ({ jobId: id })),
-              // Status-only projection (no heavy `result`) — the list/watcher
-              // only needs status; the full result is fetched per-run elsewhere.
-              ProjectionExpression:
-                "jobId, #status, modelType, errorMessage, runDurationMs, submittedAt",
-              // eslint-disable-next-line @typescript-eslint/naming-convention
-              ExpressionAttributeNames: { "#status": "status" },
-            },
-          },
-        }),
-      );
-      const items = out.Responses?.[tableName] ?? [];
-      const runs: GetRunResponse[] = items.map((item) => ({
-        jobId: item.jobId as string,
-        status: item.status as RunStatus,
-        modelType: item.modelType as GetRunResponse["modelType"],
-        errorMessage: (item.errorMessage as string | undefined) ?? undefined,
-        runDurationMs:
-          typeof item.runDurationMs === "number"
-            ? item.runDurationMs
-            : undefined,
-        runTimestamp:
-          typeof item.submittedAt === "number"
-            ? new Date(item.submittedAt).toISOString()
-            : undefined,
-      }));
+      const runs = await batchGetRunStatuses(store.ddb, store.tableName, ids);
       return res.status(200).json(runs);
     } catch (error) {
       console.error("Failed to batch-fetch runs", error);
@@ -131,8 +51,8 @@ const handler = async (
     return res.status(405).json({ error: "Method Not Allowed" });
   }
 
-  const sqs = getSqsClient();
-  if (!queueUrl || !sqs) {
+  const queue = getRunsQueueConfig();
+  if (!queue) {
     return res.status(503).json({ error: "Async runs are not configured." });
   }
 
@@ -149,45 +69,24 @@ const handler = async (
       .json({ error: "Missing required fields: data, parameters, modelType." });
   }
 
-  const jobId = generateJobId();
-  const messageBody = JSON.stringify({ jobId, modelType, data, parameters });
+  const submission = await submitRun(
+    store.ddb,
+    queue.sqs,
+    store.tableName,
+    queue.queueUrl,
+    { data, parameters, modelType, dataId },
+  );
 
-  // Too large to queue via SQS — caller falls back to the synchronous path.
-  if (Buffer.byteLength(messageBody, "utf8") > MAX_QUEUE_BODY_BYTES) {
+  if (submission.outcome === "too_large") {
     return res.status(200).json({ tooLarge: true });
   }
 
-  const now = Date.now();
-  const ttl = Math.floor(now / 1000) + TTL_SECONDS;
-
-  try {
-    await ddb.send(
-      new PutCommand({
-        TableName: tableName,
-        Item: {
-          jobId,
-          status: "queued",
-          modelType,
-          parameters: JSON.stringify(parameters),
-          dataId: dataId ?? null,
-          submittedAt: now,
-          ttl,
-        },
-      }),
-    );
-
-    await sqs.send(
-      new SendMessageCommand({
-        QueueUrl: queueUrl,
-        MessageBody: messageBody,
-      }),
-    );
-
-    return res.status(200).json({ jobId });
-  } catch (error) {
-    console.error("Failed to submit run", error);
+  if (submission.outcome === "error") {
+    console.error("Failed to submit run", submission.error);
     return res.status(500).json({ error: "Failed to submit run." });
   }
+
+  return res.status(200).json({ jobId: submission.jobId });
 };
 
 export default handler;

--- a/apps/react-ui/client/src/pages/api/runs/[jobId].ts
+++ b/apps/react-ui/client/src/pages/api/runs/[jobId].ts
@@ -1,23 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from "next";
-import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
-import { DynamoDBDocumentClient, GetCommand } from "@aws-sdk/lib-dynamodb";
-import type { GetRunResponse, RunStatus } from "@src/types/api";
-
-const region =
-  process.env.AWS_REGION ?? process.env.AWS_DEFAULT_REGION ?? undefined;
-const tableName = process.env.RUNS_TABLE_NAME;
-
-let ddbDocClient: DynamoDBDocumentClient | undefined;
-
-const getDdbDocClient = () => {
-  if (!region) {
-    return undefined;
-  }
-  if (!ddbDocClient) {
-    ddbDocClient = DynamoDBDocumentClient.from(new DynamoDBClient({ region }));
-  }
-  return ddbDocClient;
-};
+import type { GetRunResponse } from "@src/types/api";
+import { getRunItem, getRunsStoreConfig } from "@api/server/runsService";
 
 const handler = async (
   req: NextApiRequest,
@@ -28,12 +11,8 @@ const handler = async (
     return res.status(405).json({ error: "Method Not Allowed" });
   }
 
-  if (!tableName) {
-    return res.status(503).json({ error: "Async runs are not configured." });
-  }
-
-  const ddb = getDdbDocClient();
-  if (!ddb) {
+  const store = getRunsStoreConfig();
+  if (!store) {
     return res.status(503).json({ error: "Async runs are not configured." });
   }
 
@@ -44,45 +23,28 @@ const handler = async (
   }
 
   try {
-    // Single GetItem with a projection. While the run is non-terminal the
-    // `result` attribute doesn't exist yet (cheap read); the client stops
-    // polling on a terminal status, so the heavy result is read exactly once.
-    const { Item } = await ddb.send(
-      new GetCommand({
-        TableName: tableName,
-        Key: { jobId: id },
-        ProjectionExpression:
-          "jobId, #status, modelType, #result, errorMessage, runDurationMs, submittedAt",
-        ExpressionAttributeNames: {
-          // eslint-disable-next-line @typescript-eslint/naming-convention
-          "#status": "status",
-          // eslint-disable-next-line @typescript-eslint/naming-convention
-          "#result": "result",
-        },
-      }),
-    );
+    const item = await getRunItem(store.ddb, store.tableName, id);
 
-    if (!Item) {
+    if (!item) {
       return res.status(404).json({ error: "Run not found or expired." });
     }
 
-    const status = Item.status as RunStatus;
     const body: GetRunResponse = {
       jobId: id,
-      status,
-      modelType: Item.modelType as GetRunResponse["modelType"],
+      status: item.status,
+      modelType: item.modelType,
     };
-    if (Item.result) {
-      body.result = Item.result as string;
+    if (item.result) {
+      body.result = item.result;
     }
-    if (Item.errorMessage) {
-      body.errorMessage = Item.errorMessage as string;
+    if (item.errorMessage) {
+      body.errorMessage = item.errorMessage;
     }
-    if (typeof Item.runDurationMs === "number") {
-      body.runDurationMs = Item.runDurationMs;
+    if (typeof item.runDurationMs === "number") {
+      body.runDurationMs = item.runDurationMs;
     }
-    if (typeof Item.submittedAt === "number") {
-      body.runTimestamp = new Date(Item.submittedAt).toISOString();
+    if (typeof item.submittedAt === "number") {
+      body.runTimestamp = new Date(item.submittedAt).toISOString();
     }
 
     return res.status(200).json(body);

--- a/apps/react-ui/client/src/pages/api/v1/runs.ts
+++ b/apps/react-ui/client/src/pages/api/v1/runs.ts
@@ -1,0 +1,108 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import type { GetRunResponse } from "@src/types/api";
+import {
+  MAX_BATCH_IDS,
+  batchGetRunStatuses,
+  getRunsQueueConfig,
+  getRunsStoreConfig,
+  parseIdsParam,
+  submitRun,
+} from "@api/server/runsService";
+import { resolveRunParameters } from "@api/server/modelParameterDefaults";
+import { validateDataset } from "@api/server/datasetValidation";
+import { sendApiError, type ApiErrorBody } from "@api/server/errorEnvelope";
+
+// Public re-skin of `/api/runs` (design D8, §6.5): same DynamoDB/SQS
+// machinery, but with the `/v1` error envelope, server-side dataset
+// validation, applied parameter defaults, and a real `413` instead of the
+// internal `{ tooLarge: true }` signal.
+export const config = {
+  api: {
+    bodyParser: {
+      sizeLimit: "6mb",
+    },
+  },
+};
+
+type V1SubmitResponse = { jobId: string };
+
+const handler = async (
+  req: NextApiRequest,
+  res: NextApiResponse<V1SubmitResponse | GetRunResponse[] | ApiErrorBody>,
+) => {
+  const store = getRunsStoreConfig();
+  if (!store) {
+    return sendApiError(
+      res,
+      "not_configured",
+      "Async runs are not configured.",
+    );
+  }
+
+  // GET /v1/runs?ids=a,b,c — batch status lookup (statuses only, no results).
+  if (req.method === "GET") {
+    const ids = parseIdsParam(req.query.ids, MAX_BATCH_IDS);
+    if (ids.length === 0) {
+      return res.status(200).json([]);
+    }
+    try {
+      const runs = await batchGetRunStatuses(store.ddb, store.tableName, ids);
+      return res.status(200).json(runs);
+    } catch (error) {
+      console.error("Failed to batch-fetch runs", error);
+      return sendApiError(res, "internal_error", "Failed to fetch runs.");
+    }
+  }
+
+  if (req.method !== "POST") {
+    res.setHeader("Allow", "GET, POST");
+    return sendApiError(res, "method_not_allowed", "Method Not Allowed.");
+  }
+
+  const queue = getRunsQueueConfig();
+  if (!queue) {
+    return sendApiError(
+      res,
+      "not_configured",
+      "Async runs are not configured.",
+    );
+  }
+
+  const { data, parameters, modelType } = (req.body ?? {}) as {
+    data?: unknown;
+    parameters?: unknown;
+    modelType?: string;
+  };
+
+  const resolved = resolveRunParameters(modelType, parameters);
+
+  const validationError = validateDataset(data, resolved.modelType);
+  if (validationError) {
+    return sendApiError(res, "validation_error", validationError.message);
+  }
+
+  const submission = await submitRun(
+    store.ddb,
+    queue.sqs,
+    store.tableName,
+    queue.queueUrl,
+    { data, parameters: resolved.parameters, modelType: resolved.modelType },
+  );
+
+  if (submission.outcome === "too_large") {
+    return sendApiError(
+      res,
+      "payload_too_large",
+      "Dataset is too large to queue for async processing (~200KB limit). Use the synchronous endpoint (POST /v1/run-model or /v1/run-rtma) instead.",
+    );
+  }
+
+  if (submission.outcome === "error") {
+    console.error("Failed to submit run", submission.error);
+    return sendApiError(res, "internal_error", "Failed to submit run.");
+  }
+
+  return res.status(200).json({ jobId: submission.jobId });
+};
+
+export default handler;

--- a/apps/react-ui/client/src/pages/api/v1/runs/[jobId].ts
+++ b/apps/react-ui/client/src/pages/api/v1/runs/[jobId].ts
@@ -1,0 +1,100 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import type { GetRunResponse } from "@src/types/api";
+import { getRunItem, getRunsStoreConfig } from "@api/server/runsService";
+import { sendApiError, type ApiErrorBody } from "@api/server/errorEnvelope";
+
+// Public re-skin of `/api/runs/[jobId]` (design D8, §6.5): same lookup, but
+// `result` is returned as a parsed JSON object (legacy returns the stored
+// string), plot fields are stripped unless `?include=plot` (§6.4/§D7), and
+// the `/v1` error envelope is used throughout.
+
+const PLOT_FIELDS = [
+  "funnelPlot",
+  "funnelPlotWidth",
+  "funnelPlotHeight",
+  "zScorePlot",
+  "zScorePlotWidth",
+  "zScorePlotHeight",
+] as const;
+
+type V1GetRunResponse = Omit<GetRunResponse, "result"> & {
+  result?: Record<string, unknown>;
+};
+
+const shouldIncludePlot = (req: NextApiRequest): boolean => {
+  const { include } = req.query;
+  const values = Array.isArray(include) ? include : [include];
+  return values.includes("plot");
+};
+
+const stripPlotFields = (
+  result: Record<string, unknown>,
+): Record<string, unknown> => {
+  const stripped = { ...result };
+  PLOT_FIELDS.forEach((field) => {
+    delete stripped[field];
+  });
+  return stripped;
+};
+
+const handler = async (
+  req: NextApiRequest,
+  res: NextApiResponse<V1GetRunResponse | ApiErrorBody>,
+) => {
+  if (req.method !== "GET") {
+    res.setHeader("Allow", "GET");
+    return sendApiError(res, "method_not_allowed", "Method Not Allowed.");
+  }
+
+  const store = getRunsStoreConfig();
+  if (!store) {
+    return sendApiError(
+      res,
+      "not_configured",
+      "Async runs are not configured.",
+    );
+  }
+
+  const { jobId } = req.query;
+  const id = Array.isArray(jobId) ? jobId[0] : jobId;
+  if (!id) {
+    return sendApiError(res, "validation_error", "Missing jobId.");
+  }
+
+  try {
+    const item = await getRunItem(store.ddb, store.tableName, id);
+
+    if (!item) {
+      return sendApiError(res, "not_found", "Run not found or expired.");
+    }
+
+    const body: V1GetRunResponse = {
+      jobId: id,
+      status: item.status,
+      modelType: item.modelType,
+    };
+
+    if (item.result) {
+      const parsedResult = JSON.parse(item.result) as Record<string, unknown>;
+      body.result = shouldIncludePlot(req)
+        ? parsedResult
+        : stripPlotFields(parsedResult);
+    }
+    if (item.errorMessage) {
+      body.errorMessage = item.errorMessage;
+    }
+    if (typeof item.runDurationMs === "number") {
+      body.runDurationMs = item.runDurationMs;
+    }
+    if (typeof item.submittedAt === "number") {
+      body.runTimestamp = new Date(item.submittedAt).toISOString();
+    }
+
+    return res.status(200).json(body);
+  } catch (error) {
+    console.error("Failed to fetch run", error);
+    return sendApiError(res, "internal_error", "Failed to fetch run.");
+  }
+};
+
+export default handler;

--- a/apps/react-ui/client/src/tests/apiRunsJobIdLegacy.test.ts
+++ b/apps/react-ui/client/src/tests/apiRunsJobIdLegacy.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { createMockReq, createMockRes } from "@tests/helpers/nextApiMocks";
+
+const { ddbSendMock } = vi.hoisted(() => ({
+  ddbSendMock: vi.fn(),
+}));
+
+vi.mock("@aws-sdk/client-dynamodb", () => ({
+  DynamoDBClient: vi.fn(),
+}));
+vi.mock("@aws-sdk/lib-dynamodb", () => ({
+  DynamoDBDocumentClient: { from: vi.fn(() => ({ send: ddbSendMock })) },
+  GetCommand: vi.fn((input: unknown) => ({ input })),
+}));
+
+const ENV_KEYS = ["AWS_REGION", "RUNS_TABLE_NAME"] as const;
+const savedEnv: Record<string, string | undefined> = {};
+
+const setConfigured = () => {
+  process.env.AWS_REGION = "us-east-1";
+  process.env.RUNS_TABLE_NAME = "runs-table";
+};
+
+beforeEach(() => {
+  ENV_KEYS.forEach((key) => {
+    savedEnv[key] = process.env[key];
+    delete process.env[key];
+  });
+  vi.resetModules();
+  ddbSendMock.mockReset();
+});
+
+afterEach(() => {
+  ENV_KEYS.forEach((key) => {
+    if (savedEnv[key] === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = savedEnv[key];
+    }
+  });
+});
+
+describe("legacy /api/runs/[jobId] (unchanged behavior)", () => {
+  it("405s for non-GET methods", async () => {
+    const { default: handler } = await import("@src/pages/api/runs/[jobId]");
+    const req = createMockReq({ method: "POST" });
+    const res = createMockRes();
+
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(405);
+    expect(res.body).toEqual({ error: "Method Not Allowed" });
+  });
+
+  it("503s with a plain error string when not configured", async () => {
+    const { default: handler } = await import("@src/pages/api/runs/[jobId]");
+    const req = createMockReq({ method: "GET", query: { jobId: "abc" } });
+    const res = createMockRes();
+
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(503);
+    expect(res.body).toEqual({ error: "Async runs are not configured." });
+  });
+
+  it("404s for an unknown job id", async () => {
+    setConfigured();
+    ddbSendMock.mockResolvedValue({ Item: undefined });
+    const { default: handler } = await import("@src/pages/api/runs/[jobId]");
+    const req = createMockReq({ method: "GET", query: { jobId: "missing" } });
+    const res = createMockRes();
+
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(404);
+    expect(res.body).toEqual({ error: "Run not found or expired." });
+  });
+
+  it("returns `result` as the raw stored string (not parsed)", async () => {
+    setConfigured();
+    const storedResult = JSON.stringify({
+      effectEstimate: 0.5,
+      funnelPlot: "base64==",
+    });
+    ddbSendMock.mockResolvedValue({
+      Item: {
+        jobId: "abc",
+        status: "succeeded",
+        modelType: "MAIVE",
+        result: storedResult,
+        submittedAt: 1700000000000,
+      },
+    });
+    const { default: handler } = await import("@src/pages/api/runs/[jobId]");
+    const req = createMockReq({ method: "GET", query: { jobId: "abc" } });
+    const res = createMockRes();
+
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toMatchObject({
+      jobId: "abc",
+      status: "succeeded",
+      modelType: "MAIVE",
+      result: storedResult,
+    });
+    expect(typeof (res.body as { result?: unknown }).result).toBe("string");
+  });
+});

--- a/apps/react-ui/client/src/tests/apiRunsLegacy.test.ts
+++ b/apps/react-ui/client/src/tests/apiRunsLegacy.test.ts
@@ -1,0 +1,185 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { createMockReq, createMockRes } from "@tests/helpers/nextApiMocks";
+
+const { ddbSendMock, sqsSendMock } = vi.hoisted(() => ({
+  ddbSendMock: vi.fn(),
+  sqsSendMock: vi.fn(),
+}));
+
+vi.mock("@aws-sdk/client-dynamodb", () => ({
+  DynamoDBClient: vi.fn(),
+}));
+vi.mock("@aws-sdk/lib-dynamodb", () => ({
+  DynamoDBDocumentClient: { from: vi.fn(() => ({ send: ddbSendMock })) },
+  PutCommand: vi.fn((input: unknown) => ({ input })),
+  GetCommand: vi.fn((input: unknown) => ({ input })),
+  BatchGetCommand: vi.fn((input: unknown) => ({ input })),
+}));
+vi.mock("@aws-sdk/client-sqs", () => ({
+  SQSClient: vi.fn(() => ({ send: sqsSendMock })),
+  SendMessageCommand: vi.fn((input: unknown) => ({ input })),
+}));
+
+const ENV_KEYS = ["AWS_REGION", "RUNS_TABLE_NAME", "RUNS_QUEUE_URL"] as const;
+const savedEnv: Record<string, string | undefined> = {};
+
+const setConfigured = () => {
+  process.env.AWS_REGION = "us-east-1";
+  process.env.RUNS_TABLE_NAME = "runs-table";
+  process.env.RUNS_QUEUE_URL = "https://sqs.example/queue";
+};
+
+beforeEach(() => {
+  ENV_KEYS.forEach((key) => {
+    savedEnv[key] = process.env[key];
+    delete process.env[key];
+  });
+  vi.resetModules();
+  ddbSendMock.mockReset();
+  sqsSendMock.mockReset();
+});
+
+afterEach(() => {
+  ENV_KEYS.forEach((key) => {
+    if (savedEnv[key] === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = savedEnv[key];
+    }
+  });
+});
+
+describe("legacy /api/runs (unchanged behavior)", () => {
+  it("503s with a plain error string when not configured", async () => {
+    const { default: handler } = await import("@src/pages/api/runs");
+    const req = createMockReq({ method: "POST" });
+    const res = createMockRes();
+
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(503);
+    expect(res.body).toEqual({ error: "Async runs are not configured." });
+  });
+
+  it("returns 200 { tooLarge: true } for an oversized submission", async () => {
+    setConfigured();
+    const { default: handler } = await import("@src/pages/api/runs");
+    const req = createMockReq({
+      method: "POST",
+      body: {
+        data: "x".repeat(300 * 1024),
+        parameters: {},
+        modelType: "MAIVE",
+      },
+    });
+    const res = createMockRes();
+
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual({ tooLarge: true });
+    expect(ddbSendMock).not.toHaveBeenCalled();
+    expect(sqsSendMock).not.toHaveBeenCalled();
+  });
+
+  it("400s on missing required fields, with no server-side dataset validation", async () => {
+    setConfigured();
+    const { default: handler } = await import("@src/pages/api/runs");
+    const req = createMockReq({
+      method: "POST",
+      body: { data: [{ effect: 1 }] },
+    });
+    const res = createMockRes();
+
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(400);
+    expect(res.body).toEqual({
+      error: "Missing required fields: data, parameters, modelType.",
+    });
+  });
+
+  it("queues a valid submission and returns 200 { jobId } — no dataset shape enforced", async () => {
+    setConfigured();
+    ddbSendMock.mockResolvedValue({});
+    sqsSendMock.mockResolvedValue({});
+    const { default: handler } = await import("@src/pages/api/runs");
+    // Only 1 row / missing n_obs — the legacy route never validated shape.
+    const req = createMockReq({
+      method: "POST",
+      body: {
+        data: [{ effect: 1, se: 0.1 }],
+        parameters: { modelType: "MAIVE" },
+        modelType: "MAIVE",
+      },
+    });
+    const res = createMockRes();
+
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toHaveProperty("jobId");
+    expect(ddbSendMock).toHaveBeenCalledTimes(1);
+    expect(sqsSendMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns [] for GET with no ids, without hitting DynamoDB", async () => {
+    setConfigured();
+    const { default: handler } = await import("@src/pages/api/runs");
+    const req = createMockReq({ method: "GET", query: {} });
+    const res = createMockRes();
+
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual([]);
+    expect(ddbSendMock).not.toHaveBeenCalled();
+  });
+
+  it("batch-fetches statuses for GET ?ids=a,b", async () => {
+    setConfigured();
+    const responses: Record<string, unknown[]> = {};
+    responses["runs-table"] = [
+      { jobId: "a", status: "succeeded", modelType: "MAIVE" },
+      { jobId: "b", status: "running", modelType: "MAIVE" },
+    ];
+    ddbSendMock.mockResolvedValue({ Responses: responses });
+    const { default: handler } = await import("@src/pages/api/runs");
+    const req = createMockReq({ method: "GET", query: { ids: "a,b" } });
+    const res = createMockRes();
+
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual([
+      {
+        jobId: "a",
+        status: "succeeded",
+        modelType: "MAIVE",
+        errorMessage: undefined,
+        runDurationMs: undefined,
+        runTimestamp: undefined,
+      },
+      {
+        jobId: "b",
+        status: "running",
+        modelType: "MAIVE",
+        errorMessage: undefined,
+        runDurationMs: undefined,
+        runTimestamp: undefined,
+      },
+    ]);
+  });
+
+  it("405s for unsupported methods", async () => {
+    setConfigured();
+    const { default: handler } = await import("@src/pages/api/runs");
+    const req = createMockReq({ method: "DELETE" });
+    const res = createMockRes();
+
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(405);
+    expect(res.body).toEqual({ error: "Method Not Allowed" });
+  });
+});

--- a/apps/react-ui/client/src/tests/apiV1Runs.test.ts
+++ b/apps/react-ui/client/src/tests/apiV1Runs.test.ts
@@ -1,0 +1,259 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { createMockReq, createMockRes } from "@tests/helpers/nextApiMocks";
+
+const { ddbSendMock, sqsSendMock } = vi.hoisted(() => ({
+  ddbSendMock: vi.fn<[{ input: unknown }], Promise<unknown>>(),
+  sqsSendMock: vi.fn<[{ input: unknown }], Promise<unknown>>(),
+}));
+
+vi.mock("@aws-sdk/client-dynamodb", () => ({
+  DynamoDBClient: vi.fn(),
+}));
+vi.mock("@aws-sdk/lib-dynamodb", () => ({
+  DynamoDBDocumentClient: { from: vi.fn(() => ({ send: ddbSendMock })) },
+  PutCommand: vi.fn((input: unknown) => ({ input })),
+  GetCommand: vi.fn((input: unknown) => ({ input })),
+  BatchGetCommand: vi.fn((input: unknown) => ({ input })),
+}));
+vi.mock("@aws-sdk/client-sqs", () => ({
+  SQSClient: vi.fn(() => ({ send: sqsSendMock })),
+  SendMessageCommand: vi.fn((input: unknown) => ({ input })),
+}));
+
+const ENV_KEYS = ["AWS_REGION", "RUNS_TABLE_NAME", "RUNS_QUEUE_URL"] as const;
+const savedEnv: Record<string, string | undefined> = {};
+
+const setConfigured = () => {
+  process.env.AWS_REGION = "us-east-1";
+  process.env.RUNS_TABLE_NAME = "runs-table";
+  process.env.RUNS_QUEUE_URL = "https://sqs.example/queue";
+};
+
+const validMaiveData = [
+  { effect: 0.42, se: 0.11, n_obs: 120 },
+  { effect: 0.31, se: 0.06, n_obs: 90 },
+  { effect: 0.55, se: 0.2, n_obs: 45 },
+  { effect: 0.12, se: 0.04, n_obs: 200 },
+];
+
+type PutCall = {
+  input: { Item: { modelType: string; parameters: string } };
+};
+
+const getLastPutCall = (): PutCall =>
+  ddbSendMock.mock.calls[ddbSendMock.mock.calls.length - 1][0] as PutCall;
+
+beforeEach(() => {
+  ENV_KEYS.forEach((key) => {
+    savedEnv[key] = process.env[key];
+    delete process.env[key];
+  });
+  vi.resetModules();
+  ddbSendMock.mockReset();
+  sqsSendMock.mockReset();
+});
+
+afterEach(() => {
+  ENV_KEYS.forEach((key) => {
+    if (savedEnv[key] === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = savedEnv[key];
+    }
+  });
+});
+
+describe("POST /api/v1/runs", () => {
+  it("503s with the error envelope when not configured", async () => {
+    const { default: handler } = await import("@src/pages/api/v1/runs");
+    const req = createMockReq({
+      method: "POST",
+      body: { data: validMaiveData },
+    });
+    const res = createMockRes();
+
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(503);
+    expect(res.body).toEqual({
+      error: {
+        code: "not_configured",
+        message: "Async runs are not configured.",
+      },
+    });
+  });
+
+  it("400s with validation_error for an invalid dataset", async () => {
+    setConfigured();
+    const { default: handler } = await import("@src/pages/api/v1/runs");
+    const req = createMockReq({
+      method: "POST",
+      body: { data: [{ effect: 1, se: 0.1 }] }, // only 2 rows, missing n_obs
+    });
+    const res = createMockRes();
+
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(400);
+    expect(res.body).toMatchObject({ error: { code: "validation_error" } });
+    expect(ddbSendMock).not.toHaveBeenCalled();
+    expect(sqsSendMock).not.toHaveBeenCalled();
+  });
+
+  it("413s with payload_too_large for an oversized submission (not the legacy tooLarge signal)", async () => {
+    setConfigured();
+    const { default: handler } = await import("@src/pages/api/v1/runs");
+    const bigData = Array.from({ length: 4 }, (_, i) => ({
+      effect: 0.1 + i,
+      se: 0.1,
+      n_obs: 10,
+      study_id: "x".repeat(300 * 1024),
+    }));
+    const req = createMockReq({ method: "POST", body: { data: bigData } });
+    const res = createMockRes();
+
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(413);
+    expect(res.body).toMatchObject({ error: { code: "payload_too_large" } });
+  });
+
+  it("applies CONFIG.DEFAULT_MODEL_PARAMETERS defaults and derives shouldUseInstrumenting when parameters/modelType are omitted", async () => {
+    setConfigured();
+    ddbSendMock.mockResolvedValue({});
+    sqsSendMock.mockResolvedValue({});
+    const { default: handler } = await import("@src/pages/api/v1/runs");
+    const req = createMockReq({
+      method: "POST",
+      body: { data: validMaiveData },
+    });
+    const res = createMockRes();
+
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toHaveProperty("jobId");
+
+    const putCall = getLastPutCall();
+    expect(putCall.input.Item.modelType).toBe("MAIVE");
+    const storedParameters = JSON.parse(
+      putCall.input.Item.parameters,
+    ) as Record<string, unknown>;
+    expect(storedParameters).toMatchObject({
+      modelType: "MAIVE",
+      shouldUseInstrumenting: true,
+      maiveMethod: "PET-PEESE",
+    });
+  });
+
+  it("derives shouldUseInstrumenting=false for modelType WLS", async () => {
+    setConfigured();
+    ddbSendMock.mockResolvedValue({});
+    sqsSendMock.mockResolvedValue({});
+    const { default: handler } = await import("@src/pages/api/v1/runs");
+    const req = createMockReq({
+      method: "POST",
+      body: { data: validMaiveData, modelType: "WLS" },
+    });
+    const res = createMockRes();
+
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(200);
+    const putCall = getLastPutCall();
+    const storedParameters = JSON.parse(
+      putCall.input.Item.parameters,
+    ) as Record<string, unknown>;
+    expect(storedParameters).toMatchObject({
+      modelType: "WLS",
+      shouldUseInstrumenting: false,
+    });
+  });
+
+  it("routes modelType RTMA to RTMA defaults and skips the MAIVE-family row/column checks", async () => {
+    setConfigured();
+    ddbSendMock.mockResolvedValue({});
+    sqsSendMock.mockResolvedValue({});
+    const { default: handler } = await import("@src/pages/api/v1/runs");
+    const req = createMockReq({
+      method: "POST",
+      body: {
+        data: [
+          { effect: 0.1, se: 0.1 },
+          { effect: 0.2, se: 0.2 },
+        ],
+        modelType: "RTMA",
+      },
+    });
+    const res = createMockRes();
+
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(200);
+    const putCall = getLastPutCall();
+    expect(putCall.input.Item.modelType).toBe("RTMA");
+    const storedParameters = JSON.parse(
+      putCall.input.Item.parameters,
+    ) as Record<string, unknown>;
+    expect(storedParameters).toEqual({
+      modelType: "RTMA",
+      favorPositive: true,
+      alphaSelect: 0.05,
+      ciLevel: 0.95,
+      winsorize: 0,
+    });
+  });
+
+  it("405s with method_not_allowed for unsupported methods", async () => {
+    setConfigured();
+    const { default: handler } = await import("@src/pages/api/v1/runs");
+    const req = createMockReq({ method: "DELETE" });
+    const res = createMockRes();
+
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(405);
+    expect(res.body).toMatchObject({ error: { code: "method_not_allowed" } });
+  });
+});
+
+describe("GET /api/v1/runs (batch status)", () => {
+  it("returns [] for no ids without hitting DynamoDB", async () => {
+    setConfigured();
+    const { default: handler } = await import("@src/pages/api/v1/runs");
+    const req = createMockReq({ method: "GET", query: {} });
+    const res = createMockRes();
+
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual([]);
+    expect(ddbSendMock).not.toHaveBeenCalled();
+  });
+
+  it("returns statuses only (no results) for a valid id list", async () => {
+    setConfigured();
+    const responses: Record<string, unknown[]> = {};
+    responses["runs-table"] = [
+      { jobId: "a", status: "queued", modelType: "MAIVE" },
+    ];
+    ddbSendMock.mockResolvedValue({ Responses: responses });
+    const { default: handler } = await import("@src/pages/api/v1/runs");
+    const req = createMockReq({ method: "GET", query: { ids: "a" } });
+    const res = createMockRes();
+
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual([
+      {
+        jobId: "a",
+        status: "queued",
+        modelType: "MAIVE",
+        errorMessage: undefined,
+        runDurationMs: undefined,
+        runTimestamp: undefined,
+      },
+    ]);
+  });
+});

--- a/apps/react-ui/client/src/tests/apiV1RunsJobId.test.ts
+++ b/apps/react-ui/client/src/tests/apiV1RunsJobId.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { createMockReq, createMockRes } from "@tests/helpers/nextApiMocks";
+
+const { ddbSendMock } = vi.hoisted(() => ({
+  ddbSendMock: vi.fn(),
+}));
+
+vi.mock("@aws-sdk/client-dynamodb", () => ({
+  DynamoDBClient: vi.fn(),
+}));
+vi.mock("@aws-sdk/lib-dynamodb", () => ({
+  DynamoDBDocumentClient: { from: vi.fn(() => ({ send: ddbSendMock })) },
+  GetCommand: vi.fn((input: unknown) => ({ input })),
+}));
+
+const ENV_KEYS = ["AWS_REGION", "RUNS_TABLE_NAME"] as const;
+const savedEnv: Record<string, string | undefined> = {};
+
+const setConfigured = () => {
+  process.env.AWS_REGION = "us-east-1";
+  process.env.RUNS_TABLE_NAME = "runs-table";
+};
+
+beforeEach(() => {
+  ENV_KEYS.forEach((key) => {
+    savedEnv[key] = process.env[key];
+    delete process.env[key];
+  });
+  vi.resetModules();
+  ddbSendMock.mockReset();
+});
+
+afterEach(() => {
+  ENV_KEYS.forEach((key) => {
+    if (savedEnv[key] === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = savedEnv[key];
+    }
+  });
+});
+
+describe("GET /api/v1/runs/[jobId]", () => {
+  it("405s with the error envelope for non-GET methods", async () => {
+    const { default: handler } = await import("@src/pages/api/v1/runs/[jobId]");
+    const req = createMockReq({ method: "POST" });
+    const res = createMockRes();
+
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(405);
+    expect(res.body).toMatchObject({ error: { code: "method_not_allowed" } });
+  });
+
+  it("503s with not_configured when async runs aren't configured", async () => {
+    const { default: handler } = await import("@src/pages/api/v1/runs/[jobId]");
+    const req = createMockReq({ method: "GET", query: { jobId: "abc" } });
+    const res = createMockRes();
+
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(503);
+    expect(res.body).toMatchObject({ error: { code: "not_configured" } });
+  });
+
+  it("404s with not_found for an unknown/expired job id", async () => {
+    setConfigured();
+    ddbSendMock.mockResolvedValue({ Item: undefined });
+    const { default: handler } = await import("@src/pages/api/v1/runs/[jobId]");
+    const req = createMockReq({ method: "GET", query: { jobId: "missing" } });
+    const res = createMockRes();
+
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(404);
+    expect(res.body).toEqual({
+      error: { code: "not_found", message: "Run not found or expired." },
+    });
+  });
+
+  it("returns `result` as a parsed object with plot fields stripped by default", async () => {
+    setConfigured();
+    const storedResult = {
+      effectEstimate: 0.5,
+      standardError: 0.1,
+      funnelPlot: "base64==",
+      funnelPlotWidth: 400,
+      funnelPlotHeight: 300,
+    };
+    ddbSendMock.mockResolvedValue({
+      Item: {
+        jobId: "abc",
+        status: "succeeded",
+        modelType: "MAIVE",
+        result: JSON.stringify(storedResult),
+        submittedAt: 1700000000000,
+      },
+    });
+    const { default: handler } = await import("@src/pages/api/v1/runs/[jobId]");
+    const req = createMockReq({ method: "GET", query: { jobId: "abc" } });
+    const res = createMockRes();
+
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(200);
+    const body = res.body as { result?: Record<string, unknown> };
+    expect(typeof body.result).toBe("object");
+    expect(body.result).toEqual({
+      effectEstimate: 0.5,
+      standardError: 0.1,
+    });
+  });
+
+  it("includes plot fields when ?include=plot is set", async () => {
+    setConfigured();
+    const storedResult = {
+      effectEstimate: 0.5,
+      funnelPlot: "base64==",
+      funnelPlotWidth: 400,
+      funnelPlotHeight: 300,
+    };
+    ddbSendMock.mockResolvedValue({
+      Item: {
+        jobId: "abc",
+        status: "succeeded",
+        modelType: "MAIVE",
+        result: JSON.stringify(storedResult),
+      },
+    });
+    const { default: handler } = await import("@src/pages/api/v1/runs/[jobId]");
+    const req = createMockReq({
+      method: "GET",
+      query: { jobId: "abc", include: "plot" },
+    });
+    const res = createMockRes();
+
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(200);
+    const body = res.body as { result?: Record<string, unknown> };
+    expect(body.result).toEqual(storedResult);
+  });
+
+  it("strips zScorePlot fields for RTMA results", async () => {
+    setConfigured();
+    const storedResult = {
+      mu: 0.2,
+      tau: 0.1,
+      zScorePlot: "base64==",
+      zScorePlotWidth: 400,
+      zScorePlotHeight: 300,
+    };
+    ddbSendMock.mockResolvedValue({
+      Item: {
+        jobId: "abc",
+        status: "succeeded",
+        modelType: "RTMA",
+        result: JSON.stringify(storedResult),
+      },
+    });
+    const { default: handler } = await import("@src/pages/api/v1/runs/[jobId]");
+    const req = createMockReq({ method: "GET", query: { jobId: "abc" } });
+    const res = createMockRes();
+
+    await handler(req, res);
+
+    expect(res.body).toMatchObject({ result: { mu: 0.2, tau: 0.1 } });
+    const body = res.body as { result?: Record<string, unknown> };
+    expect(body.result).not.toHaveProperty("zScorePlot");
+  });
+});

--- a/apps/react-ui/client/src/tests/datasetValidation.test.ts
+++ b/apps/react-ui/client/src/tests/datasetValidation.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect } from "vitest";
+import { resolveColumns, validateDataset } from "@api/server/datasetValidation";
+
+const maiveRow = (
+  effect: number,
+  se: number,
+  nObs: number,
+  studyId?: string,
+) => {
+  const row: Record<string, unknown> = { effect, se, n_obs: nObs };
+  if (studyId !== undefined) {
+    row.study_id = studyId;
+  }
+  return row;
+};
+
+describe("resolveColumns", () => {
+  it("resolves canonical column names when present", () => {
+    const columns = resolveColumns([{ effect: 1, se: 2, n_obs: 3 }]);
+    expect(columns).toEqual({
+      effect: "effect",
+      se: "se",
+      nObs: "n_obs",
+      studyId: undefined,
+    });
+  });
+
+  it("resolves canonical names case-insensitively", () => {
+    const row: Record<string, number> = { Effect: 1, SE: 2 };
+    row.N_Obs = 3;
+    const columns = resolveColumns([row]);
+    expect(columns).toEqual({
+      effect: "Effect",
+      se: "SE",
+      nObs: "N_Obs",
+      studyId: undefined,
+    });
+  });
+
+  it("falls back to positional resolution for non-canonical names", () => {
+    const columns = resolveColumns([{ b: 0.5, s: 0.1, n: 100, study: "A" }]);
+    expect(columns).toEqual({
+      effect: "b",
+      se: "s",
+      nObs: "n",
+      studyId: "study",
+    });
+  });
+
+  it("falls back positionally for a 2-column (RTMA-shaped) row", () => {
+    const columns = resolveColumns([{ b: 0.5, s: 0.1 }]);
+    expect(columns).toEqual({
+      effect: "b",
+      se: "s",
+      nObs: undefined,
+      studyId: undefined,
+    });
+  });
+
+  it("returns null for an empty row", () => {
+    expect(resolveColumns([{}])).toBeNull();
+  });
+});
+
+describe("validateDataset — MAIVE-family", () => {
+  it("accepts a valid dataset", () => {
+    const data = [
+      maiveRow(0.42, 0.11, 120),
+      maiveRow(0.31, 0.06, 90),
+      maiveRow(0.55, 0.2, 45),
+      maiveRow(0.12, 0.04, 200),
+    ];
+    expect(validateDataset(data, "MAIVE")).toBeNull();
+  });
+
+  it("rejects a non-array payload", () => {
+    expect(validateDataset({ not: "an array" }, "MAIVE")?.message).toMatch(
+      /non-empty array/,
+    );
+  });
+
+  it("rejects fewer than 4 rows", () => {
+    const data = [maiveRow(0.4, 0.1, 100), maiveRow(0.3, 0.1, 90)];
+    expect(validateDataset(data, "MAIVE")?.message).toMatch(/at least 4 rows/);
+  });
+
+  it("rejects a 2-column dataset (missing n_obs)", () => {
+    const data = [
+      { effect: 0.1, se: 0.1 },
+      { effect: 0.2, se: 0.1 },
+      { effect: 0.3, se: 0.1 },
+      { effect: 0.4, se: 0.1 },
+    ];
+    expect(validateDataset(data, "MAIVE")?.message).toMatch(
+      /3 or 4 columns; found 2/,
+    );
+  });
+
+  it("rejects non-numeric effect values", () => {
+    const data = [
+      maiveRow(0.1, 0.1, 10),
+      { effect: "not-a-number", se: 0.1, n_obs: 10 },
+      maiveRow(0.3, 0.1, 10),
+      maiveRow(0.4, 0.1, 10),
+    ];
+    expect(validateDataset(data, "MAIVE")?.message).toMatch(
+      /effect.*non-numeric/,
+    );
+  });
+
+  it("rejects non-positive se", () => {
+    const data = [
+      maiveRow(0.1, 0.1, 10),
+      maiveRow(0.2, 0, 10),
+      maiveRow(0.3, 0.1, 10),
+      maiveRow(0.4, 0.1, 10),
+    ];
+    expect(validateDataset(data, "MAIVE")?.message).toMatch(/se.*positive/);
+  });
+
+  it("rejects non-positive-integer n_obs", () => {
+    const data = [
+      maiveRow(0.1, 0.1, 10),
+      maiveRow(0.2, 0.1, 10.5),
+      maiveRow(0.3, 0.1, 10),
+      maiveRow(0.4, 0.1, 10),
+    ];
+    expect(validateDataset(data, "MAIVE")?.message).toMatch(
+      /n_obs.*positive integers/,
+    );
+  });
+
+  it("rejects too few rows relative to unique study ids", () => {
+    const data = [
+      maiveRow(0.1, 0.1, 10, "A"),
+      maiveRow(0.2, 0.1, 10, "B"),
+      maiveRow(0.3, 0.1, 10, "C"),
+      maiveRow(0.4, 0.1, 10, "D"),
+    ];
+    expect(validateDataset(data, "MAIVE")?.message).toMatch(
+      /unique study IDs plus 3/,
+    );
+  });
+});
+
+describe("validateDataset — RTMA", () => {
+  it("accepts a 2-column effect/se dataset", () => {
+    const data = [
+      { effect: 0.1, se: 0.1 },
+      { effect: 0.2, se: 0.2 },
+    ];
+    expect(validateDataset(data, "RTMA")).toBeNull();
+  });
+
+  it("does not require 4 rows", () => {
+    const data = [{ effect: 0.1, se: 0.1 }];
+    expect(validateDataset(data, "RTMA")).toBeNull();
+  });
+
+  it("still rejects non-positive se", () => {
+    const data = [
+      { effect: 0.1, se: 0.1 },
+      { effect: 0.2, se: -1 },
+    ];
+    expect(validateDataset(data, "RTMA")?.message).toMatch(/se.*positive/);
+  });
+});

--- a/apps/react-ui/client/src/tests/helpers/nextApiMocks.ts
+++ b/apps/react-ui/client/src/tests/helpers/nextApiMocks.ts
@@ -1,0 +1,44 @@
+import { vi } from "vitest";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+export const createMockReq = (
+  overrides: Partial<NextApiRequest> = {},
+): NextApiRequest =>
+  ({
+    method: "GET",
+    query: {},
+    body: undefined,
+    headers: {},
+    ...overrides,
+  }) as NextApiRequest;
+
+export type MockResponse<T = unknown> = NextApiResponse<T> & {
+  statusCode: number;
+  body: T | undefined;
+  headers: Record<string, string>;
+};
+
+export const createMockRes = <T = unknown>(): MockResponse<T> => {
+  const res = {
+    statusCode: 200,
+    body: undefined,
+    headers: {},
+  } as MockResponse<T>;
+
+  res.status = vi.fn((code: number) => {
+    res.statusCode = code;
+    return res;
+  }) as MockResponse<T>["status"];
+
+  res.json = vi.fn((body: T) => {
+    res.body = body;
+    return res;
+  }) as MockResponse<T>["json"];
+
+  res.setHeader = vi.fn((name: string, value: string | string[]) => {
+    res.headers[name] = Array.isArray(value) ? value.join(", ") : value;
+    return res;
+  }) as MockResponse<T>["setHeader"];
+
+  return res;
+};

--- a/apps/react-ui/client/src/tests/modelParameterDefaults.test.ts
+++ b/apps/react-ui/client/src/tests/modelParameterDefaults.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from "vitest";
+import { resolveRunParameters } from "@api/server/modelParameterDefaults";
+import CONFIG from "@src/CONFIG";
+
+describe("resolveRunParameters", () => {
+  it("defaults to CONFIG.DEFAULT_MODEL_PARAMETERS when modelType/parameters are omitted", () => {
+    const resolved = resolveRunParameters(undefined, undefined);
+    expect(resolved.modelType).toBe(CONFIG.DEFAULT_MODEL_PARAMETERS.modelType);
+    expect(resolved.parameters).toMatchObject({
+      ...CONFIG.DEFAULT_MODEL_PARAMETERS,
+      shouldUseInstrumenting: true,
+    });
+  });
+
+  it("derives shouldUseInstrumenting=false for WLS unless explicitly overridden", () => {
+    const resolved = resolveRunParameters("WLS", undefined);
+    expect(resolved.parameters).toMatchObject({
+      modelType: "WLS",
+      shouldUseInstrumenting: false,
+    });
+  });
+
+  it("keeps an explicit shouldUseInstrumenting override for WLS", () => {
+    const resolved = resolveRunParameters("WLS", {
+      shouldUseInstrumenting: true,
+    });
+    expect(resolved.parameters).toMatchObject({
+      modelType: "WLS",
+      shouldUseInstrumenting: true,
+    });
+  });
+
+  it("derives shouldUseInstrumenting=true for MAIVE/WAIVE", () => {
+    const resolved = resolveRunParameters("WAIVE", undefined);
+    expect(resolved.parameters).toMatchObject({
+      modelType: "WAIVE",
+      shouldUseInstrumenting: true,
+    });
+  });
+
+  it("merges explicit parameter overrides over the defaults", () => {
+    const resolved = resolveRunParameters("MAIVE", { winsorize: 5 });
+    expect(resolved.parameters).toMatchObject({
+      modelType: "MAIVE",
+      winsorize: 5,
+      maiveMethod: CONFIG.DEFAULT_MODEL_PARAMETERS.maiveMethod,
+    });
+  });
+
+  it("routes modelType RTMA to the RTMA defaults, ignoring MAIVE parameter fields", () => {
+    const resolved = resolveRunParameters("RTMA", undefined);
+    expect(resolved).toEqual({
+      modelType: "RTMA",
+      parameters: {
+        modelType: "RTMA",
+        favorPositive: true,
+        alphaSelect: 0.05,
+        ciLevel: 0.95,
+        winsorize: 0,
+      },
+    });
+  });
+
+  it("applies explicit RTMA overrides", () => {
+    const resolved = resolveRunParameters("RTMA", {
+      favorPositive: false,
+      winsorize: 2,
+    });
+    expect(resolved.parameters).toEqual({
+      modelType: "RTMA",
+      favorPositive: false,
+      alphaSelect: 0.05,
+      ciLevel: 0.95,
+      winsorize: 2,
+    });
+  });
+});

--- a/docs/PUBLIC_API_DESIGN.md
+++ b/docs/PUBLIC_API_DESIGN.md
@@ -333,16 +333,17 @@ synchronous UI runs. Revisit only if bypass abuse is actually observed (§12).
       plots unless `?include=plot`, set proper status codes. Legacy routes
       untouched. Shipped in #469.
 - [x] `Dockerfile`: `COPY r_scripts/api_v1.R .` Shipped in #469.
-- [ ] Next.js `pages/api/v1/runs.ts` + `pages/api/v1/runs/[jobId].ts`: public
+- [x] Next.js `pages/api/v1/runs.ts` + `pages/api/v1/runs/[jobId].ts`: public
       re-skins of the existing runs routes (shared helpers extracted, not
       duplicated) with D8 semantics (parsed `result`, `413`, plot stripping,
-      error envelope).
+      error envelope). Shipped in #467.
 - [ ] `docs/api/openapi.yaml` (D10) + `docs/PUBLIC_API.md` usage guide with
       curl/R/Python examples.
 - [x] Tests (R side): e2e scenario `tests/e2e/scenarios/api_v1_test.R` (happy
       path, validation 400s, defaults, plot opt-in, legacy-route parity) via an
       extended `utils/api_client.R`. Shipped in #469.
-- [ ] Tests (UI side): Vitest coverage for the `/api/v1/runs` routes.
+- [x] Tests (UI side): Vitest coverage for the `/api/v1/runs` routes. Shipped
+      in #467.
 
 **Phase 2 — infra & edge:**
 


### PR DESCRIPTION
## Summary

Implements the async half of the public model API per [docs/PUBLIC_API_DESIGN.md](docs/PUBLIC_API_DESIGN.md) (§4 D8, §6.1, §6.2, §6.5 — merged via #465). Ships dark: purely additive, no behavior change to the existing UI routes.

- Extracted the shared DynamoDB/SQS submit/poll/batch-get logic out of `pages/api/runs.ts` and `pages/api/runs/[jobId].ts` into `src/api/server/runsService.ts`, so both the legacy and new routes reuse it instead of duplicating it. The legacy routes were rewritten to call the shared helpers but keep their **exact** current request/response behavior (verified with dedicated regression tests).
- New `src/api/server/datasetValidation.ts`: server-side dataset validation mirroring `pages/validation/index.tsx` (canonical column resolution with positional fallback per D5; 3–4 columns / ≥4 rows / numeric / `se>0` / positive-integer `n_obs` / study-clustering row-count check for MAIVE-family; relaxed 2-column check for RTMA).
- New `src/api/server/modelParameterDefaults.ts`: applies `CONFIG.DEFAULT_MODEL_PARAMETERS` defaults, derives `shouldUseInstrumenting` from `modelType` (WLS → `false`, else `true`) unless explicitly set, and routes `modelType: "RTMA"` to its own default parameter set.
- New `src/api/server/errorEnvelope.ts`: the `/v1` structured `{ error: { code, message } }` envelope (§6.1).
- New routes:
  - `POST /api/v1/runs` — validates the dataset before queueing (400 `validation_error`), returns `413 payload_too_large` for oversized submissions (instead of the legacy `200 {tooLarge:true}`), `200 {jobId}` on success.
  - `GET /api/v1/runs?ids=` — batch status lookup, same semantics as legacy but with the `/v1` error envelope.
  - `GET /api/v1/runs/[jobId]` — returns `result` as a parsed JSON object (legacy returns the stored string), strips plot fields unless `?include=plot`, `404 not_found` for unknown/expired ids.

## Test plan

- [x] `npm run ui:test` — 108/108 passing (49 new tests covering validation, parameter defaults, legacy-route regression, and the new v1 routes)
- [x] `npm run ui:lint` — clean
- [x] `tsc --noEmit` — no new errors (one pre-existing, unrelated failure in `src/tests/integration/results.test.tsx`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)