### PR TITLE
feat: add /v1 public API endpoints to R backend

### DIFF
--- a/apps/lambda-r-backend/Dockerfile
+++ b/apps/lambda-r-backend/Dockerfile
@@ -91,6 +91,7 @@ COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:0.9.1 /lambda-adapter /opt
 # App code
 WORKDIR ${LAMBDA_TASK_ROOT}
 COPY r_scripts/index.R .
+COPY r_scripts/api_v1.R .
 COPY r_scripts/maive_model.R .
 COPY r_scripts/funnel_plot.R .
 COPY r_scripts/rtma_model.R .

--- a/apps/lambda-r-backend/r_scripts/api_v1.R
+++ b/apps/lambda-r-backend/r_scripts/api_v1.R
@@ -1,0 +1,554 @@
+# Public /v1 API helpers
+#
+# Request parsing, column resolution (design D5), server-side validation
+# (design section 6.2), parameter defaulting (design D6), and structured error
+# envelopes (design section 6.1) for the versioned public routes in index.R.
+# The legacy routes (/run-model, /run-rtma) do not use this file and keep their
+# existing behavior. See docs/PUBLIC_API_DESIGN.md.
+
+API_V1_MODEL_TYPES <- c("MAIVE", "WAIVE", "WLS")
+API_V1_MAIVE_METHODS <- c("PET", "PEESE", "PET-PEESE", "EK")
+API_V1_WEIGHTS <- c(
+  "equal_weights",
+  "standard_weights",
+  "adjusted_weights",
+  "study_weights"
+)
+API_V1_SE_TREATMENTS <- c(
+  "not_clustered",
+  "clustered",
+  "clustered_cr2",
+  "bootstrap"
+)
+
+API_V1_MAIVE_CANONICAL <- c("effect", "se", "n_obs")
+API_V1_RTMA_CANONICAL <- c("effect", "se")
+
+API_V1_MAIVE_PLOT_FIELDS <- c("funnelPlot", "funnelPlotWidth", "funnelPlotHeight")
+API_V1_RTMA_PLOT_FIELDS <- c("zScorePlot", "zScorePlotWidth", "zScorePlotHeight")
+
+# Messages raised by the model layer that describe bad input rather than an
+# unexpected failure; these map to 400 instead of 500. The first five mirror
+# the validation patterns recognized inside run_maive_model().
+API_V1_MODEL_VALIDATION_PATTERNS <- c(
+  "Insufficient data",
+  "Missing required columns",
+  "must be numeric",
+  "must be positive",
+  "degrees of freedom",
+  "Data must have"
+)
+
+API_V1_BODY_SHAPE_MESSAGE <- paste0(
+  "Request body must be a JSON object of the form ",
+  '{"data": [...], "parameters": {...}}.'
+)
+
+#' Signal a validation error that the /v1 handlers translate into a 400
+#'
+#' @param msg Human-readable description of the problem
+api_v1_abort_validation <- function(msg) {
+  # "{msg}" keeps cli from glue-interpolating braces inside the message itself
+  cli::cli_abort("{msg}", class = "api_v1_validation_error", call = NULL)
+}
+
+#' Build the structured error envelope (design section 6.1)
+#'
+#' @param res Plumber response object; its status code is set here
+#' @param status HTTP status code
+#' @param code Machine-readable error code (e.g. "validation_error")
+#' @param msg Human-readable error message
+#' @return The error envelope to serialize as the response body
+api_v1_error_body <- function(res, status, code, msg) {
+  res$status <- status
+  list(error = list(code = code, message = msg))
+}
+
+#' Check whether a parsed value is a JSON object (named list)
+api_v1_is_json_object <- function(x) {
+  is.list(x) && !is.data.frame(x) && (length(x) == 0 || !is.null(names(x)))
+}
+
+#' Parse the plain nested JSON body of a /v1 POST request
+#'
+#' Unlike the legacy routes, /v1 accepts `data` and `parameters` as plain JSON
+#' values (design D4), so the raw body is parsed here without simplification to
+#' preserve each row's keys for column resolution.
+#'
+#' @param req Plumber request object
+#' @return The request body as a named list
+api_v1_request_body <- function(req) {
+  raw_json <- NULL
+  if (!is.null(req$bodyRaw) && length(req$bodyRaw) > 0) {
+    raw_json <- rawToChar(req$bodyRaw)
+  } else if (!is.null(req$postBody) && length(req$postBody) > 0) {
+    raw_json <- paste(req$postBody, collapse = "\n")
+  }
+
+  if (!is.null(raw_json) && nzchar(trimws(raw_json))) {
+    parsed <- tryCatch(
+      jsonlite::fromJSON(raw_json, simplifyVector = FALSE),
+      error = function(e) NULL
+    )
+    if (!api_v1_is_json_object(parsed)) {
+      api_v1_abort_validation(API_V1_BODY_SHAPE_MESSAGE)
+    }
+    return(parsed)
+  }
+
+  # Fall back to the body plumber already parsed when the raw body is not
+  # available on the request object.
+  if (api_v1_is_json_object(req$body) && length(req$body) > 0) {
+    return(req$body)
+  }
+
+  api_v1_abort_validation(API_V1_BODY_SHAPE_MESSAGE)
+}
+
+#' Extract one column from a list of row objects
+#'
+#' @param rows List of named lists (JSON row objects)
+#' @param key Column key to extract; missing values become NA
+#' @return Atomic vector with one value per row
+api_v1_extract_column <- function(rows, key) {
+  values <- lapply(rows, function(row) {
+    value <- row[[key]]
+    if (is.null(value) || length(value) == 0) NA else value
+  })
+  if (any(vapply(values, length, integer(1)) != 1)) {
+    api_v1_abort_validation(
+      sprintf("Each `%s` value must be a scalar (a single number or string).", key)
+    )
+  }
+  unlist(values, use.names = FALSE)
+}
+
+#' Convert the `data` field into a named list of columns
+#'
+#' Accepts either a list of row objects (from api_v1_request_body) or a data
+#' frame (when falling back to plumber's own body parsing).
+#'
+#' @param data The `data` field of the request body
+#' @return Named list of equal-length column vectors, in key order
+api_v1_data_columns <- function(data) {
+  if (is.null(data)) {
+    api_v1_abort_validation(
+      "The request body must include a non-empty `data` array of row objects."
+    )
+  }
+
+  if (is.data.frame(data)) {
+    if (nrow(data) == 0 || ncol(data) == 0) {
+      api_v1_abort_validation("The `data` array must contain at least one row.")
+    }
+    return(as.list(data))
+  }
+
+  if (!is.list(data) || length(data) == 0 || !is.null(names(data))) {
+    api_v1_abort_validation(
+      "The `data` field must be a non-empty JSON array of row objects."
+    )
+  }
+
+  rows_are_objects <- vapply(data, function(row) {
+    is.list(row) && length(row) > 0 && !is.null(names(row)) && all(nzchar(names(row)))
+  }, logical(1))
+  if (!all(rows_are_objects)) {
+    api_v1_abort_validation(
+      "Each entry in `data` must be a JSON object keyed by column name."
+    )
+  }
+
+  keys <- names(data[[1]])
+  columns <- lapply(keys, function(key) api_v1_extract_column(data, key))
+  names(columns) <- keys
+  columns
+}
+
+#' Resolve MAIVE-family columns per design D5
+#'
+#' Canonical keys (effect, se, n_obs, study_id) are selected by name when all
+#' required ones are present; otherwise the keys are taken positionally, which
+#' keeps parity with the legacy positional contract.
+#'
+#' @param data The `data` field of the request body
+#' @return Named list of columns: effect, se, n_obs and optionally study_id
+api_v1_resolve_maive_columns <- function(data) {
+  columns <- api_v1_data_columns(data)
+  keys <- names(columns)
+
+  if (all(API_V1_MAIVE_CANONICAL %in% keys)) {
+    selected <- API_V1_MAIVE_CANONICAL
+    if ("study_id" %in% keys) {
+      selected <- c(selected, "study_id")
+    }
+    return(columns[selected])
+  }
+
+  if (length(keys) < 3 || length(keys) > 4) {
+    api_v1_abort_validation(
+      sprintf("Data must have 3 or 4 columns; found %d.", length(keys))
+    )
+  }
+  names(columns) <- c("effect", "se", "n_obs", "study_id")[seq_along(columns)]
+  columns
+}
+
+#' Resolve RTMA columns per design D5 (effect, se)
+#'
+#' @param data The `data` field of the request body
+#' @return Named list with effect and se columns
+api_v1_resolve_rtma_columns <- function(data) {
+  columns <- api_v1_data_columns(data)
+  keys <- names(columns)
+
+  if (all(API_V1_RTMA_CANONICAL %in% keys)) {
+    return(columns[API_V1_RTMA_CANONICAL])
+  }
+
+  if (length(keys) < 2) {
+    api_v1_abort_validation(
+      sprintf("Data must have at least 2 columns (effect, se); found %d.", length(keys))
+    )
+  }
+  columns <- columns[1:2]
+  names(columns) <- API_V1_RTMA_CANONICAL
+  columns
+}
+
+#' Coerce a column to numeric, rejecting missing or non-numeric entries
+api_v1_coerce_numeric_column <- function(values, column) {
+  parsed <- suppressWarnings(as.numeric(values))
+  if (any(is.na(parsed))) {
+    api_v1_abort_validation(
+      sprintf(
+        "The %s column must contain only numeric values with no missing entries.",
+        column
+      )
+    )
+  }
+  if (any(!is.finite(parsed))) {
+    api_v1_abort_validation(
+      sprintf("The %s column must contain only finite values.", column)
+    )
+  }
+  parsed
+}
+
+#' Validate MAIVE-family data per design section 6.2
+#'
+#' Mirrors the UI validation page rules so API callers get structured 400s:
+#' 3 or 4 columns, at least 4 rows, numeric effect/se/n_obs, se > 0, n_obs
+#' positive integers, and rows >= unique studies + 3 when study_id is present.
+#'
+#' @param data The `data` field of the request body
+#' @return Validated data frame ready for the positional model contract
+api_v1_validate_maive_data <- function(data) {
+  columns <- api_v1_resolve_maive_columns(data)
+  n_rows <- length(columns[[1]])
+
+  if (n_rows < 4) {
+    api_v1_abort_validation(
+      sprintf("Data must contain at least 4 rows; found %d.", n_rows)
+    )
+  }
+
+  df <- data.frame(
+    effect = api_v1_coerce_numeric_column(columns$effect, "effect"),
+    se = api_v1_coerce_numeric_column(columns$se, "se"),
+    n_obs = api_v1_coerce_numeric_column(columns$n_obs, "n_obs"),
+    stringsAsFactors = FALSE
+  )
+
+  if (any(df$se <= 0)) {
+    api_v1_abort_validation(
+      "The se column must contain only positive values (greater than 0)."
+    )
+  }
+  if (any(df$n_obs <= 0 | abs(df$n_obs - round(df$n_obs)) > .Machine$double.eps^0.5)) {
+    api_v1_abort_validation(
+      "The n_obs column must contain only positive integers (greater than 0)."
+    )
+  }
+
+  if (!is.null(columns$study_id)) {
+    study_id_text <- trimws(as.character(columns$study_id))
+    if (any(is.na(columns$study_id) | !nzchar(study_id_text))) {
+      api_v1_abort_validation(
+        "The study_id column contains empty values. Study IDs can be strings or numbers."
+      )
+    }
+    if (n_rows < length(unique(study_id_text)) + 3) {
+      api_v1_abort_validation(
+        "The number of rows must be larger than the number of unique study IDs plus 3."
+      )
+    }
+    df$study_id <- columns$study_id
+  }
+
+  df
+}
+
+#' Validate RTMA data per design section 6.2
+#'
+#' Rows with missing or non-positive se are dropped by run_rtma_model itself
+#' (matching legacy behavior), so only overall usability is enforced here.
+#'
+#' @param data The `data` field of the request body
+#' @return Validated two-column data frame (effect, se)
+api_v1_validate_rtma_data <- function(data) {
+  columns <- api_v1_resolve_rtma_columns(data)
+
+  df <- data.frame(
+    effect = suppressWarnings(as.numeric(columns$effect)),
+    se = suppressWarnings(as.numeric(columns$se)),
+    stringsAsFactors = FALSE
+  )
+
+  valid <- !is.na(df$effect) & !is.na(df$se) & df$se > 0
+  if (!any(valid)) {
+    api_v1_abort_validation(
+      "Data must contain at least one row with a numeric effect and a positive se."
+    )
+  }
+
+  df
+}
+
+#' Normalize the `parameters` field into a named list
+api_v1_parameters_object <- function(parameters) {
+  if (is.null(parameters)) {
+    return(list())
+  }
+  if (!api_v1_is_json_object(parameters)) {
+    api_v1_abort_validation("The `parameters` field must be a JSON object.")
+  }
+  parameters
+}
+
+#' Validate an enum parameter, falling back to its default when absent
+api_v1_enum_parameter <- function(params, name, choices, default) {
+  value <- params[[name]]
+  if (is.null(value)) {
+    return(default)
+  }
+  if (!is.character(value) || length(value) != 1 || !(value %in% choices)) {
+    api_v1_abort_validation(
+      sprintf(
+        "Invalid %s value: %s. Must be one of: %s.",
+        name,
+        paste(unlist(value), collapse = ", "),
+        paste(choices, collapse = ", ")
+      )
+    )
+  }
+  value
+}
+
+#' Validate a boolean parameter, falling back to its default when absent
+api_v1_flag_parameter <- function(params, name, default) {
+  value <- params[[name]]
+  if (is.null(value)) {
+    return(default)
+  }
+  if (!is.logical(value) || length(value) != 1 || is.na(value)) {
+    api_v1_abort_validation(
+      sprintf("Invalid %s value: must be true or false.", name)
+    )
+  }
+  value
+}
+
+#' Validate the winsorize parameter (percent; 0 disables)
+api_v1_winsorize_parameter <- function(params) {
+  value <- params$winsorize
+  if (is.null(value)) {
+    return(0)
+  }
+  if (!is.numeric(value) || length(value) != 1 || is.na(value) || value < 0 || value >= 100) {
+    api_v1_abort_validation(
+      "Invalid winsorize value: must be a percentage between 0 (disabled) and 100."
+    )
+  }
+  value
+}
+
+#' Validate a parameter that must lie strictly between 0 and 1
+api_v1_unit_interval_parameter <- function(params, name, default) {
+  value <- params[[name]]
+  if (is.null(value)) {
+    return(default)
+  }
+  if (!is.numeric(value) || length(value) != 1 || is.na(value) || value <= 0 || value >= 1) {
+    api_v1_abort_validation(
+      sprintf("Invalid %s value: must be a number strictly between 0 and 1.", name)
+    )
+  }
+  value
+}
+
+#' Apply MAIVE-family parameter defaults per design D6
+#'
+#' All parameters are optional; defaults match the UI's
+#' CONFIG.DEFAULT_MODEL_PARAMETERS. shouldUseInstrumenting is derived from
+#' modelType (WLS -> FALSE, otherwise TRUE) unless explicitly provided.
+#'
+#' @param parameters The `parameters` field of the request body (may be NULL)
+#' @return Complete parameter list for run_maive_model()
+api_v1_default_maive_parameters <- function(parameters) {
+  params <- api_v1_parameters_object(parameters)
+  model_type <- api_v1_enum_parameter(params, "modelType", API_V1_MODEL_TYPES, "MAIVE")
+
+  should_use_instrumenting <- if (is.null(params$shouldUseInstrumenting)) {
+    !identical(model_type, "WLS")
+  } else {
+    api_v1_flag_parameter(params, "shouldUseInstrumenting", NA)
+  }
+
+  list(
+    modelType = model_type,
+    maiveMethod = api_v1_enum_parameter(
+      params, "maiveMethod", API_V1_MAIVE_METHODS, "PET-PEESE"
+    ),
+    weight = api_v1_enum_parameter(
+      params, "weight", API_V1_WEIGHTS, "equal_weights"
+    ),
+    standardErrorTreatment = api_v1_enum_parameter(
+      params, "standardErrorTreatment", API_V1_SE_TREATMENTS, "clustered_cr2"
+    ),
+    includeStudyDummies = api_v1_flag_parameter(params, "includeStudyDummies", FALSE),
+    includeStudyClustering = api_v1_flag_parameter(params, "includeStudyClustering", FALSE),
+    computeAndersonRubin = api_v1_flag_parameter(params, "computeAndersonRubin", FALSE),
+    useLogFirstStage = api_v1_flag_parameter(params, "useLogFirstStage", FALSE),
+    winsorize = api_v1_winsorize_parameter(params),
+    shouldUseInstrumenting = should_use_instrumenting
+  )
+}
+
+#' Apply RTMA parameter defaults per design D6
+#'
+#' The internal parallelize/timeoutSeconds knobs are deliberately not exposed;
+#' run_rtma_model falls back to its own safe defaults for them.
+#'
+#' @param parameters The `parameters` field of the request body (may be NULL)
+#' @return Complete parameter list for run_rtma_model()
+api_v1_default_rtma_parameters <- function(parameters) {
+  params <- api_v1_parameters_object(parameters)
+
+  list(
+    favorPositive = api_v1_flag_parameter(params, "favorPositive", TRUE),
+    alphaSelect = api_v1_unit_interval_parameter(params, "alphaSelect", 0.05),
+    ciLevel = api_v1_unit_interval_parameter(params, "ciLevel", 0.95),
+    winsorize = api_v1_winsorize_parameter(params)
+  )
+}
+
+#' Check whether ?include=plot was requested (design D7)
+api_v1_include_plot <- function(include) {
+  if (is.null(include)) {
+    return(FALSE)
+  }
+  requested <- unlist(strsplit(as.character(include), ",", fixed = TRUE))
+  any(trimws(requested) == "plot")
+}
+
+#' Drop base64 plot fields from a results object
+api_v1_strip_plot_fields <- function(results, plot_fields) {
+  results[!(names(results) %in% plot_fields)]
+}
+
+#' Check whether a model error message describes invalid input
+api_v1_is_validation_message <- function(msg) {
+  any(vapply(API_V1_MODEL_VALIDATION_PATTERNS, function(pattern) {
+    grepl(pattern, msg, ignore.case = TRUE)
+  }, logical(1)))
+}
+
+#' Run a /v1 handler, mapping errors to the structured envelope
+#'
+#' Validation errors (both the api_v1_validation_error condition and
+#' validation-type model errors) become 400s; anything else becomes a 500.
+#'
+#' @param res Plumber response object
+#' @param endpoint Endpoint label used in log messages
+#' @param run Zero-argument function producing the success response body
+api_v1_handle <- function(res, endpoint, run) {
+  tryCatch(
+    run(),
+    api_v1_validation_error = function(e) {
+      err_message <- conditionMessage(e)
+      cli::cli_alert_warning("Validation error in {endpoint}: {err_message}")
+      api_v1_error_body(res, 400L, "validation_error", err_message)
+    },
+    error = function(e) {
+      err_message <- conditionMessage(e)
+      if (api_v1_is_validation_message(err_message)) {
+        cli::cli_alert_warning("Validation error in {endpoint}: {err_message}")
+        return(api_v1_error_body(res, 400L, "validation_error", err_message))
+      }
+      cli::cli_alert_danger("Error in {endpoint}: {err_message}")
+      api_v1_error_body(
+        res, 500L, "internal_error",
+        paste("Internal server error:", err_message)
+      )
+    }
+  )
+}
+
+#' Handle POST /v1/run-model
+#'
+#' @param req Plumber request object (plain nested JSON body)
+#' @param res Plumber response object
+#' @param include Query parameter; "plot" embeds the funnel plot fields
+#' @return The flat results object, or a structured error envelope
+api_v1_run_model <- function(req, res, include = "") {
+  api_v1_handle(res, "/v1/run-model", function() {
+    # nolint start: undesirable_function_linter.
+    source("maive_model.R")
+    # nolint end: undesirable_function_linter.
+
+    body <- api_v1_request_body(req)
+    df <- api_v1_validate_maive_data(body$data)
+    params <- api_v1_default_maive_parameters(body$parameters)
+
+    results <- run_maive_model( # nolint: object_usage_linter.
+      jsonlite::toJSON(df, dataframe = "rows", digits = NA),
+      jsonlite::toJSON(params, auto_unbox = TRUE, digits = NA)
+    )
+
+    if (api_v1_include_plot(include)) {
+      results
+    } else {
+      api_v1_strip_plot_fields(results, API_V1_MAIVE_PLOT_FIELDS)
+    }
+  })
+}
+
+#' Handle POST /v1/run-rtma
+#'
+#' @param req Plumber request object (plain nested JSON body)
+#' @param res Plumber response object
+#' @param include Query parameter; "plot" embeds the z-score plot fields
+#' @return The flat results object, or a structured error envelope
+api_v1_run_rtma <- function(req, res, include = "") {
+  api_v1_handle(res, "/v1/run-rtma", function() {
+    # nolint start: undesirable_function_linter.
+    source("rtma_model.R")
+    # nolint end: undesirable_function_linter.
+
+    body <- api_v1_request_body(req)
+    df <- api_v1_validate_rtma_data(body$data)
+    params <- api_v1_default_rtma_parameters(body$parameters)
+
+    results <- run_rtma_model( # nolint: object_usage_linter.
+      jsonlite::toJSON(df, dataframe = "rows", digits = NA),
+      jsonlite::toJSON(params, auto_unbox = TRUE, digits = NA)
+    )
+
+    if (api_v1_include_plot(include)) {
+      results
+    } else {
+      api_v1_strip_plot_fields(results, API_V1_RTMA_PLOT_FIELDS)
+    }
+  })
+}

