### PR TITLE
feat: cap R backend concurrency and alarm on throttles for public API

### DIFF
--- a/terraform/stacks/prod-runtime/lambda.tf
+++ b/terraform/stacks/prod-runtime/lambda.tf
@@ -86,6 +86,26 @@ resource "aws_cloudwatch_metric_alarm" "lambda_r_backend_errors" {
   }
 }
 
+# Throttle alarm: with reserved concurrency now capping the R backend
+# (docs/PUBLIC_API_DESIGN.md D2), throttles are the signal that the cap is being
+# hit, whether from an abusive caller or organic growth that warrants raising it.
+resource "aws_cloudwatch_metric_alarm" "lambda_r_backend_throttles" {
+  alarm_name          = "${local.lambda_r_backend_function_name}-throttles"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = "1"
+  metric_name         = "Throttles"
+  namespace           = "AWS/Lambda"
+  period              = "300"
+  statistic           = "Sum"
+  threshold           = "0"
+  alarm_description   = "Lambda R backend is being throttled (reserved concurrency cap reached)"
+  alarm_actions       = []
+
+  dimensions = {
+    FunctionName = aws_lambda_function.r_backend.function_name
+  }
+}
+
 resource "aws_cloudwatch_metric_alarm" "lambda_r_backend_duration" {
   alarm_name          = "${local.lambda_r_backend_function_name}-duration"
   comparison_operator = "GreaterThanThreshold"
@@ -119,7 +139,8 @@ resource "aws_cloudwatch_dashboard" "lambda_r_backend" {
           metrics = [
             ["AWS/Lambda", "Invocations", "FunctionName", aws_lambda_function.r_backend.function_name],
             [".", "Errors", ".", "."],
-            [".", "Duration", ".", "."]
+            [".", "Duration", ".", "."],
+            [".", "Throttles", ".", "."]
           ]
           period = 300
           stat   = "Sum"

--- a/terraform/stacks/prod-runtime/variables.tf
+++ b/terraform/stacks/prod-runtime/variables.tf
@@ -58,9 +58,16 @@ variable "lambda_r_backend_timeout" {
 }
 
 variable "lambda_r_backend_reserved_concurrency" {
-  description = "Reserved concurrency for Lambda R backend (-1 = unreserved)"
+  description = <<-EOT
+    Reserved concurrency for the Lambda R backend (-1 = unreserved). This is the
+    primary cost/abuse control for the public /v1 API (docs/PUBLIC_API_DESIGN.md
+    D2): it hard-caps concurrent R executions regardless of entry path (UI, sync
+    /v1, or the async orchestrator), so worst-case spend is bounded and excess
+    requests get a 429. Must stay above the orchestrator's maximum_concurrency
+    (5) so async runs never starve synchronous UI/API calls.
+  EOT
   type        = number
-  default     = -1
+  default     = 10
 }
 
 variable "lambda_r_backend_log_retention_days" {


### PR DESCRIPTION
## Summary

Phase 2 (infra half) of the public API, [design doc](https://github.com/PetrCala/maive-ui/blob/master/docs/PUBLIC_API_DESIGN.md) decision **D2**. Now that the `/v1` endpoints are live and about to be documented publicly, this puts the **primary cost/abuse control** in place before the branded hostname exists.

- **Reserved concurrency on the R Lambda: `-1` (unreserved) → `10`.** This hard-caps concurrent R executions regardless of entry path (UI, sync `/v1`, or the async orchestrator), so worst-case spend is bounded and excess requests get a `429`. `10` sits above the orchestrator's `maximum_concurrency = 5`, so async runs can never starve synchronous UI/API calls.
- **New CloudWatch throttle alarm** on the R Lambda (`Throttles > 0` over 5 min). With the cap in place, throttles are the signal that it's being hit, from an abusive caller or from organic growth that warrants raising the number. `Throttles` also added to the existing dashboard widget.

`alarm_actions` is left `[]`, consistent with the existing error/duration alarms in this file (visible on the dashboard, no paging wired up yet).

## Why this is the load-bearing control

Rate-limiting only the future `api.maive.eu` hostname is bypassable via the raw `.on.aws` Function URL (the UI's own path). A concurrency cap bounds spend no matter who calls or how, which is why the design makes it the primary lever and edge rate limits secondary.

## Rollout note

This flips the R Lambda from unreserved to a cap of 10. Per the design doc, the plan is to apply the cap first and watch the new throttle alarm across a normal week of UI traffic before standing up the public hostname, tuning the number from observed load. If `10` proves tight for real UI usage, bump `lambda_r_backend_reserved_concurrency`.

**Rollback:** set `lambda_r_backend_reserved_concurrency` back to `-1`.

## Verification

- `terraform fmt`: clean. `terraform validate` needs `init` against the remote S3 state + AWS creds, so it runs in the deploy pipeline's plan step rather than locally.

## Not in this PR (your Cloudflare console work)

The `api.maive.eu` edge is managed out of band (no Worker source in this repo). To finish Phase 2:

1. **DNS**: `api.maive.eu` proxied (orange-cloud) through Cloudflare.
2. **Worker route** on `api.maive.eu/*`, path-routing to the two origins and rewriting `Host`/SNI to the `.on.aws` origin (same rewrite the UI Worker already does, since Function URLs reject a foreign `Host`):
   - `/v1/runs*` → **UI Lambda** Function URL (async submit/poll; fast handlers).
   - everything else under `/v1/*` (`/v1/run-model`, `/v1/run-rtma`, `/v1/health`) → **R Lambda** Function URL (sync).
   - Function URLs are in `terraform output` (`r_backend`/`ui` function URLs).
3. **Rate limiting rules** (per-IP), starting points to tune from the throttle alarm:
   - `POST api.maive.eu/v1/*` → 10 req / min / IP.
   - `GET api.maive.eu/v1/*` → 120 req / min / IP.
4. **WAF/bot** managed rules on the zone, as on the UI hostname.

Do **not** lock the Function URLs to Cloudflare-only (shared-secret header): that would force the UI's direct browser calls through the edge and inherit the ~100s cap, breaking long sync UI runs. The concurrency cap in this PR is the protection; revisit only if bypass abuse is actually observed (design §7, §12).

## Merge

Needs the `release` + a `v-*` label to deploy (the release workflow applies `prod-runtime`). Suggest `v-patch`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)