### PR TITLE
fix: update R e2e scenarios for winsorize param and backend validation

### DIFF
--- a/apps/lambda-r-backend/r_scripts/tests/e2e/debug_test.R
+++ b/apps/lambda-r-backend/r_scripts/tests/e2e/debug_test.R
@@ -22,7 +22,8 @@ params <- list(
   maiveMethod = "PET",
   weight = "standard_weights",
   shouldUseInstrumenting = TRUE,
-  useLogFirstStage = FALSE
+  useLogFirstStage = FALSE,
+  winsorize = 0
 )
 
 # Convert to JSON

--- a/apps/lambda-r-backend/r_scripts/tests/e2e/scenarios/basic_maive_test.R
+++ b/apps/lambda-r-backend/r_scripts/tests/e2e/scenarios/basic_maive_test.R
@@ -81,7 +81,8 @@ test_parameter_combinations <- function() {
         maiveMethod = "PET",
         weight = "equal_weights",
         shouldUseInstrumenting = TRUE,
-        useLogFirstStage = FALSE
+        useLogFirstStage = FALSE,
+        winsorize = 0
       )
     ),
     list(
@@ -95,7 +96,8 @@ test_parameter_combinations <- function() {
         maiveMethod = "PEESE",
         weight = "standard_weights",
         shouldUseInstrumenting = TRUE,
-        useLogFirstStage = FALSE
+        useLogFirstStage = FALSE,
+        winsorize = 0
       )
     ),
     list(
@@ -109,7 +111,8 @@ test_parameter_combinations <- function() {
         maiveMethod = "EK",
         weight = "adjusted_weights",
         shouldUseInstrumenting = FALSE,
-        useLogFirstStage = FALSE
+        useLogFirstStage = FALSE,
+        winsorize = 0
       )
     )
   )

--- a/apps/lambda-r-backend/r_scripts/tests/e2e/scenarios/edge_cases_test.R
+++ b/apps/lambda-r-backend/r_scripts/tests/e2e/scenarios/edge_cases_test.R
@@ -124,27 +124,26 @@ test_data_with_nas <- function() {
       file_data_json <- df_to_json(test_data)
       params_json <- params_to_json(params)
 
-      # Call API
+      # Call API. The backend rejects data with missing values, so the
+      # graceful behavior to assert is a clean validation error rather
+      # than a successful analysis.
       cat("Testing with data containing NA values...\n")
       response <- test_run_model(file_data_json, params_json)
 
-      # Validate response
-      assert_response_structure(response)
-      assert_maive_results(response)
-
-      results <- response$data
-
-      # Check that NA values are handled gracefully
-      if (is.na(results$effectEstimate)) {
-        stop("Should handle NA values gracefully")
+      if (!isTRUE(response$error)) {
+        stop("Expected a validation error for data with NA values")
       }
 
-      log_test_result(test_name, "PASS", "NA values handled correctly")
+      if (!grepl("missing values", response$message, ignore.case = TRUE)) {
+        stop(paste("Unexpected error message:", response$message))
+      }
+
+      log_test_result(test_name, "PASS", "NA values rejected with a clear validation error")
 
       return(list(
         status = "PASS",
         test_name = test_name,
-        results = results
+        error_message = response$message
       ))
     },
     error = function(e) {
@@ -191,11 +190,13 @@ test_extreme_values <- function() {
         10 # Very small sample
       )
 
+      # Group observations into 5 studies (3 each) so study dummies leave
+      # enough degrees of freedom for the model.
       extreme_data <- data.frame(
         bs = effects,
         sebs = standard_errors,
         Ns = sample_sizes,
-        study_id = paste0("study_", 1:n_studies)
+        study_id = paste0("study_", rep(1:5, each = 3))
       )
 
       # Prepare parameters
@@ -265,7 +266,8 @@ test_invalid_parameters <- function() {
         maiveMethod = "INVALID_METHOD",
         weight = "equal_weights",
         shouldUseInstrumenting = TRUE,
-        useLogFirstStage = FALSE
+        useLogFirstStage = FALSE,
+        winsorize = 0
       ),
       expected_error = TRUE
     ),
@@ -280,7 +282,8 @@ test_invalid_parameters <- function() {
         maiveMethod = "PET-PEESE",
         weight = "standard_weights",
         shouldUseInstrumenting = TRUE,
-        useLogFirstStage = FALSE
+        useLogFirstStage = FALSE,
+        winsorize = 0
       ),
       expected_error = TRUE
     )