--- a/apps/lambda-r-backend/r_scripts/index.R
+++ b/apps/lambda-r-backend/r_scripts/index.R
@@ -84,3 +84,34 @@ function(data, parameters) {
     }
   )
 }
+
+# -- Public /v1 API (docs/PUBLIC_API_DESIGN.md) ------------------------------
+# Versioned routes with a plain nested JSON contract, server-side validation,
+# parameter defaults, and real HTTP status codes. The legacy routes above are
+# untouched; the UI depends on them unchanged.
+
+#* Health check (public /v1 alias of /health)
+#* @get /v1/health
+function() {
+  list(status = "ok", time = format(Sys.time(), tz = "UTC"))
+}
+
+#* Run the MAIVE/WAIVE/WLS model via the public /v1 API
+#* @param include Set to "plot" to include the funnel plot fields in the response
+#* @post /v1/run-model
+function(req, res, include = "", ...) {
+  # nolint start: undesirable_function_linter.
+  source("api_v1.R")
+  # nolint end: undesirable_function_linter.
+  api_v1_run_model(req, res, include = include)
+}
+
+#* Run the RTMA model via the public /v1 API
+#* @param include Set to "plot" to include the z-score plot fields in the response
+#* @post /v1/run-rtma
+function(req, res, include = "", ...) {
+  # nolint start: undesirable_function_linter.
+  source("api_v1.R")
+  # nolint end: undesirable_function_linter.
+  api_v1_run_rtma(req, res, include = include)
+}

