### PR TITLE
fix: align /v1 API implementations after integration pass

### DIFF
--- a/apps/lambda-r-backend/r_scripts/api_v1.R
+++ b/apps/lambda-r-backend/r_scripts/api_v1.R
@@ -36,7 +36,8 @@ API_V1_MODEL_VALIDATION_PATTERNS <- c(
   "must be numeric",
   "must be positive",
   "degrees of freedom",
-  "Data must have"
+  "Data must have",
+  "nonaffirmative"
 )
 
 API_V1_BODY_SHAPE_MESSAGE <- paste0(
@@ -61,6 +62,9 @@ api_v1_abort_validation <- function(msg) {
 #' @return The error envelope to serialize as the response body
 api_v1_error_body <- function(res, status, code, msg) {
   res$status <- status
+  # cli_abort wraps long messages with embedded newlines; collapse them so the
+  # JSON error message is a single line
+  msg <- gsub("[[:space:]]+", " ", msg)
   list(error = list(code = code, message = msg))
 }
 
@@ -176,13 +180,18 @@ api_v1_data_columns <- function(data) {
 api_v1_resolve_maive_columns <- function(data) {
   columns <- api_v1_data_columns(data)
   keys <- names(columns)
+  keys_lower <- tolower(keys)
 
-  if (all(API_V1_MAIVE_CANONICAL %in% keys)) {
-    selected <- API_V1_MAIVE_CANONICAL
-    if ("study_id" %in% keys) {
-      selected <- c(selected, "study_id")
+  if (all(API_V1_MAIVE_CANONICAL %in% keys_lower)) {
+    selected <- match(API_V1_MAIVE_CANONICAL, keys_lower)
+    resolved_names <- API_V1_MAIVE_CANONICAL
+    if ("study_id" %in% keys_lower) {
+      selected <- c(selected, match("study_id", keys_lower))
+      resolved_names <- c(resolved_names, "study_id")
     }
-    return(columns[selected])
+    columns <- columns[selected]
+    names(columns) <- resolved_names
+    return(columns)
   }
 
   if (length(keys) < 3 || length(keys) > 4) {
@@ -201,9 +210,12 @@ api_v1_resolve_maive_columns <- function(data) {
 api_v1_resolve_rtma_columns <- function(data) {
   columns <- api_v1_data_columns(data)
   keys <- names(columns)
+  keys_lower <- tolower(keys)
 
-  if (all(API_V1_RTMA_CANONICAL %in% keys)) {
-    return(columns[API_V1_RTMA_CANONICAL])
+  if (all(API_V1_RTMA_CANONICAL %in% keys_lower)) {
+    columns <- columns[match(API_V1_RTMA_CANONICAL, keys_lower)]
+    names(columns) <- API_V1_RTMA_CANONICAL
+    return(columns)
   }
 
   if (length(keys) < 2) {

--- a/apps/lambda-r-backend/r_scripts/host.R
+++ b/apps/lambda-r-backend/r_scripts/host.R
@@ -74,4 +74,43 @@ pr$filter("cors", function(req, res) {
   forward()
 })
 
+# ---- GLOBAL ERROR HANDLER ------------------------------------------------
+# Body parsing runs before route handlers, so a malformed JSON body never
+# reaches the /v1 handlers' own error mapping and would surface as plumber's
+# default 500. Give /v1 requests the structured envelope (see
+# docs/PUBLIC_API_DESIGN.md section 6.1); keep plumber's default shape for all
+# other routes so legacy behavior is unchanged.
+pr$setErrorHandler(function(req, res, err) {
+  err_message <- conditionMessage(err)
+  path <- req$PATH_INFO %||% ""
+
+  if (startsWith(path, "/v1/")) {
+    is_parse_error <- grepl(
+      "lexical error|parse error|invalid|unexpected",
+      err_message,
+      ignore.case = TRUE
+    )
+    if (is_parse_error) {
+      res$status <- 400L
+      return(list(error = list(
+        code = "validation_error",
+        message = paste0(
+          "Request body must be valid JSON of the form ",
+          "{\"data\": [...], \"parameters\": {...}}."
+        )
+      )))
+    }
+    cli::cli_alert_danger("Unhandled error on {path}: {err_message}")
+    res$status <- 500L
+    return(list(error = list(
+      code = "internal_error",
+      message = "Internal server error."
+    )))
+  }
+
+  cli::cli_alert_danger("Unhandled error on {path}: {err_message}")
+  res$status <- 500L
+  list(error = "500 - Internal server error")
+})
+
 pr$run(host = R_HOST, port = R_PORT)

--- a/apps/lambda-r-backend/r_scripts/tests/e2e/scenarios/api_v1_test.R
+++ b/apps/lambda-r-backend/r_scripts/tests/e2e/scenarios/api_v1_test.R
@@ -246,6 +246,27 @@ test_api_v1 <- function() {
         "non-boolean flag parameter"
       )
 
+      # A body that is not valid JSON fails before the handler runs; the
+      # global error handler in host.R must still produce the 400 envelope.
+      expect_api_v1_validation_error(
+        v1_post_raw("/v1/run-model", "not json at all"),
+        "malformed JSON body"
+      )
+
+      # Canonical names are matched case-insensitively
+      cat("Testing /v1/run-model case-insensitive canonical names...\n")
+      uppercase_rows <- lapply(canonical_rows, function(row) {
+        stats::setNames(row, toupper(names(row)))
+      })
+      uppercase_body <- expect_api_v1_success(
+        v1_post_json("/v1/run-model", list(data = uppercase_rows)),
+        "uppercase-keys run"
+      )
+      expect_api_v1(
+        abs(uppercase_body$effectEstimate - minimal_body$effectEstimate) < 1e-8,
+        "uppercase-keys run: canonical names must match case-insensitively"
+      )
+
       # 8. RTMA: minimal request with defaults, plots stripped
       # Deterministic data with a solid share of nonaffirmative estimates;
       # mostly-affirmative datasets make the phacking sampler unpredictably

--- a/apps/lambda-r-backend/r_scripts/tests/e2e/utils/api_client.R
+++ b/apps/lambda-r-backend/r_scripts/tests/e2e/utils/api_client.R
@@ -131,6 +131,27 @@ v1_post_json <- function(path, body, query = NULL,
   )
 }
 
+#' POST a raw (possibly invalid) body to a public /v1 endpoint
+#'
+#' Used to exercise the malformed-body error path, which v1_post_json cannot
+#' produce because it always serializes valid JSON.
+#'
+#' @param path Endpoint path (e.g. "/v1/run-model")
+#' @param body Raw request body string, sent as application/json
+#' @param base_url Base URL of the API
+#' @param timeout Timeout in seconds
+#' @return Raw httr response object
+v1_post_raw <- function(path, body,
+                        base_url = API_BASE_URL,
+                        timeout = API_TIMEOUT) {
+  httr::POST(
+    paste0(base_url, path),
+    body = body,
+    httr::content_type_json(),
+    httr::timeout(timeout)
+  )
+}
+
 #' GET a public /v1 endpoint
 #' @param path Endpoint path (e.g. "/v1/health")
 #' @param base_url Base URL of the API

--- a/apps/react-ui/client/src/api/server/datasetValidation.ts
+++ b/apps/react-ui/client/src/api/server/datasetValidation.ts
@@ -13,6 +13,8 @@ export type ResolvedColumns = {
   se: string;
   nObs?: string;
   studyId?: string;
+  /** True when resolved by canonical names rather than positionally. */
+  byName: boolean;
 };
 
 export type ValidationError = { message: string };
@@ -43,14 +45,26 @@ export const resolveColumns = (
   const studyIdKey = findKeyCaseInsensitive(first, "study_id");
 
   if (effectKey && seKey && nObsKey) {
-    return { effect: effectKey, se: seKey, nObs: nObsKey, studyId: studyIdKey };
+    return {
+      effect: effectKey,
+      se: seKey,
+      nObs: nObsKey,
+      studyId: studyIdKey,
+      byName: true,
+    };
   }
 
   const keys = Object.keys(first);
   if (keys.length < 2) {
     return null;
   }
-  return { effect: keys[0], se: keys[1], nObs: keys[2], studyId: keys[3] };
+  return {
+    effect: keys[0],
+    se: keys[1],
+    nObs: keys[2],
+    studyId: keys[3],
+    byName: false,
+  };
 };
 
 const isFiniteNumber = (value: unknown): boolean => {
@@ -93,16 +107,18 @@ export const validateDataset = (
   }
 
   if (!isRtma) {
-    const resolvedCount = [
-      columns.effect,
-      columns.se,
-      columns.nObs,
-      columns.studyId,
-    ].filter(Boolean).length;
-
-    if (!columns.nObs || resolvedCount < 3 || resolvedCount > 4) {
+    // Positional resolution requires exactly 3-4 columns (matching the sync R
+    // path); by-name resolution tolerates extra columns since they're ignored.
+    const totalKeys = Object.keys(rows[0]).length;
+    if (!columns.byName && (totalKeys < 3 || totalKeys > 4)) {
       return {
-        message: `Data must have 3 or 4 columns; found ${resolvedCount}.`,
+        message: `Data must have 3 or 4 columns; found ${totalKeys}.`,
+      };
+    }
+
+    if (!columns.nObs) {
+      return {
+        message: `Data must have 3 or 4 columns; found ${totalKeys}.`,
       };
     }
 
@@ -162,13 +178,20 @@ export const validateDataset = (
 
   if (!isRtma && columns.studyId) {
     const studyIdKey = columns.studyId;
-    const uniqueStudyIds = new Set(
-      rows
-        .map((row) => row[studyIdKey])
-        .filter(
-          (value) => value !== undefined && value !== null && value !== "",
-        ),
-    ).size;
+    const studyIds = rows.map((row) => row[studyIdKey]);
+
+    const hasEmptyStudyId = studyIds.some(
+      (value) =>
+        value === undefined || value === null || String(value).trim() === "",
+    );
+    if (hasEmptyStudyId) {
+      return {
+        message:
+          "The `study_id` column contains empty values. Study IDs can be strings or numbers.",
+      };
+    }
+
+    const uniqueStudyIds = new Set(studyIds.map((value) => String(value))).size;
 
     if (rows.length < uniqueStudyIds + 3) {
       return {

--- a/apps/react-ui/client/src/api/server/modelParameterDefaults.ts
+++ b/apps/react-ui/client/src/api/server/modelParameterDefaults.ts
@@ -1,12 +1,19 @@
 import CONST from "@src/CONST";
 import CONFIG from "@src/CONFIG";
 import type { ModelParameters, RTMAParameters } from "@src/types/api";
+import type { ValidationError } from "@api/server/datasetValidation";
 
 // Applies the `/v1/runs` parameter defaults (design D6, §6.5): a minimal
-// valid request is `{ "data": [...] }` — `modelType` defaults to the UI's
+// valid request is `{ "data": [...] }`, where `modelType` defaults to the UI's
 // default model type, and unset parameters fall back to
 // `CONFIG.DEFAULT_MODEL_PARAMETERS`. `modelType: "RTMA"` routes to the RTMA
 // defaults instead, since RTMA has its own parameter shape.
+//
+// Supplied parameters are validated the same way the sync R endpoints
+// validate them (enum membership, numeric bounds, boolean flags), so a bad
+// value fails fast with a 400 instead of queueing a run that dies in R.
+// Only whitelisted keys reach the queued parameter object, keeping the async
+// payload identical to what the sync path sends.
 
 const RTMA_DEFAULTS: Omit<RTMAParameters, "modelType"> = {
   favorPositive: true,
@@ -15,10 +22,23 @@ const RTMA_DEFAULTS: Omit<RTMAParameters, "modelType"> = {
   winsorize: 0,
 };
 
+const MODEL_TYPE_VALUES = Object.values(CONST.MODEL_TYPES);
+const MAIVE_METHOD_VALUES = Object.values(CONST.MAIVE_METHODS);
+const WEIGHT_VALUES = Object.values(CONST.WEIGHT_OPTIONS).map(
+  (option) => option.VALUE,
+);
+const SE_TREATMENT_VALUES = Object.values(CONST.STANDARD_ERROR_TREATMENTS).map(
+  (option) => option.VALUE,
+);
+
 export type ResolvedRunParameters = {
   modelType: string;
   parameters: ModelParameters | RTMAParameters;
 };
+
+export type ResolveRunParametersResult =
+  | { resolved: ResolvedRunParameters; error?: undefined }
+  | { resolved?: undefined; error: ValidationError };
 
 const asOverrides = (parametersInput: unknown): Record<string, unknown> =>
   parametersInput &&
@@ -27,51 +47,196 @@ const asOverrides = (parametersInput: unknown): Record<string, unknown> =>
     ? (parametersInput as Record<string, unknown>)
     : {};
 
-export const resolveRunParameters = (
+class ParameterValidationError extends Error {}
+
+const invalid = (message: string): never => {
+  throw new ParameterValidationError(message);
+};
+
+const enumParameter = <T extends string>(
+  overrides: Record<string, unknown>,
+  name: string,
+  choices: readonly string[],
+  fallback: T,
+): T => {
+  const value = overrides[name];
+  if (value === undefined || value === null) {
+    return fallback;
+  }
+  if (typeof value !== "string" || !choices.includes(value)) {
+    invalid(
+      `Invalid ${name} value: ${String(value)}. Must be one of: ${choices.join(", ")}.`,
+    );
+  }
+  return value as T;
+};
+
+const flagParameter = (
+  overrides: Record<string, unknown>,
+  name: string,
+  fallback: boolean,
+): boolean => {
+  const value = overrides[name];
+  if (value === undefined || value === null) {
+    return fallback;
+  }
+  if (typeof value !== "boolean") {
+    invalid(`Invalid ${name} value: must be true or false.`);
+  }
+  return value as boolean;
+};
+
+const winsorizeParameter = (overrides: Record<string, unknown>): number => {
+  const value = overrides.winsorize;
+  if (value === undefined || value === null) {
+    return 0;
+  }
+  if (
+    typeof value !== "number" ||
+    !Number.isFinite(value) ||
+    value < 0 ||
+    value >= 100
+  ) {
+    invalid(
+      "Invalid winsorize value: must be a percentage between 0 (disabled) and 100.",
+    );
+  }
+  return value as number;
+};
+
+const unitIntervalParameter = (
+  overrides: Record<string, unknown>,
+  name: string,
+  fallback: number,
+): number => {
+  const value = overrides[name];
+  if (value === undefined || value === null) {
+    return fallback;
+  }
+  if (
+    typeof value !== "number" ||
+    !Number.isFinite(value) ||
+    value <= 0 ||
+    value >= 1
+  ) {
+    invalid(
+      `Invalid ${name} value: must be a number strictly between 0 and 1.`,
+    );
+  }
+  return value as number;
+};
+
+const resolveOrThrow = (
   modelTypeInput: unknown,
   parametersInput: unknown,
 ): ResolvedRunParameters => {
   const overrides = asOverrides(parametersInput);
 
   const requestedModelType =
-    typeof modelTypeInput === "string" && modelTypeInput.length > 0
-      ? modelTypeInput
-      : CONFIG.DEFAULT_MODEL_PARAMETERS.modelType;
+    modelTypeInput === undefined ||
+    modelTypeInput === null ||
+    modelTypeInput === ""
+      ? CONFIG.DEFAULT_MODEL_PARAMETERS.modelType
+      : modelTypeInput;
 
-  if (requestedModelType === CONST.MODEL_TYPES.RTMA) {
+  if (
+    typeof requestedModelType !== "string" ||
+    !MODEL_TYPE_VALUES.includes(
+      requestedModelType as (typeof MODEL_TYPE_VALUES)[number],
+    )
+  ) {
+    invalid(
+      `Invalid modelType value: ${String(requestedModelType)}. Must be one of: ${MODEL_TYPE_VALUES.join(", ")}.`,
+    );
+  }
+  const modelType = requestedModelType as ModelParameters["modelType"];
+
+  if (modelType === CONST.MODEL_TYPES.RTMA) {
     const parameters: RTMAParameters = {
       modelType: "RTMA",
-      favorPositive:
-        typeof overrides.favorPositive === "boolean"
-          ? overrides.favorPositive
-          : RTMA_DEFAULTS.favorPositive,
-      alphaSelect:
-        typeof overrides.alphaSelect === "number"
-          ? overrides.alphaSelect
-          : RTMA_DEFAULTS.alphaSelect,
-      ciLevel:
-        typeof overrides.ciLevel === "number"
-          ? overrides.ciLevel
-          : RTMA_DEFAULTS.ciLevel,
-      winsorize:
-        typeof overrides.winsorize === "number"
-          ? overrides.winsorize
-          : RTMA_DEFAULTS.winsorize,
+      favorPositive: flagParameter(
+        overrides,
+        "favorPositive",
+        RTMA_DEFAULTS.favorPositive,
+      ),
+      alphaSelect: unitIntervalParameter(
+        overrides,
+        "alphaSelect",
+        RTMA_DEFAULTS.alphaSelect,
+      ),
+      ciLevel: unitIntervalParameter(
+        overrides,
+        "ciLevel",
+        RTMA_DEFAULTS.ciLevel,
+      ),
+      winsorize: winsorizeParameter(overrides),
     };
     return { modelType: "RTMA", parameters };
   }
 
-  const shouldUseInstrumenting =
-    typeof overrides.shouldUseInstrumenting === "boolean"
-      ? overrides.shouldUseInstrumenting
-      : requestedModelType !== CONST.MODEL_TYPES.WLS;
+  const defaults = CONFIG.DEFAULT_MODEL_PARAMETERS;
 
+  const shouldUseInstrumenting =
+    overrides.shouldUseInstrumenting === undefined ||
+    overrides.shouldUseInstrumenting === null
+      ? modelType !== CONST.MODEL_TYPES.WLS
+      : flagParameter(overrides, "shouldUseInstrumenting", false);
+
+  // Fixed whitelist matching the sync R path (api_v1.R); unknown keys and
+  // RTMA-only parameters (e.g. favorPositive) never reach the queue.
   const parameters: ModelParameters = {
-    ...CONFIG.DEFAULT_MODEL_PARAMETERS,
-    ...overrides,
-    modelType: requestedModelType as ModelParameters["modelType"],
+    modelType,
+    maiveMethod: enumParameter(
+      overrides,
+      "maiveMethod",
+      MAIVE_METHOD_VALUES,
+      defaults.maiveMethod,
+    ),
+    weight: enumParameter(overrides, "weight", WEIGHT_VALUES, defaults.weight),
+    standardErrorTreatment: enumParameter(
+      overrides,
+      "standardErrorTreatment",
+      SE_TREATMENT_VALUES,
+      defaults.standardErrorTreatment,
+    ),
+    includeStudyDummies: flagParameter(
+      overrides,
+      "includeStudyDummies",
+      defaults.includeStudyDummies,
+    ),
+    includeStudyClustering: flagParameter(
+      overrides,
+      "includeStudyClustering",
+      defaults.includeStudyClustering,
+    ),
+    computeAndersonRubin: flagParameter(
+      overrides,
+      "computeAndersonRubin",
+      defaults.computeAndersonRubin,
+    ),
+    useLogFirstStage: flagParameter(
+      overrides,
+      "useLogFirstStage",
+      defaults.useLogFirstStage,
+    ),
+    winsorize: winsorizeParameter(overrides),
     shouldUseInstrumenting,
+    favorPositive: defaults.favorPositive,
   };
 
-  return { modelType: requestedModelType, parameters };
+  return { modelType, parameters };
+};
+
+export const resolveRunParameters = (
+  modelTypeInput: unknown,
+  parametersInput: unknown,
+): ResolveRunParametersResult => {
+  try {
+    return { resolved: resolveOrThrow(modelTypeInput, parametersInput) };
+  } catch (error) {
+    if (error instanceof ParameterValidationError) {
+      return { error: { message: error.message } };
+    }
+    throw error;
+  }
 };

--- a/apps/react-ui/client/src/pages/api/v1/runs.ts
+++ b/apps/react-ui/client/src/pages/api/v1/runs.ts
@@ -39,7 +39,7 @@ const handler = async (
     );
   }
 
-  // GET /v1/runs?ids=a,b,c — batch status lookup (statuses only, no results).
+  // GET /v1/runs?ids=a,b,c: batch status lookup (statuses only, no results).
   if (req.method === "GET") {
     const ids = parseIdsParam(req.query.ids, MAX_BATCH_IDS);
     if (ids.length === 0) {
@@ -74,7 +74,13 @@ const handler = async (
     modelType?: string;
   };
 
-  const resolved = resolveRunParameters(modelType, parameters);
+  const { resolved, error: parameterError } = resolveRunParameters(
+    modelType,
+    parameters,
+  );
+  if (parameterError) {
+    return sendApiError(res, "validation_error", parameterError.message);
+  }
 
   const validationError = validateDataset(data, resolved.modelType);
   if (validationError) {

--- a/apps/react-ui/client/src/tests/datasetValidation.test.ts
+++ b/apps/react-ui/client/src/tests/datasetValidation.test.ts
@@ -22,6 +22,7 @@ describe("resolveColumns", () => {
       se: "se",
       nObs: "n_obs",
       studyId: undefined,
+      byName: true,
     });
   });
 
@@ -34,6 +35,7 @@ describe("resolveColumns", () => {
       se: "SE",
       nObs: "N_Obs",
       studyId: undefined,
+      byName: true,
     });
   });
 
@@ -44,6 +46,7 @@ describe("resolveColumns", () => {
       se: "s",
       nObs: "n",
       studyId: "study",
+      byName: false,
     });
   });
 
@@ -54,6 +57,7 @@ describe("resolveColumns", () => {
       se: "s",
       nObs: undefined,
       studyId: undefined,
+      byName: false,
     });
   });
 
@@ -62,7 +66,7 @@ describe("resolveColumns", () => {
   });
 });
 
-describe("validateDataset — MAIVE-family", () => {
+describe("validateDataset: MAIVE-family", () => {
   it("accepts a valid dataset", () => {
     const data = [
       maiveRow(0.42, 0.11, 120),
@@ -141,9 +145,45 @@ describe("validateDataset — MAIVE-family", () => {
       /unique study IDs plus 3/,
     );
   });
+
+  it("rejects more than 4 columns when resolving positionally", () => {
+    const data = [
+      { a: 0.1, b: 0.1, c: 10, d: "A", e: 1 },
+      { a: 0.2, b: 0.1, c: 10, d: "A", e: 1 },
+      { a: 0.3, b: 0.1, c: 10, d: "B", e: 1 },
+      { a: 0.4, b: 0.1, c: 10, d: "B", e: 1 },
+    ];
+    expect(validateDataset(data, "MAIVE")?.message).toMatch(
+      /3 or 4 columns; found 5/,
+    );
+  });
+
+  it("tolerates extra columns when canonical names are present", () => {
+    const data = [
+      { effect: 0.1, se: 0.1, n_obs: 10, note: "x" },
+      { effect: 0.2, se: 0.1, n_obs: 10, note: "x" },
+      { effect: 0.3, se: 0.1, n_obs: 10, note: "x" },
+      { effect: 0.4, se: 0.1, n_obs: 10, note: "x" },
+    ];
+    expect(validateDataset(data, "MAIVE")).toBeNull();
+  });
+
+  it("rejects empty study_id values", () => {
+    const data = [
+      maiveRow(0.1, 0.1, 10, "A"),
+      maiveRow(0.2, 0.1, 10, ""),
+      maiveRow(0.3, 0.1, 10, "A"),
+      maiveRow(0.4, 0.1, 10, "B"),
+      maiveRow(0.5, 0.1, 10, "B"),
+      maiveRow(0.6, 0.1, 10, "B"),
+    ];
+    expect(validateDataset(data, "MAIVE")?.message).toMatch(
+      /study_id.*empty values/,
+    );
+  });
 });
 
-describe("validateDataset — RTMA", () => {
+describe("validateDataset: RTMA", () => {
   it("accepts a 2-column effect/se dataset", () => {
     const data = [
       { effect: 0.1, se: 0.1 },

--- a/apps/react-ui/client/src/tests/modelParameterDefaults.test.ts
+++ b/apps/react-ui/client/src/tests/modelParameterDefaults.test.ts
@@ -1,10 +1,32 @@
 import { describe, it, expect } from "vitest";
 import { resolveRunParameters } from "@api/server/modelParameterDefaults";
+import type { ResolvedRunParameters } from "@api/server/modelParameterDefaults";
 import CONFIG from "@src/CONFIG";
+
+const resolveOk = (
+  modelType: unknown,
+  parameters: unknown,
+): ResolvedRunParameters => {
+  const result = resolveRunParameters(modelType, parameters);
+  expect(result.error).toBeUndefined();
+  if (!result.resolved) {
+    throw new Error("expected parameters to resolve");
+  }
+  return result.resolved;
+};
+
+const resolveError = (modelType: unknown, parameters: unknown): string => {
+  const result = resolveRunParameters(modelType, parameters);
+  expect(result.resolved).toBeUndefined();
+  if (!result.error) {
+    throw new Error("expected a validation error");
+  }
+  return result.error.message;
+};
 
 describe("resolveRunParameters", () => {
   it("defaults to CONFIG.DEFAULT_MODEL_PARAMETERS when modelType/parameters are omitted", () => {
-    const resolved = resolveRunParameters(undefined, undefined);
+    const resolved = resolveOk(undefined, undefined);
     expect(resolved.modelType).toBe(CONFIG.DEFAULT_MODEL_PARAMETERS.modelType);
     expect(resolved.parameters).toMatchObject({
       ...CONFIG.DEFAULT_MODEL_PARAMETERS,
@@ -13,7 +35,7 @@ describe("resolveRunParameters", () => {
   });
 
   it("derives shouldUseInstrumenting=false for WLS unless explicitly overridden", () => {
-    const resolved = resolveRunParameters("WLS", undefined);
+    const resolved = resolveOk("WLS", undefined);
     expect(resolved.parameters).toMatchObject({
       modelType: "WLS",
       shouldUseInstrumenting: false,
@@ -21,7 +43,7 @@ describe("resolveRunParameters", () => {
   });
 
   it("keeps an explicit shouldUseInstrumenting override for WLS", () => {
-    const resolved = resolveRunParameters("WLS", {
+    const resolved = resolveOk("WLS", {
       shouldUseInstrumenting: true,
     });
     expect(resolved.parameters).toMatchObject({
@@ -31,7 +53,7 @@ describe("resolveRunParameters", () => {
   });
 
   it("derives shouldUseInstrumenting=true for MAIVE/WAIVE", () => {
-    const resolved = resolveRunParameters("WAIVE", undefined);
+    const resolved = resolveOk("WAIVE", undefined);
     expect(resolved.parameters).toMatchObject({
       modelType: "WAIVE",
       shouldUseInstrumenting: true,
@@ -39,7 +61,7 @@ describe("resolveRunParameters", () => {
   });
 
   it("merges explicit parameter overrides over the defaults", () => {
-    const resolved = resolveRunParameters("MAIVE", { winsorize: 5 });
+    const resolved = resolveOk("MAIVE", { winsorize: 5 });
     expect(resolved.parameters).toMatchObject({
       modelType: "MAIVE",
       winsorize: 5,
@@ -47,8 +69,16 @@ describe("resolveRunParameters", () => {
     });
   });
 
+  it("drops unknown parameter keys instead of queueing them", () => {
+    const resolved = resolveOk("MAIVE", {
+      winsorize: 5,
+      unknownKnob: "boom",
+    });
+    expect(resolved.parameters).not.toHaveProperty("unknownKnob");
+  });
+
   it("routes modelType RTMA to the RTMA defaults, ignoring MAIVE parameter fields", () => {
-    const resolved = resolveRunParameters("RTMA", undefined);
+    const resolved = resolveOk("RTMA", undefined);
     expect(resolved).toEqual({
       modelType: "RTMA",
       parameters: {
@@ -62,7 +92,7 @@ describe("resolveRunParameters", () => {
   });
 
   it("applies explicit RTMA overrides", () => {
-    const resolved = resolveRunParameters("RTMA", {
+    const resolved = resolveOk("RTMA", {
       favorPositive: false,
       winsorize: 2,
     });
@@ -73,5 +103,45 @@ describe("resolveRunParameters", () => {
       ciLevel: 0.95,
       winsorize: 2,
     });
+  });
+
+  it("rejects an invalid modelType", () => {
+    expect(resolveError("BOGUS", undefined)).toMatch(/Invalid modelType/);
+  });
+
+  it("rejects invalid enum values instead of silently defaulting", () => {
+    expect(resolveError("MAIVE", { maiveMethod: "PETX" })).toMatch(
+      /Invalid maiveMethod value: PETX/,
+    );
+    expect(resolveError("MAIVE", { weight: "heavy" })).toMatch(
+      /Invalid weight value/,
+    );
+    expect(resolveError("MAIVE", { standardErrorTreatment: "nope" })).toMatch(
+      /Invalid standardErrorTreatment value/,
+    );
+  });
+
+  it("rejects non-boolean flags", () => {
+    expect(resolveError("MAIVE", { includeStudyDummies: "yes" })).toMatch(
+      /Invalid includeStudyDummies value/,
+    );
+  });
+
+  it("rejects out-of-range winsorize", () => {
+    expect(resolveError("MAIVE", { winsorize: 150 })).toMatch(
+      /Invalid winsorize value/,
+    );
+    expect(resolveError("MAIVE", { winsorize: -1 })).toMatch(
+      /Invalid winsorize value/,
+    );
+  });
+
+  it("rejects out-of-range RTMA alphaSelect and ciLevel", () => {
+    expect(resolveError("RTMA", { alphaSelect: 5 })).toMatch(
+      /Invalid alphaSelect value/,
+    );
+    expect(resolveError("RTMA", { ciLevel: 1.5 })).toMatch(
+      /Invalid ciLevel value/,
+    );
   });
 });

--- a/docs/PUBLIC_API.md
+++ b/docs/PUBLIC_API.md
@@ -1,24 +1,24 @@
-# Public Model API — Usage Guide
+# Public Model API: Usage Guide
 
 ## Overview
 
 MAIVE exposes a public, anonymous HTTP API for running MAIVE / WAIVE / WLS
-and RTMA meta-analysis models programmatically — no accounts, no API keys.
+and RTMA meta-analysis models programmatically; no accounts, no API keys.
 It's the same compute the MAIVE UI uses, given a clean, documented contract.
 
 > **Status:** this guide documents the target `/v1` contract. The branded
-> hostname (`api.maive.eu`) goes live in a later rollout phase — if it
+> hostname (`api.maive.eu`) goes live in a later rollout phase; if it
 > doesn't resolve yet, that's expected; see
 > [`PUBLIC_API_DESIGN.md`](PUBLIC_API_DESIGN.md) for the rollout plan.
 
 The full machine-readable contract lives in
-[`docs/api/openapi.yaml`](api/openapi.yaml) (OpenAPI 3) — it is the source of
+[`docs/api/openapi.yaml`](api/openapi.yaml) (OpenAPI 3); it is the source of
 truth for request/response shapes. This guide is a narrative companion with
 copy-paste examples.
 
 - Base URL: `https://api.maive.eu`
 - Content type: `application/json` both ways
-- Auth: none — the API is anonymous by design. Abuse is bounded by
+- Auth: none; the API is anonymous by design. Abuse is bounded by
   server-side concurrency caps and edge rate limits, not identity.
 
 ## Sync vs. async
@@ -29,7 +29,7 @@ Two ways to run a model:
 |---|---|---|
 | Endpoints | `POST /v1/run-model`, `POST /v1/run-rtma` | `POST /v1/runs` (submit) + `GET /v1/runs/{jobId}` (poll) |
 | Shape | One request, one response | Submit returns a `jobId` immediately; poll until terminal, then read `result` |
-| Edge cap | Subject to Cloudflare's **~100s** proxy cap on `api.maive.eu` | Not subject to the cap — no long-lived connection |
+| Edge cap | Subject to Cloudflare's **~100s** proxy cap on `api.maive.eu` | Not subject to the cap (no long-lived connection) |
 | When to use | Typical datasets, runs finishing in well under 100s (roughly 15-60s including cold start) | **Recommended default.** Anything that might run long, batch/CI usage, or when you'd rather not hold a connection open |
 
 **Recommendation: use the async path by default.** It has no failure mode tied
@@ -39,8 +39,9 @@ want the simplicity of a single request.
 ## Data requirements
 
 Requests take `data` as an array of row objects. Columns are resolved by
-canonical key name when present (`effect`, `se`, `n_obs`, `study_id`);
-otherwise the first 3-4 object keys are read positionally in that order.
+canonical key name when present (`effect`, `se`, `n_obs`, `study_id`,
+matched case-insensitively); otherwise the first 3-4 object keys are read
+positionally in that order.
 
 | Field | Type | Required for | Notes |
 |---|---|---|---|
@@ -52,10 +53,10 @@ otherwise the first 3-4 object keys are read positionally in that order.
 | Endpoint | Columns | Min rows |
 |---|---|---|
 | `POST /v1/run-model` (MAIVE/WAIVE/WLS) | 3 or 4 | 4 |
-| `POST /v1/run-rtma` | 2 (`effect`, `se`) | Rows with missing/non-positive `se` are dropped with a warning |
+| `POST /v1/run-rtma` | 2 (`effect`, `se`) | Rows with missing/non-positive `se` are silently dropped |
 
 These mirror the MAIVE UI's own validation page, enforced server-side so API
-callers get a structured `400 validation_error` instead of a raw R error —
+callers get a structured `400 validation_error` instead of a raw R error;
 see [`components/responses/ValidationError`](api/openapi.yaml) in the spec.
 
 All model parameters are optional; unset ones fall back to documented
@@ -64,7 +65,7 @@ just `{"data": [...]}`. See the `ModelParameters` / `RTMAParameters` schemas
 in the OpenAPI spec for the full enum/default table.
 
 Plots (`funnelPlot`, `zScorePlot`, and their width/height companions) are
-**excluded by default** — each is a ~50KB base64 PNG, noise for most
+**excluded by default**: each is a ~50KB base64 PNG, noise for most
 programmatic callers. Add `?include=plot` to any run or poll request to embed
 them.
 
@@ -244,7 +245,7 @@ Batch status for multiple runs at once (no results, just status): `GET
 ## `jobId` semantics
 
 `jobId` is an **opaque bearer token**, not a user- or account-scoped
-identifier. Anyone holding a `jobId` can read that run's status and result —
+identifier. Anyone holding a `jobId` can read that run's status and result;
 the same exposure model the MAIVE UI's own async runs already use. Treat it
 like a share link:
 
@@ -255,27 +256,27 @@ like a share link:
 
 ## Privacy
 
-- Requests are anonymous — no accounts, no identity is collected.
+- Requests are anonymous: no accounts, no identity is collected.
 - Synchronous runs are stateless; nothing is persisted beyond the response.
 - Asynchronous runs persist the submitted parameters and the result in the
   run store for up to 48 hours, keyed by `jobId`, then expire automatically.
   The input dataset itself is not persisted beyond the transient queue
   message used to dispatch the run.
 - **Do not submit confidential or personally identifiable data.** The API has
-  no data-classification or redaction layer — treat every request the same
+  no data-classification or redaction layer; treat every request the same
   way you'd treat a request to any other unauthenticated public web service.
 
 ## Rate limits & errors
 
 Two independent guardrails apply, load-bearing in this order:
 
-1. A hard concurrency cap on the compute backend — once saturated, further
+1. A hard concurrency cap on the compute backend; once saturated, further
    requests receive `429 rate_limited` regardless of entry path.
 2. Per-IP rate limiting at the edge on `api.maive.eu` for casual abuse
    deterrence.
 
 Both are documented starting points and may be tuned based on observed load
-— treat any `429` as "retry with backoff," not a hard quota. Datasets that
+Treat any `429` as "retry with backoff," not a hard quota. Datasets that
 are too large to queue asynchronously (roughly 200KB of JSON) get `413
 payload_too_large` pointing you at the synchronous endpoint instead.
 
@@ -298,11 +299,11 @@ If you use MAIVE in published or reported work, please cite:
 
 ## See also
 
-- [`docs/api/openapi.yaml`](api/openapi.yaml) — the OpenAPI 3 contract
+- [`docs/api/openapi.yaml`](api/openapi.yaml): the OpenAPI 3 contract
   (source of truth).
-- [`PUBLIC_API_DESIGN.md`](PUBLIC_API_DESIGN.md) — the design doc this API is
+- [`PUBLIC_API_DESIGN.md`](PUBLIC_API_DESIGN.md): the design doc this API is
   scoped from, including rollout phases and abuse/cost controls.
-- [`SERVER_SIDE_API_ARCHITECTURE.md`](SERVER_SIDE_API_ARCHITECTURE.md) —
+- [`SERVER_SIDE_API_ARCHITECTURE.md`](SERVER_SIDE_API_ARCHITECTURE.md):
   current serving topology (UI Lambda, R Lambda, Cloudflare).
-- [`ASYNC_RUNS_DESIGN.md`](ASYNC_RUNS_DESIGN.md) — the async runs
+- [`ASYNC_RUNS_DESIGN.md`](ASYNC_RUNS_DESIGN.md): the async runs
   infrastructure this API's `/v1/runs*` routes wrap.

--- a/docs/PUBLIC_API_DESIGN.md
+++ b/docs/PUBLIC_API_DESIGN.md
@@ -1,13 +1,13 @@
-# Public Model API — Design & Implementation Plan
+# Public Model API: Design & Implementation Plan
 
-**Status:** Proposed (pre-implementation)
+**Status:** Phase 1 implemented (sync + async /v1, spec, docs); Phases 2-3 pending
 **Date:** 2026-07-08
 **Related:** [ASYNC_RUNS_DESIGN.md](ASYNC_RUNS_DESIGN.md) (async runs infra this design reuses);
 [SERVER_SIDE_API_ARCHITECTURE.md](SERVER_SIDE_API_ARCHITECTURE.md) (current serving topology)
 
 > This document is the scope of record for exposing a **documented, public,
 > anonymous HTTP API** that lets anyone run MAIVE/WAIVE/WLS and RTMA analyses
-> programmatically — without going through the MAIVE UI. It is meant to be
+> programmatically, without going through the MAIVE UI. It is meant to be
 > reviewed and agreed before implementation starts. Decisions in §4 are
 > considered locked once this document is approved.
 
@@ -23,19 +23,19 @@ for programmatic access from Python/Stata/CI pipelines.
 The key realization: **the API already exists and is already public.** The R
 Plumber backend runs behind a Lambda Function URL with `authorization_type =
 "NONE"` and CORS `*` (`terraform/stacks/prod-runtime/lambda.tf`), and the
-browser already POSTs to it directly. What is missing is not a service — it is
+browser already POSTs to it directly. What is missing is not a service; it is
 **productization**:
 
 - a **stable, branded URL** (today: an obscure `.on.aws` hostname that changes
   if the Function URL is ever recreated),
 - a **clean request contract** (today: `data` and `parameters` are
-  double-encoded JSON *strings* inside the JSON body — an internal UI
+  double-encoded JSON *strings* inside the JSON body, an internal UI
   convention, hostile to third-party callers),
 - **proper HTTP semantics** (today: errors return `200 {error: true, ...}`),
 - **server-side input validation** (today: the friendly validation lives in the
   UI's validation page; the backend gives raw R errors),
 - **documentation** (OpenAPI spec + examples),
-- **abuse/cost protection** (today: obscurity plus nothing — the R Lambda has
+- **abuse/cost protection** (today: obscurity plus nothing; the R Lambda has
   no reserved concurrency, so unbounded anonymous compute at 2 GB × 600 s).
 
 Publicly documenting the endpoint removes the obscurity, so the cost controls
@@ -46,9 +46,9 @@ are a **prerequisite**, not a nice-to-have.
 **Goals**
 
 - A documented `/v1` HTTP API for running models: **synchronous** for typical
-  datasets and **asynchronous** (submit + poll) for long runs — both from the
+  datasets and **asynchronous** (submit + poll) for long runs, both from the
   start.
-- **Anonymous access** — no accounts, no API keys — matching the UI's access
+- **Anonymous access** (no accounts, no API keys) matching the UI's access
   model. Abuse is bounded by hard concurrency caps and edge rate limits, not
   identity.
 - Clean JSON request/response contract with real HTTP status codes and
@@ -57,15 +57,15 @@ are a **prerequisite**, not a nice-to-have.
   callers get friendly `400`s instead of raw R errors.
 - An OpenAPI 3 spec as the single source of truth, plus copy-paste `curl` / R /
   Python examples.
-- **Zero behavior change for the UI** — legacy routes (`/run-model`,
+- **Zero behavior change for the UI**: legacy routes (`/run-model`,
   `/run-rtma`, `/api/runs*`) are untouched.
 
 **Non-goals (this iteration)**
 
 - API keys, accounts, per-caller quotas, usage metering, billing.
-- SDK packages (R/Python client libraries) — examples only.
+- SDK packages (R/Python client libraries); examples only.
 - Guaranteed support for datasets that are simultaneously too large to queue
-  (>200 KB) *and* too slow for the edge (>100 s) — see §12.
+  (>200 KB) *and* too slow for the edge (>100 s); see §12.
 - Changing the statistical/compute path or the R model code.
 - SLA/uptime commitments.
 
@@ -74,7 +74,7 @@ are a **prerequisite**, not a nice-to-have.
 - **R backend Lambda** (`apps/lambda-r-backend/r_scripts/`): Plumber via the
   AWS Lambda Web Adapter; Function URL auth `NONE`, CORS `*`; `timeout=600s`,
   `memory_size=2048`, **no reserved concurrency** (deliberately unreserved so
-  synchronous browser calls are never throttled — see comment in
+  synchronous browser calls are never throttled; see comment in
   `orchestrator_lambda.tf`).
 - **Existing routes** (`r_scripts/index.R`): `GET /echo`, `GET /health`,
   `GET /ping`, `POST /run-model`, `POST /run-rtma`. The POST routes take two
@@ -95,7 +95,7 @@ are a **prerequisite**, not a nice-to-have.
   `spuriousprecision.com`), with a Worker rewriting Host/SNI to the `.on.aws`
   origin. The R Function URL is **not** behind Cloudflare; the browser calls
   it directly. Cloudflare caps proxied origin responses at ~100 s.
-- **Costs**: ~$0.001–0.002 of Lambda compute per typical run; pathological
+- **Costs**: ~$0.001-0.002 of Lambda compute per typical run; pathological
   runs bounded by the R-side 480 s guard (RTMA) / 600 s Lambda timeout.
 
 ## 4. Locked decisions
@@ -104,11 +104,11 @@ are a **prerequisite**, not a nice-to-have.
 |---|----------|-----------|
 | D1 | **Anonymous access; no API keys.** | The UI calls the same compute keylessly from the browser, so any key would be trivially bypassable by replaying what the browser does. Keys buy attribution/quotas we don't need yet; they cost UX and support burden. Cost is bounded structurally (D2), not by identity. |
 | D2 | **Primary cost control: reserved concurrency on the R Lambda (start: 10).** Edge rate limits are secondary. | Rate-limiting only the branded hostname is bypassable via the raw `.on.aws` URL (the UI's own path). A concurrency cap bounds worst-case spend regardless of route: at most N concurrent 2 GB × 600 s executions, excess gets `429`. 10 = orchestrator's 5 async slots + headroom for sync UI/API calls. |
-| D3 | **New versioned routes (`/v1/...`); legacy routes untouched.** | The UI keeps working unchanged; the public contract can be clean without a risky migration. `/v1` is frozen once shipped — additive changes only; breaking changes mean `/v2`. |
+| D3 | **New versioned routes (`/v1/...`); legacy routes untouched.** | The UI keeps working unchanged; the public contract can be clean without a risky migration. `/v1` is frozen once shipped: additive changes only; breaking changes mean `/v2`. |
 | D4 | **`/v1` accepts plain nested JSON** (objects, not double-encoded strings) and returns proper HTTP status codes with a structured error envelope. | Double-encoded strings and `200`-on-error are internal warts we must not export. The `/v1` handlers re-encode internally (`toJSON`) before calling the unchanged `run_maive_model()` / `run_rtma_model()`. |
 | D5 | **Rows are JSON objects; columns resolved by canonical names (`effect`, `se`, `n_obs`, `study_id`) when present, positionally otherwise.** | Key order in JSON is not reliably meaningful; resolving by name removes a silent-misordering footgun. Positional fallback keeps parity with the legacy contract for callers with arbitrary column names. |
 | D6 | **All parameters optional with documented defaults** (matching the UI's `CONFIG.DEFAULT_MODEL_PARAMETERS`); `shouldUseInstrumenting` is derived from `modelType` unless explicitly set. | A minimal valid request is just `{"data": [...]}`. Internal parameters shouldn't be required knowledge; WLS-vs-MAIVE instrumenting coupling is app logic the server should own. |
-| D7 | **Plots excluded by default; opt-in via `?include=plot`.** | The base64 funnel/z-density PNG is ~50 KB — noise for programmatic callers. Applies to sync responses and async result fetches alike. |
+| D7 | **Plots excluded by default; opt-in via `?include=plot`.** | The base64 funnel/z-density PNG is ~50 KB, noise for programmatic callers. Applies to sync responses and async result fetches alike. |
 | D8 | **Async API = thin `/v1/runs` routes on the UI Lambda wrapping the existing DDB/SQS machinery.** `result` is returned as a parsed JSON object; oversized submissions get `413` (not the internal `{tooLarge: true}` signal). `jobId` stays an opaque bearer token with 48 h TTL. | The queue/orchestrator/store already exist and are proven; the public surface is a re-skin with public-grade semantics. No new AWS infra. |
 | D9 | **Branded hostname `api.maive.eu`, path-routed by the Cloudflare Worker: `/v1/runs*` → UI Lambda origin, everything else `/v1/*` → R Lambda origin.** | One hostname for the whole API surface. A subdomain (vs `maive.eu/api/...`) gets its own WAF/rate-limit scoping and avoids entangling with the Next.js `/api/*` namespace. The Worker already does Host/SNI rewriting for the UI; this reuses the pattern. |
 | D10 | **OpenAPI 3 spec in-repo (`docs/api/openapi.yaml`) is the source of truth for the contract.** | Reviewable, versionable, lint-able; can later be served/rendered by the UI without redefinition. |
@@ -137,8 +137,8 @@ are a **prerequisite**, not a nice-to-have.
 ```
 
 - **Sync** (`/v1/run-model`, `/v1/run-rtma`): request → R Lambda → response in
-  one round trip. Subject to Cloudflare's ~100 s proxy cap — fine for typical
-  runs (~15–60 s incl. cold start), documented as unsuitable for long runs.
+  one round trip. Subject to Cloudflare's ~100 s proxy cap, fine for typical
+  runs (~15-60 s incl. cold start), documented as unsuitable for long runs.
 - **Async** (`/v1/runs`): submit returns `{jobId}` immediately; poll until a
   terminal status; fetch the result once. No long-lived connections; immune to
   the edge cap; the path to recommend by default in the docs.
@@ -174,18 +174,17 @@ are a **prerequisite**, not a nice-to-have.
 ```
 
 - Columns are resolved by the canonical names above when present; otherwise
-  the first 3–4 keys are taken positionally as (effect, se, n_obs[, study_id])
-  — per D5.
+  the first 3-4 keys are taken positionally as (effect, se, n_obs[, study_id])
+  per D5.
 - **MAIVE-family** (`/v1/run-model`): 3 or 4 columns; ≥ 4 rows; `effect`,
   `se`, `n_obs` numeric; `se > 0`; `n_obs` positive integers; if `study_id`
   present, rows ≥ unique studies + 3. These mirror the UI validation page
   (`pages/validation/index.tsx`) and are enforced server-side so API callers
   get structured `400`s.
 - **RTMA** (`/v1/run-rtma`): ≥ 2 columns (`effect`, `se`); rows with missing
-  or non-positive `se` are dropped with a warning field, matching current
-  behavior.
+  or non-positive `se` are silently dropped, matching current behavior.
 
-### 6.3 `POST /v1/run-model` — synchronous MAIVE / WAIVE / WLS
+### 6.3 `POST /v1/run-model`: synchronous MAIVE / WAIVE / WLS
 
 Request (`?include=plot` to embed the funnel plot):
 
@@ -222,14 +221,14 @@ All parameters optional (D6); defaults = the UI's defaults
 | `winsorize` | number (percent, 0 disables) | `0` |
 | `shouldUseInstrumenting` | boolean | derived: `WLS` → `false`, else `true` |
 
-Response `200`: the flat results object (today's `ModelResults` shape —
+Response `200`: the flat results object (today's `ModelResults` shape:
 `effectEstimate`, `standardError`, `isSignificant`, `andersonRubinCI`,
 `publicationBias{...}`, `firstStageFStatistic`, `hausmanTest{...}`,
-`seInstrumented`, `bootSE`, `bootCI`, `firstStage`, `petpeese_selected`, … —
+`seInstrumented`, `bootSE`, `bootCI`, `firstStage`, `petpeese_selected`, …,
 plus `funnelPlot`/`funnelPlotWidth`/`funnelPlotHeight` only with
 `?include=plot`).
 
-### 6.4 `POST /v1/run-rtma` — synchronous RTMA
+### 6.4 `POST /v1/run-rtma`: synchronous RTMA
 
 Same envelope; parameters (all optional): `favorPositive` (default `true`),
 `alphaSelect` (`0.05`), `ciLevel` (`0.95`), `winsorize` (`0`). The internal
@@ -239,13 +238,13 @@ Same envelope; parameters (all optional): `favorPositive` (default `true`),
 
 ### 6.5 Async: `POST /v1/runs`, `GET /v1/runs/{jobId}`
 
-**Submit** — body `{ data, parameters?, modelType? }` (same data/parameter
+**Submit**: body `{ data, parameters?, modelType? }` (same data/parameter
 contract; `modelType: "RTMA"` routes to the RTMA path). Returns `200
 { "jobId": "..." }`. Datasets whose queue message would exceed the ~200 KB SQS
 budget get `413 payload_too_large` with a message pointing at the synchronous
 endpoint (D8).
 
-**Poll** — `GET /v1/runs/{jobId}`:
+**Poll**: `GET /v1/runs/{jobId}`:
 
 ```json
 { "jobId": "…", "status": "queued|running|succeeded|failed|timedout",
@@ -256,16 +255,16 @@ endpoint (D8).
 }
 ```
 
-`404` for unknown/expired ids (48 h TTL). Suggested polling: every 2–5 s.
+`404` for unknown/expired ids (48 h TTL). Suggested polling: every 2-5 s.
 Batch status: `GET /v1/runs?ids=a,b,c` (statuses only, no results; max 100).
 
-`jobId` is a bearer token: anyone holding it can read that run for 48 h — the
+`jobId` is a bearer token: anyone holding it can read that run for 48 h, the
 same exposure model the UI already has (async design D6). Stated plainly in
 the docs.
 
 ### 6.6 `GET /v1/health`
 
-`200 { "status": "ok", "time": "…" }` — alias of the existing `/health`.
+`200 { "status": "ok", "time": "…" }`, an alias of the existing `/health`.
 
 ### 6.7 Example (curl)
 
@@ -302,7 +301,7 @@ Layered, in order of load-bearing-ness:
    documented hostname; the concurrency cap covers the bypass route.
 3. **Existing guards**: RTMA 480 s wall-clock limit, Lambda 600 s timeout,
    Function URL ~6 MB payload cap, existing CloudWatch error alarms. Add one
-   alarm on R-Lambda throttles (signal that the cap is being hit — abuse or
+   alarm on R-Lambda throttles (signal that the cap is being hit, abuse or
    organic growth).
 
 Explicitly rejected: locking the Function URL to Cloudflare-only via a
@@ -315,20 +314,20 @@ synchronous UI runs. Revisit only if bypass abuse is actually observed (§12).
 - No change to data-at-rest posture: sync requests are stateless; async runs
   persist results for 48 h in DynamoDB exactly as the UI's async path already
   does; input datasets are still not persisted (transient SQS message only).
-- Anonymous by design (D1) — no new PII collected. Cloudflare sees API traffic
+- Anonymous by design (D1): no new PII collected. Cloudflare sees API traffic
   for the branded hostname (it already sees all UI traffic).
 - The docs must state: don't submit personally identifiable or confidential
   data; `jobId` is a share-token; results auto-expire.
 
 ## 9. Implementation plan
 
-**Phase 1 — the contract (one PR, no infra):**
+**Phase 1, the contract (one PR, no infra):**
 
 - [x] `r_scripts/api_v1.R`: validation helpers (column resolution per D5,
       UI-parity checks per §6.2, parameter defaulting per D6, error responses
       per §6.1). Shipped in #469.
 - [x] `r_scripts/index.R`: add `POST /v1/run-model`, `POST /v1/run-rtma`,
-      `GET /v1/health` — thin wrappers that validate, apply defaults,
+      `GET /v1/health`: thin wrappers that validate, apply defaults,
       `toJSON()` the inputs, call the **unchanged** model functions, strip
       plots unless `?include=plot`, set proper status codes. Legacy routes
       untouched. Shipped in #469.
@@ -345,7 +344,7 @@ synchronous UI runs. Revisit only if bypass abuse is actually observed (§12).
 - [x] Tests (UI side): Vitest coverage for the `/api/v1/runs` routes. Shipped
       in #467.
 
-**Phase 2 — infra & edge:**
+**Phase 2, infra & edge:**
 
 - [ ] Terraform (`prod-runtime`): `reserved_concurrent_executions = 10` on the
       R Lambda; CloudWatch throttle alarm.
@@ -355,7 +354,7 @@ synchronous UI runs. Revisit only if bypass abuse is actually observed (§12).
 - [ ] Smoke test the full surface through the branded hostname; verify the UI
       is unaffected (its direct `.on.aws` path unchanged).
 
-**Phase 3 — publication:**
+**Phase 3, publication:**
 
 - [ ] Docs page in the UI (e.g. `/api`) rendering the OpenAPI spec + examples;
       link from the footer next to the reproducibility material.
@@ -390,15 +389,15 @@ until Phase 3.
   the S3 input-pointer escape hatch from the async design (§15 there) is the
   eventual fix.
 - **Concurrency cap = 10 is a guess.** It now also throttles UI sync traffic
-  at the margin — previously deliberately unreserved. Watch the throttle
+  at the margin; previously it was deliberately unreserved. Watch the throttle
   alarm; tune.
 - **Column resolution by name (D5)** adds one behavior divergence from legacy
   (which is purely positional). Contained to `/v1`; property-tested in the e2e
   scenario.
-- **Hostname mirroring:** also expose `api.spuriousprecision.com`? Deferred —
+- **Hostname mirroring:** also expose `api.spuriousprecision.com`? Deferred;
   one canonical hostname keeps docs and rate-limit scoping simple.
 - **Result-shape stability:** `/v1` freezes field names that today mirror
-  internal R naming (`petpeese_selected`, `is_quadratic_fit`, …). Accepted —
+  internal R naming (`petpeese_selected`, `is_quadratic_fit`, …). Accepted;
   they're already the de-facto contract for the UI and reproducibility
   packages.
 

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -13,9 +13,9 @@ info:
 
     **Status:** this spec documents the target contract. The branded hostname
     (`api.maive.eu`) goes live in a later rollout phase (Phase 2 of the design
-    doc) — it may not resolve yet.
+    doc); it may not resolve yet.
 
-    **Access:** anonymous — no accounts, no API keys. Abuse is bounded by
+    **Access:** anonymous; no accounts, no API keys. Abuse is bounded by
     server-side concurrency caps and edge rate limits, not identity.
 
     **Citation:** if you use MAIVE in published or reported work, please cite:
@@ -31,7 +31,7 @@ servers:
   - url: https://api.maive.eu
     description: Production
 
-# Anonymous by design (D1) — no accounts, no API keys. Documented explicitly
+# Anonymous by design (D1): no accounts, no API keys. Documented explicitly
 # rather than omitted, so linters don't flag a missing security definition.
 security: []
 
@@ -51,7 +51,7 @@ paths:
       summary: Run MAIVE, WAIVE, or WLS synchronously
       description: |
         Runs the requested model and returns the result in the same HTTP
-        response. Subject to Cloudflare's ~100s proxy cap at the edge — fine
+        response. Subject to Cloudflare's ~100s proxy cap at the edge, fine
         for typical runs (roughly 15-60s including cold start), but
         unsuitable for large or slow datasets. Prefer `POST /v1/runs` (async)
         for anything that might run long. See §6.3 of the design doc.
@@ -179,7 +179,7 @@ paths:
       description: |
         Queues a model run and returns immediately with a `jobId`. Poll
         `GET /v1/runs/{jobId}` until the status is terminal, then read
-        `result`. Recommended as the default integration path — immune to the
+        `result`. Recommended as the default integration path, immune to the
         edge's ~100s proxy cap. See §6.5 of the design doc.
       requestBody:
         required: true
@@ -231,7 +231,7 @@ paths:
                     type: string
                     description: >-
                       Opaque bearer token. Anyone holding it can read the run
-                      for 48h — treat it like a share link.
+                      for 48h; treat it like a share link.
                     example: "8f14e45f-ceea-467e-9e42-1c0e0f5a4e3e"
         "400":
           $ref: "#/components/responses/ValidationError"
@@ -252,7 +252,7 @@ paths:
       description: |
         Returns status (no `result`) for up to 100 job ids in one call. Used
         for polling multiple runs at once (e.g. a "my runs" list). Unknown ids
-        are silently omitted from the response — this endpoint never 404s.
+        are silently omitted from the response; this endpoint never 404s.
       parameters:
         - name: ids
           in: query
@@ -302,6 +302,8 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Run"
+        "400":
+          $ref: "#/components/responses/ValidationError"
         "404":
           $ref: "#/components/responses/NotFound"
         "405":
@@ -344,7 +346,7 @@ components:
       required: false
       description: >-
         Set to `plot` to embed the base64-encoded plot image(s) in the
-        response. Omitted by default (D7) — the plot is ~50KB and most
+        response. Omitted by default (D7): the plot is ~50KB and most
         programmatic callers don't need it.
       schema:
         type: string
@@ -395,7 +397,7 @@ components:
               message: "Dataset too large to queue; use POST /v1/run-model or /v1/run-rtma instead."
     RateLimited:
       description: >-
-        Too many requests — either the edge rate limit or the server-side
+        Too many requests: either the edge rate limit or the server-side
         concurrency cap was hit. Retry with backoff.
       content:
         application/json:
@@ -452,9 +454,12 @@ components:
       type: object
       description: |
         One row of meta-analysis input data. Columns are resolved by the
-        canonical keys below when present; otherwise the first 3-4 keys of
-        the object are taken positionally as (effect, se, n_obs[, study_id])
-        for MAIVE-family endpoints, or (effect, se) for RTMA (D5).
+        canonical keys below when present (matched case-insensitively);
+        otherwise the first 3-4 keys of the object are taken positionally as
+        (effect, se, n_obs[, study_id]) for MAIVE-family endpoints, or
+        (effect, se) for RTMA (D5). With positional resolution, MAIVE-family
+        rows must have exactly 3 or 4 keys; extra columns are tolerated only
+        when the canonical names are present.
       properties:
         effect:
           type: number
@@ -618,7 +623,7 @@ components:
       type: object
       description: >-
         Result of `POST /v1/run-model`. Field names mirror the internal R
-        result object 1:1 (`maive_model.R`, `run_maive_model`) — they are
+        result object 1:1 (`maive_model.R`, `run_maive_model`); they are
         already the de-facto contract for the UI and reproducibility
         packages, and are frozen as-is (§11).
       required:


### PR DESCRIPTION
## Summary

Integration pass over the three parallel Phase 1 PRs of the public API ([design doc](https://github.com/PetrCala/maive-ui/blob/master/docs/PUBLIC_API_DESIGN.md)): live behavioral testing of every /v1 endpoint against a local R server, the full R e2e scenario, the vitest suite, plus a field-by-field drift check of openapi.yaml vs the R sync path vs the TS async path. Everything found is fixed here.

## Findings fixed

**Breaks-a-caller (3):**
- **Case-sensitivity split on canonical column names**: R matched `effect`/`se`/`n_obs` case-sensitively while TS matched case-insensitively, so capitalized headers (e.g. `SE`, `Effect`) silently fell back to positional resolution on the sync path and mis-assigned columns (effect got the SE values). R now matches case-insensitively; verified live that `{SE, Effect, N_obs}` produces the identical estimate as the lowercase run.
- **Async accepted invalid parameters**: the TS submit route silently defaulted wrong-typed values and passed unknown enum values (e.g. `maiveMethod: "PETX"`, `winsorize: 150`) straight to the queue, surfacing as failed runs. It now validates enums, bounds, and flags exactly like the R sync path and returns `400 validation_error`.
- **Malformed JSON body returned plumber's default 500**: plumber parses the body before /v1 handlers run, so invalid JSON never reached the handler's error mapping. A global error handler in host.R now returns the structured `400` envelope for /v1 paths; legacy routes keep plumber's default shape (verified unchanged).

**Consistency / cosmetic (5):**
- RTMA's caller-fixable "at least one nonaffirmative study" error mapped to 500; now 400.
- cli line-wrapping embedded literal newlines in JSON error messages; collapsed.
- TS positional resolution accepted >4-column datasets that R rejects; now rejected (extra columns still tolerated when canonical names are present, both sides).
- TS silently ignored empty `study_id` values that R rejects; now rejected.
- Queued MAIVE parameters use a fixed whitelist, so unknown caller keys no longer flow into the stored run parameters.

**Docs/spec:** documented the 400 response on `GET /v1/runs/{jobId}`, documented case-insensitive canonical matching and the positional 3-4 column rule, removed the inaccurate RTMA "dropped with a warning" claim, and updated the design doc status to Phase 1 implemented.

## Verification

- 13-case live curl battery against the R server: happy paths (MAIVE minimal/full, WLS, positional, shuffled canonical, capitalized), all validation 400s, plot opt-in on/off, RTMA happy path + validation, legacy `/run-model` regression (double-encoded contract and `{data:{...}}` envelope unchanged)
- R e2e scenario (extended with malformed-JSON and case-insensitivity cases): PASS
- vitest: 117/117 (9 new tests), tsc clean, eslint/prettier clean, lintr clean on touched files
- `redocly lint docs/api/openapi.yaml`: valid

## Next steps (not this PR)

Phase 2 per the design doc: Terraform reserved concurrency + throttle alarm on the R Lambda, then the `api.maive.eu` Cloudflare hostname with Worker path routing and rate limits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)