@@ -300,14 +303,26 @@ test_invalid_parameters <- function() {
         file_data_json <- df_to_json(test_data)
         params_json <- params_to_json(test_case$params)
 
-        # Call API
+        # Call API. The endpoint catches model errors and returns a 200
+        # response with an error body, so check the body rather than
+        # relying on test_run_model to throw.
         response <- test_run_model(file_data_json, params_json)
+        got_error <- isTRUE(response$error)
 
-        # If we expected an error but didn't get one
-        if (test_case$expected_error) {
+        if (test_case$expected_error && got_error) {
+          results[[test_case$name]] <- list(
+            status = "PASS",
+            error_message = response$message
+          )
+        } else if (test_case$expected_error) {
           results[[test_case$name]] <- list(
             status = "FAIL",
             error = "Expected error but got successful response"
+          )
+        } else if (got_error) {
+          results[[test_case$name]] <- list(
+            status = "FAIL",
+            error = response$message
           )
         } else {
           results[[test_case$name]] <- list(

--- a/apps/lambda-r-backend/r_scripts/tests/e2e/test_config.R
+++ b/apps/lambda-r-backend/r_scripts/tests/e2e/test_config.R
@@ -1,8 +1,8 @@
 # E2E Test Configuration
 
 # API Configuration
-API_BASE_URL <- "http://localhost:8787"
-API_TIMEOUT <- 30 # seconds
+API_BASE_URL <- Sys.getenv("E2E_API_BASE_URL", "http://localhost:8787")
+API_TIMEOUT <- as.numeric(Sys.getenv("E2E_API_TIMEOUT", "30")) # seconds
 
 # Test Data Configuration
 TEST_DATA_DIR <- "fixtures"


### PR DESCRIPTION
## Summary

Several R e2e scenarios failed against the current backend because their inline parameter lists predate the required `winsorize` parameter, and two edge-case tests asserted behavior the backend no longer has. (The `winsorize = 0` entry in `DEFAULT_PARAMETERS` landed on master separately; this PR covers everything else.)

- Add `winsorize = 0` to every inline `params = list(...)` block in `basic_maive_test.R`, `edge_cases_test.R`, and `debug_test.R`. The "Missing parameters" invalid-input case intentionally stays incomplete.
- Fix `test_invalid_parameters`: the `/run-model` endpoint catches model errors and returns HTTP 200 with an `error = TRUE` body, so the test now inspects the response body instead of expecting `test_run_model` to throw.
- Update `test_data_with_nas`: the MAIVE package now rejects data with missing values ("Column 'bs' must not contain missing values"), so the test asserts a clean validation error instead of a successful run.
- Fix `test_extreme_values`: the fixture had 15 single-observation studies, which fails the backend's degrees-of-freedom check once study dummies are added. The extreme values are kept but grouped into 5 studies of 3 observations, matching the other fixtures.
- Allow overriding the test target and client timeout via `E2E_API_BASE_URL` and `E2E_API_TIMEOUT` (defaults unchanged: `http://localhost:8787`, 30s). Useful when port 8787 is occupied or the machine is under load (bootstrap runs can exceed 30s there).

## Testing

Rebased onto master (which added the api-v1 scenario) and ran the local Plumber backend with `Rscript tests/e2e/run_e2e_tests.R`: all 14 tests pass. `lintr` is clean on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)