--- a/apps/lambda-r-backend/r_scripts/tests/e2e/run_e2e_tests.R
+++ b/apps/lambda-r-backend/r_scripts/tests/e2e/run_e2e_tests.R
@@ -38,6 +38,7 @@ source(file.path(script_dir, "scenarios/basic_maive_test.R"))
 source(file.path(script_dir, "scenarios/publication_bias_test.R"))
 source(file.path(script_dir, "scenarios/edge_cases_test.R"))
 source(file.path(script_dir, "scenarios/basic_rtma_test.R"))
+source(file.path(script_dir, "scenarios/api_v1_test.R"))
 
 # Define available test scenarios
 AVAILABLE_SCENARIOS <- list(
@@ -102,6 +103,13 @@ AVAILABLE_SCENARIOS <- list(
     name = "Basic RTMA Test",
     description = "Test basic RTMA functionality with phacking package",
     function_name = "test_basic_rtma"
+  ),
+
+  # Public /v1 API scenarios
+  "api-v1" = list(
+    name = "API v1 Test",
+    description = "Test the public /v1 endpoints (validation, defaults, plot opt-in)",
+    function_name = "test_api_v1"
   ),
 
   # Special scenarios
@@ -355,6 +363,18 @@ run_all_scenarios <- function(api_url = NULL, verbose = TRUE) {
     }
     test_count <- test_count + 1
   }
+
+  # Public /v1 API tests
+  cat("\n7. Running API v1 tests...\n")
+  api_v1_result <- test_api_v1()
+  all_results$api_v1 <- api_v1_result
+  if (api_v1_result$status == "PASS") {
+    passed_count <- passed_count + 1
+    cat("   ✓ API v1 test passed\n")
+  } else {
+    cat("   ✗ API v1 test failed:", api_v1_result$error, "\n")
+  }
+  test_count <- test_count + 1
 
   # Summary
   cat("\n", paste(rep("=", 60), collapse = ""), "\n")

--- a/apps/lambda-r-backend/r_scripts/tests/e2e/scenarios/api_v1_test.R
+++ b/apps/lambda-r-backend/r_scripts/tests/e2e/scenarios/api_v1_test.R
@@ -1,0 +1,342 @@
+# API v1 Test Scenario
+#
+# Covers the public /v1 routes (docs/PUBLIC_API_DESIGN.md): plain nested JSON
+# request bodies, column resolution by canonical name with positional
+# fallback, parameter defaulting, structured 400 validation errors, plot
+# opt-in via ?include=plot, the /v1/health alias, and unchanged legacy-route
+# behavior.
+
+#' Load a CSV fixture from the shared fixtures directory
+load_api_v1_fixture <- function(file) {
+  read.csv(file.path(TEST_DATA_DIR, file), stringsAsFactors = FALSE)
+}
+
+#' Fail with a message unless a condition holds
+expect_api_v1 <- function(condition, message) {
+  if (!isTRUE(condition)) {
+    stop(message)
+  }
+}
+
+#' Assert a /v1 response carries the structured 400 validation envelope
+expect_api_v1_validation_error <- function(response, label) {
+  status <- httr::status_code(response)
+  expect_api_v1(
+    status == 400,
+    sprintf("%s: expected status 400, got %d", label, status)
+  )
+
+  body <- v1_parse_body(response)
+  expect_api_v1(
+    identical(body$error$code, "validation_error"),
+    sprintf("%s: expected error code 'validation_error'", label)
+  )
+  expect_api_v1(
+    is.character(body$error$message) && nzchar(body$error$message),
+    sprintf("%s: expected a non-empty error message", label)
+  )
+}
+
+#' Assert a /v1 response succeeded and return its parsed body
+expect_api_v1_success <- function(response, label) {
+  status <- httr::status_code(response)
+  if (status != 200) {
+    body <- tryCatch(v1_parse_body(response), error = function(e) NULL)
+    detail <- if (!is.null(body$error$message)) body$error$message else ""
+    stop(sprintf("%s: expected status 200, got %d. %s", label, status, detail))
+  }
+  v1_parse_body(response)
+}
+
+#' Test the public /v1 API surface
+#' @return Test results
+test_api_v1 <- function() {
+  test_name <- "API v1 Test"
+
+  tryCatch(
+    {
+      fixture_3col <- load_api_v1_fixture("sample_data_3col.csv")
+      fixture_4col <- load_api_v1_fixture("sample_data_4col.csv")
+
+      canonical_df <- data.frame(
+        effect = fixture_3col$bs,
+        se = fixture_3col$sebs,
+        n_obs = fixture_3col$Ns
+      )
+      canonical_rows <- df_to_v1_rows(canonical_df)
+      positional_rows <- df_to_v1_rows(fixture_3col) # keys bs/sebs/Ns -> positional
+
+      # The raw 4-column fixture has one unique study per row, which violates
+      # the "rows >= unique studies + 3" rule; regroup into 5 studies of 4
+      # rows for the happy path and keep the raw fixture for the 400 test.
+      grouped_4col <- fixture_4col
+      grouped_4col$study_id <- paste0("study_", rep(seq_len(5), each = 4))
+      grouped_rows <- df_to_v1_rows(grouped_4col)
+
+      # 1. GET /v1/health
+      cat("Testing GET /v1/health...\n")
+      health_body <- expect_api_v1_success(v1_get("/v1/health"), "GET /v1/health")
+      expect_api_v1(
+        identical(health_body$status, "ok"),
+        "GET /v1/health: expected status field 'ok'"
+      )
+      expect_api_v1(
+        is.character(health_body$time) && nzchar(health_body$time),
+        "GET /v1/health: expected a non-empty time field"
+      )
+
+      # 2. Happy path with explicit parameters (positional 4-column data)
+      cat("Testing /v1/run-model happy path with explicit parameters...\n")
+      explicit_params <- list(
+        modelType = "MAIVE",
+        maiveMethod = "PET-PEESE",
+        weight = "equal_weights",
+        standardErrorTreatment = "clustered_cr2",
+        includeStudyDummies = FALSE,
+        includeStudyClustering = TRUE,
+        computeAndersonRubin = FALSE,
+        useLogFirstStage = FALSE,
+        winsorize = 0,
+        shouldUseInstrumenting = TRUE
+      )
+      explicit_body <- expect_api_v1_success(
+        v1_post_json(
+          "/v1/run-model",
+          list(data = grouped_rows, parameters = explicit_params)
+        ),
+        "explicit-params run"
+      )
+      expect_api_v1(
+        is.numeric(explicit_body$effectEstimate),
+        "explicit-params run: effectEstimate should be numeric"
+      )
+      expect_api_v1(
+        is.numeric(explicit_body$standardError) && explicit_body$standardError > 0,
+        "explicit-params run: standardError should be positive"
+      )
+      expect_api_v1(
+        is.null(explicit_body$data),
+        "explicit-params run: results must be at the top level (no data envelope)"
+      )
+      expect_api_v1(
+        is.null(explicit_body$funnelPlot) && is.null(explicit_body$funnelPlotWidth),
+        "explicit-params run: plot fields must be stripped by default"
+      )
+
+      # 3. Minimal request: data only, all defaults applied
+      cat("Testing /v1/run-model minimal request (defaults)...\n")
+      minimal_body <- expect_api_v1_success(
+        v1_post_json("/v1/run-model", list(data = canonical_rows)),
+        "minimal run"
+      )
+      expect_api_v1(
+        is.numeric(minimal_body$effectEstimate),
+        "minimal run: effectEstimate should be numeric"
+      )
+      expect_api_v1(
+        is.null(minimal_body$funnelPlot),
+        "minimal run: plot fields must be stripped by default"
+      )
+
+      # 4. Positional fallback matches canonical resolution on the same data
+      cat("Testing /v1/run-model positional column fallback...\n")
+      positional_body <- expect_api_v1_success(
+        v1_post_json("/v1/run-model", list(data = positional_rows)),
+        "positional run"
+      )
+      expect_api_v1(
+        abs(positional_body$effectEstimate - minimal_body$effectEstimate) < 1e-8,
+        "positional run: estimate should match the canonical-name run"
+      )
+
+      # 5. Canonical names win over key order
+      cat("Testing /v1/run-model canonical name resolution...\n")
+      scrambled_rows <- lapply(canonical_rows, function(row) {
+        row[c("n_obs", "effect", "se")]
+      })
+      scrambled_body <- expect_api_v1_success(
+        v1_post_json("/v1/run-model", list(data = scrambled_rows)),
+        "scrambled-keys run"
+      )
+      expect_api_v1(
+        abs(scrambled_body$effectEstimate - minimal_body$effectEstimate) < 1e-8,
+        "scrambled-keys run: canonical keys must be resolved by name, not position"
+      )
+
+      # 6. Plot opt-in via ?include=plot
+      cat("Testing /v1/run-model plot opt-in...\n")
+      plot_body <- expect_api_v1_success(
+        v1_post_json(
+          "/v1/run-model",
+          list(data = canonical_rows),
+          query = list(include = "plot")
+        ),
+        "plot opt-in run"
+      )
+      expect_api_v1(
+        is.character(plot_body$funnelPlot) &&
+          startsWith(plot_body$funnelPlot, "data:image/png;base64,"),
+        "plot opt-in run: funnelPlot should be a PNG data URI"
+      )
+      expect_api_v1(
+        is.numeric(plot_body$funnelPlotWidth) && plot_body$funnelPlotWidth > 0,
+        "plot opt-in run: funnelPlotWidth should be positive"
+      )
+
+      # 7. Validation failures return structured 400s
+      cat("Testing /v1/run-model validation errors...\n")
+      expect_api_v1_validation_error(
+        v1_post_json("/v1/run-model", list(data = canonical_rows[1:3])),
+        "too few rows"
+      )
+
+      five_col_rows <- lapply(canonical_rows, function(row) {
+        c(stats::setNames(row, c("a", "b", "c")), list(d = 1, e = 2))
+      })
+      expect_api_v1_validation_error(
+        v1_post_json("/v1/run-model", list(data = five_col_rows)),
+        "wrong column count"
+      )
+
+      non_numeric_rows <- canonical_rows
+      non_numeric_rows[[1]]$effect <- "not-a-number"
+      expect_api_v1_validation_error(
+        v1_post_json("/v1/run-model", list(data = non_numeric_rows)),
+        "non-numeric effect"
+      )
+
+      bad_se_rows <- canonical_rows
+      bad_se_rows[[1]]$se <- 0
+      expect_api_v1_validation_error(
+        v1_post_json("/v1/run-model", list(data = bad_se_rows)),
+        "non-positive se"
+      )
+
+      bad_n_obs_rows <- canonical_rows
+      bad_n_obs_rows[[1]]$n_obs <- 10.5
+      expect_api_v1_validation_error(
+        v1_post_json("/v1/run-model", list(data = bad_n_obs_rows)),
+        "non-integer n_obs"
+      )
+
+      # The raw 4-column fixture: 20 rows, 20 unique studies -> rule violated
+      expect_api_v1_validation_error(
+        v1_post_json("/v1/run-model", list(data = df_to_v1_rows(fixture_4col))),
+        "rows vs unique studies rule"
+      )
+
+      expect_api_v1_validation_error(
+        v1_post_json("/v1/run-model", list(parameters = list(modelType = "MAIVE"))),
+        "missing data field"
+      )
+
+      expect_api_v1_validation_error(
+        v1_post_json(
+          "/v1/run-model",
+          list(data = canonical_rows, parameters = list(modelType = "INVALID"))
+        ),
+        "invalid modelType enum"
+      )
+
+      expect_api_v1_validation_error(
+        v1_post_json(
+          "/v1/run-model",
+          list(data = canonical_rows, parameters = list(computeAndersonRubin = "yes"))
+        ),
+        "non-boolean flag parameter"
+      )
+
+      # 8. RTMA: minimal request with defaults, plots stripped
+      # Deterministic data with a solid share of nonaffirmative estimates;
+      # mostly-affirmative datasets make the phacking sampler unpredictably
+      # slow, which would flake this test.
+      cat("Testing /v1/run-rtma minimal request (this may take a while)...\n")
+      rtma_data <- data.frame(
+        effect = rep(c(0.05, 0.10, 0.15, 0.25, 0.35), each = 8),
+        se = rep(0.1, 40)
+      )
+      rtma_body <- expect_api_v1_success(
+        v1_post_json(
+          "/v1/run-rtma",
+          list(data = df_to_v1_rows(rtma_data)),
+          timeout = 300
+        ),
+        "RTMA minimal run"
+      )
+      expect_api_v1(
+        is.numeric(rtma_body$mu),
+        "RTMA minimal run: mu should be numeric"
+      )
+      expect_api_v1(
+        length(rtma_body$muCI) == 2,
+        "RTMA minimal run: muCI should have 2 elements"
+      )
+      expect_api_v1(
+        is.null(rtma_body$zScorePlot) && is.null(rtma_body$zScorePlotWidth),
+        "RTMA minimal run: plot fields must be stripped by default"
+      )
+
+      # 9. RTMA validation failure: single-column data
+      cat("Testing /v1/run-rtma validation errors...\n")
+      one_col_rows <- lapply(fixture_3col$bs, function(value) list(x = value))
+      expect_api_v1_validation_error(
+        v1_post_json("/v1/run-rtma", list(data = one_col_rows)),
+        "RTMA single column"
+      )
+
+      # 10. Legacy routes still behave as before (200 + data envelope,
+      # and 200 with an error body on failure)
+      cat("Testing legacy route parity...\n")
+      legacy_response <- test_run_model(
+        df_to_json(grouped_4col),
+        params_to_json(DEFAULT_PARAMETERS)
+      )
+      expect_api_v1(
+        is.numeric(legacy_response$data$effectEstimate),
+        "legacy run-model: expected results under a data envelope"
+      )
+      expect_api_v1(
+        is.character(legacy_response$data$funnelPlot) &&
+          nzchar(legacy_response$data$funnelPlot),
+        "legacy run-model: funnel plot should still be included"
+      )
+
+      legacy_error_response <- httr::POST(
+        paste0(API_BASE_URL, "/run-model"),
+        body = list(
+          data = "not json",
+          parameters = params_to_json(DEFAULT_PARAMETERS)
+        ),
+        encode = "form",
+        httr::timeout(API_TIMEOUT)
+      )
+      expect_api_v1(
+        httr::status_code(legacy_error_response) == 200,
+        "legacy run-model error: must keep returning HTTP 200"
+      )
+      legacy_error_body <- httr::content(legacy_error_response, "parsed")
+      expect_api_v1(
+        isTRUE(legacy_error_body$error),
+        "legacy run-model error: must keep the {error: true} body shape"
+      )
+
+      log_test_result(
+        test_name, "PASS",
+        "Public /v1 endpoints working correctly; legacy routes unchanged"
+      )
+
+      return(list(
+        status = "PASS",
+        test_name = test_name
+      ))
+    },
+    error = function(e) {
+      log_test_result(test_name, "FAIL", e$message)
+      return(list(
+        status = "FAIL",
+        test_name = test_name,
+        error = e$message
+      ))
+    }
+  )
+}

--- a/apps/lambda-r-backend/r_scripts/tests/e2e/test_config.R
+++ b/apps/lambda-r-backend/r_scripts/tests/e2e/test_config.R
@@ -45,6 +45,7 @@ DEFAULT_PARAMETERS <- list(
   weight = "equal_weights",
   shouldUseInstrumenting = TRUE,
   useLogFirstStage = FALSE,
+  winsorize = 0,
   # The UI forwards the full ModelParameters object, which carries the
   # RTMA-only favorPositive key. run_maive_model must tolerate extra keys.
   favorPositive = TRUE

--- a/apps/lambda-r-backend/r_scripts/tests/e2e/utils/api_client.R
+++ b/apps/lambda-r-backend/r_scripts/tests/e2e/utils/api_client.R
@@ -107,6 +107,53 @@ test_run_rtma <- function(data, parameters,
   )
 }
 
+#' POST a plain nested JSON body to a public /v1 endpoint
+#'
+#' Unlike the legacy helpers above, this sends `application/json` (no form
+#' encoding, no double-encoded JSON strings) and returns the raw httr response
+#' so tests can assert on HTTP status codes and error envelopes.
+#'
+#' @param path Endpoint path (e.g. "/v1/run-model")
+#' @param body Request body as an R list (e.g. list(data = ..., parameters = ...))
+#' @param query Optional named list of query parameters (e.g. list(include = "plot"))
+#' @param base_url Base URL of the API
+#' @param timeout Timeout in seconds
+#' @return Raw httr response object
+v1_post_json <- function(path, body, query = NULL,
+                         base_url = API_BASE_URL,
+                         timeout = API_TIMEOUT) {
+  httr::POST(
+    paste0(base_url, path),
+    body = jsonlite::toJSON(body, auto_unbox = TRUE, digits = NA, null = "null"),
+    httr::content_type_json(),
+    query = query,
+    httr::timeout(timeout)
+  )
+}
+
+#' GET a public /v1 endpoint
+#' @param path Endpoint path (e.g. "/v1/health")
+#' @param base_url Base URL of the API
+#' @param timeout Timeout in seconds
+#' @return Raw httr response object
+v1_get <- function(path, base_url = API_BASE_URL, timeout = API_TIMEOUT) {
+  httr::GET(paste0(base_url, path), httr::timeout(timeout))
+}
+
+#' Parse a /v1 JSON response body into an R list
+#' @param response Raw httr response object
+#' @return Parsed response body
+v1_parse_body <- function(response) {
+  httr::content(response, "parsed")
+}
+
+#' Convert a data frame into a list of /v1 row objects
+#' @param df Data frame to convert
+#' @return Unnamed list of named lists, one per row
+df_to_v1_rows <- function(df) {
+  lapply(seq_len(nrow(df)), function(i) as.list(df[i, , drop = FALSE]))
+}
+
 #' Convert data frame to JSON string for API
 #' @param df Data frame to convert
 #' @return JSON string


### PR DESCRIPTION
Phase 1 (R side) of the public model API, per docs/PUBLIC_API_DESIGN.md (scope of record, merged in #465). Everything is additive and ships dark: the legacy routes (POST /run-model, POST /run-rtma) and all UI code are untouched.

## What's included

**New routes** ([index.R](apps/lambda-r-backend/r_scripts/index.R)):
- `POST /v1/run-model` and `POST /v1/run-rtma`: accept a plain nested JSON body `{"data": [{...}], "parameters": {...}}` (no double-encoded strings), return the flat results object at the top level (no `{data: ...}` envelope)
- `GET /v1/health`: alias of `/health`

**New helper file** ([api_v1.R](apps/lambda-r-backend/r_scripts/api_v1.R)):
- Column resolution per D5: canonical keys (`effect`, `se`, `n_obs`, `study_id`) selected by name when present, positional fallback otherwise; the resolved frame feeds the unchanged positional model contract
- Server-side validation per section 6.2, mirroring the UI validation page: 3 or 4 columns, at least 4 rows, numeric effect/se/n_obs, se > 0, n_obs positive integers, rows >= unique studies + 3 when study_id is present; RTMA needs 2+ columns
- Parameter defaulting per D6: all parameters optional, defaults match `CONFIG.DEFAULT_MODEL_PARAMETERS`; `shouldUseInstrumenting` derived from modelType (WLS -> false) unless explicitly set; enums validated with 400 on bad values; RTMA's internal `parallelize`/`timeoutSeconds` are not exposed
- Structured error envelope per section 6.1: `{"error": {"code": "validation_error" | "internal_error", "message": ...}}` with real 400/500 status codes; validation-type model errors map to 400
- Plot fields (`funnelPlot*`, `zScorePlot*`) stripped unless `?include=plot` (D7)

The handlers re-encode the validated input with `jsonlite::toJSON(df, dataframe = "rows")` / `toJSON(params, auto_unbox = TRUE)` and call the unchanged `run_maive_model()` / `run_rtma_model()`.

**Dockerfile**: `COPY r_scripts/api_v1.R .`

**Tests**: new e2e scenario [api_v1_test.R](apps/lambda-r-backend/r_scripts/tests/e2e/scenarios/api_v1_test.R) (registered as `--scenario api-v1` and in the all-scenarios run) covering the happy path with explicit params, the minimal `{"data": [...]}` request, canonical-vs-positional column resolution (scrambled key order must not change results), each validation failure returning the structured 400 envelope, plot opt-in on/off, `GET /v1/health`, and legacy-route parity (200 + `data` envelope on success, HTTP 200 with `{error: true}` body on failure). [api_client.R](apps/lambda-r-backend/r_scripts/tests/e2e/utils/api_client.R) gains `v1_post_json`/`v1_get`/`v1_parse_body`/`df_to_v1_rows` helpers that send real JSON bodies. The 4-column fixture is reused as-is for the study-count rule test (its 20 unique studies violate it) and with regrouped study ids for the happy path.

## Also in this PR

`DEFAULT_PARAMETERS` in [test_config.R](apps/lambda-r-backend/r_scripts/tests/e2e/test_config.R) was missing `winsorize`, which `run_maive_model` now requires; this broke several existing scenarios before this PR. Added `winsorize = 0`, which fixes `basic` and the legacy-parity baseline. The remaining scenarios with inline (non-config) param lists are being fixed separately.

## Known limitation

A body that is not parseable JSON at all fails in plumber's own parser before the /v1 handler runs and returns plumber's default 500 rather than the section 6.1 envelope. `@parser none` cannot fix this (its content-type alias is broken in plumber 1.3.0, failing every request); every JSON-object body, including `{}` and wrong shapes, does get the proper 400 envelope.

## Verification

Ran locally against `npm run r:dev` (R 4.5.1, plumber 1.3.0): `Rscript tests/e2e/run_e2e_tests.R --scenario api-v1` passes repeatedly on cold and warm servers, and `--scenario basic`, `basic-rtma`, and the plumb syntax check pass. Full-suite failures in `parameter-combinations` and three edge-case scenarios are pre-existing (inline param lists missing `winsorize`) and tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)