### PR TITLE
fix: retry R backend 429s and capture the Cloudflare edge in-repo

### DIFF
--- a/apps/orchestrator/src/index.ts
+++ b/apps/orchestrator/src/index.ts
@@ -11,8 +11,72 @@ const tableName = process.env.RUNS_TABLE_NAME ?? "";
 const rApiUrl = (process.env.R_API_URL ?? "").replace(/\/+$/, "");
 
 const TTL_SECONDS = 48 * 60 * 60; // 48h
-const FETCH_TIMEOUT_MS = 630_000; // below the Lambda 660s timeout
+const FETCH_TIMEOUT_MS = 630_000; // total work budget, below the Lambda 660s timeout
 const TERMINAL_STATUSES = new Set(["succeeded", "failed", "timedout"]);
+
+// Retry budget for HTTP 429 only (see postWithThrottleRetry). Nominally
+// 2+4+8+16+32 = ~62s of waiting for a concurrency slot, jittered, and always
+// bounded by the run's overall deadline.
+const THROTTLE_MAX_RETRIES = 5;
+const THROTTLE_BASE_DELAY_MS = 2_000;
+
+const sleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+
+/**
+ * POST to the R backend, retrying *only* on HTTP 429.
+ *
+ * A 429 means the R Lambda's reserved-concurrency cap rejected the invocation,
+ * so the analysis never ran. That makes a retry both safe and cheap, and it is
+ * the one case the async design's D4 ("no auto-retry") does not actually cover:
+ * D4 refuses retries because MCMC is nondeterministic and pathological datasets
+ * just re-time-out at double cost, which is only true of runs that executed.
+ * Without this, a burst of synchronous traffic saturating the cap would mark
+ * queued runs permanently `failed` instead of letting them wait for a slot.
+ *
+ * Every other response, including 5xx, is returned untouched for the caller to
+ * record as terminal.
+ */
+export async function postWithThrottleRetry(
+  url: string,
+  body: string,
+  deadline: number,
+): Promise<Response> {
+  for (let attempt = 0; ; attempt++) {
+    const remaining = deadline - Date.now();
+    if (remaining <= 0) {
+      throw new Error("Timed out waiting for R backend capacity.");
+    }
+
+    // eslint-disable-next-line no-await-in-loop
+    const response = await fetch(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body,
+      signal: AbortSignal.timeout(remaining),
+    });
+
+    if (response.status !== 429) {
+      return response;
+    }
+
+    const delay = Math.round(
+      THROTTLE_BASE_DELAY_MS * 2 ** attempt * (0.5 + Math.random()),
+    );
+    if (attempt >= THROTTLE_MAX_RETRIES || Date.now() + delay >= deadline) {
+      return response; // out of budget; caller records the 429 as terminal
+    }
+
+    // Release the socket before sleeping; the body is a throttle error we
+    // never read.
+    // eslint-disable-next-line no-await-in-loop
+    await response.arrayBuffer().catch(() => undefined);
+    // eslint-disable-next-line no-await-in-loop
+    await sleep(delay);
+  }
+}
 
 const ddb = DynamoDBDocumentClient.from(new DynamoDBClient({ region }));
 
@@ -87,27 +151,29 @@ async function processRecord(record: SQSRecord): Promise<void> {
   const endpoint = modelType === "RTMA" ? "/run-rtma" : "/run-model";
 
   try {
-    const response = await fetch(`${rApiUrl}${endpoint}`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
+    const response = await postWithThrottleRetry(
+      `${rApiUrl}${endpoint}`,
       // Mirror the browser modelService request shape: the R Plumber endpoint
       // expects JSON strings for `data` and `parameters`.
-      body: JSON.stringify({
+      JSON.stringify({
         data: JSON.stringify(data),
         parameters: JSON.stringify(parameters),
       }),
-      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
-    });
-
-    const text = await response.text();
+      startedAt + FETCH_TIMEOUT_MS,
+    );
 
     if (!response.ok) {
       await markTerminal(jobId, "failed", {
         startedAt,
-        errorMessage: `R backend returned HTTP ${response.status}`,
+        errorMessage:
+          response.status === 429
+            ? "R backend is at capacity: every concurrency slot was busy for the whole retry window. Please try again."
+            : `R backend returned HTTP ${response.status}`,
       });
       return;
     }
+
+    const text = await response.text();
 
     let parsed: RBackendResponse;
     try {

--- a/docs/ASYNC_RUNS_DESIGN.md
+++ b/docs/ASYNC_RUNS_DESIGN.md
@@ -70,7 +70,7 @@ This aligns with the direction agreed in #441 ("async/background runs now").
 | D1 | **Worker invocation: SQS → thin orchestrator Lambda (Node 20) → existing R Function URL.** The R backend is unchanged. | The R image is an HTTP server behind the Lambda Web Adapter; an SQS event source or async SDK `Invoke` would not route to it without a risky runtime rewrite. The orchestrator isolates the brittle R image and gives retries/concurrency/DLQ for free. |
 | D2 | **Result storage: DynamoDB-only, full result (~50 KB) stored inline; 48 h TTL.** No S3. | Result fits well under DynamoDB's 400 KB item limit. One store, minimal footprint. S3 reserved only if a payload ever exceeds ~400 KB. |
 | D3 | **Durable history is client-side** (IndexedDB for result payloads, localStorage for the lightweight job list). The DynamoDB item is only a **48 h pickup buffer**. | Matches "persist it in the client's session"; minimizes server persistence. |
-| D4 | **No auto-retry** (`maxReceiveCount=1` → DLQ; user re-runs explicitly). | MCMC is nondeterministic (a retry yields a different result) and pathological datasets just re-time-out, doubling cost. |
+| D4 | **No auto-retry for runs that executed** (`maxReceiveCount=1` → DLQ; user re-runs explicitly). **Amended 2026-07-17:** HTTP 429 from the R backend *is* retried in-process with bounded backoff. | MCMC is nondeterministic (a retry yields a different result) and pathological datasets just re-time-out, doubling cost, but both rationales only apply to runs that actually ran. A 429 means the reserved-concurrency cap (see PUBLIC_API_DESIGN.md D2) refused the invocation and no analysis happened, so retrying is deterministic-safe and free. Without the carve-out, a burst of synchronous traffic saturating the cap marks queued runs permanently `failed` instead of letting them wait for a slot. |
 | D5 | **Keep the synchronous path as a flagged fallback** — and as the route for datasets too large to queue. | Instant rollback lever; avoids needing S3 input plumbing in Phase 1 (large datasets bypass the queue). |
 | D6 | **Runs list is per-browser** (no accounts). `jobId` is an opaque bearer token; results readable by anyone holding the id. | No identity system exists; same sharing model as today's shareable results URL. |
 | D7 | **Status delivery via short polling** (status-only reads; full result fetched once when terminal). No SSE/WebSocket. | Simple; fast handlers; avoids Lambda/Cloudflare long-connection issues. |
@@ -171,6 +171,9 @@ All handlers are fast (DDB/SQS calls), so the UI Lambda's 30 s cap is irrelevant
   `maximum_concurrency` set to match so it never out-calls the R cap (avoids 429s).
 - **SQS visibility timeout** (~660 s) > R Lambda max work time (600 s) to avoid mid-run redelivery.
 - **No auto-retry** (D4): `maxReceiveCount=1` → DLQ; CloudWatch alarm on DLQ depth.
+  The one exception is an HTTP 429 from the R backend (its reserved-concurrency
+  cap refusing the invocation): the orchestrator retries in-process with
+  bounded, jittered backoff, since no analysis ran. See D4.
 - **SQS 256 KB message limit**: datasets above the budget use the synchronous fallback (D5);
   the S3 input-pointer escape hatch is deferred (see §15).
 

--- a/docs/PUBLIC_API.md
+++ b/docs/PUBLIC_API.md
@@ -6,10 +6,9 @@ MAIVE exposes a public, anonymous HTTP API for running MAIVE / WAIVE / WLS
 and RTMA meta-analysis models programmatically; no accounts, no API keys.
 It's the same compute the MAIVE UI uses, given a clean, documented contract.
 
-> **Status:** this guide documents the target `/v1` contract. The branded
-> hostname (`api.maive.eu`) goes live in a later rollout phase; if it
-> doesn't resolve yet, that's expected; see
-> [`PUBLIC_API_DESIGN.md`](PUBLIC_API_DESIGN.md) for the rollout plan.
+> **Status:** live. `https://api.maive.eu` serves the `/v1` contract described
+> here. See [`PUBLIC_API_DESIGN.md`](PUBLIC_API_DESIGN.md) for the design
+> decisions behind it.
 
 The full machine-readable contract lives in
 [`docs/api/openapi.yaml`](api/openapi.yaml) (OpenAPI 3); it is the source of

--- a/docs/PUBLIC_API_DESIGN.md
+++ b/docs/PUBLIC_API_DESIGN.md
@@ -1,6 +1,6 @@
 # Public Model API: Design & Implementation Plan
 
-**Status:** Phase 1 implemented (sync + async /v1, spec, docs); Phases 2-3 pending
+**Status:** Phases 1-2 implemented and live at `https://api.maive.eu`; Phase 3 (UI docs page, announcement) pending
 **Date:** 2026-07-08
 **Related:** [ASYNC_RUNS_DESIGN.md](ASYNC_RUNS_DESIGN.md) (async runs infra this design reuses);
 [SERVER_SIDE_API_ARCHITECTURE.md](SERVER_SIDE_API_ARCHITECTURE.md) (current serving topology)
@@ -344,15 +344,29 @@ synchronous UI runs. Revisit only if bypass abuse is actually observed (§12).
 - [x] Tests (UI side): Vitest coverage for the `/api/v1/runs` routes. Shipped
       in #467.
 
-**Phase 2, infra & edge:**
+**Phase 2, infra & edge:** *(done)*
 
-- [ ] Terraform (`prod-runtime`): `reserved_concurrent_executions = 10` on the
+- [x] Terraform (`prod-runtime`): `reserved_concurrent_executions = 10` on the
       R Lambda; CloudWatch throttle alarm.
-- [ ] Cloudflare (managed out of band, like the existing Worker): DNS
-      `api.maive.eu`, Worker route with path-based origin selection (D9),
-      rate-limit + WAF rules.
-- [ ] Smoke test the full surface through the branded hostname; verify the UI
+- [x] Cloudflare: DNS `api.maive.eu`, Worker route with path-based origin
+      selection (D9), rate-limit rule. The Worker sources and the edge
+      inventory now live in `infra/cloudflare/` rather than only in the
+      Cloudflare account.
+- [x] Smoke test the full surface through the branded hostname; verify the UI
       is unaffected (its direct `.on.aws` path unchanged).
+
+Two things differed from the plan as written:
+
+- **Rate limiting:** the zone is on the **Free** plan, which allows exactly
+  **one** rate-limiting rule and locks the window to 10s, and that one rule was
+  already in use for the UI. So instead of the separate per-method limits this
+  document originally specced (10/min POST, 120/min GET), the existing rule's
+  expression was extended to also match `api.maive.eu`, giving the API a shared
+  ~100 req/10s per-IP limit. The concurrency cap (D2) remains the real control,
+  so this is a speed bump rather than the primary defense.
+- **DNS:** a wildcard `CNAME *.maive.eu` already existed, so `api.maive.eu`
+  resolved (and hung) before any change. An explicit `api` record was added so
+  the API does not silently depend on that wildcard.
 
 **Phase 3, publication:**
 
@@ -390,12 +404,30 @@ until Phase 3.
   eventual fix.
 - **Concurrency cap = 10 is a guess.** It now also throttles UI sync traffic
   at the margin; previously it was deliberately unreserved. Watch the throttle
-  alarm; tune.
+  alarm; tune. Each unit of concurrency is worth roughly **$0.12/hour
+  (~$86/month)** of worst-case exposure at 2 GB, so the cap is effectively the
+  ceiling on an anonymous abuse bill: ~$29/day at 10, ~$58/day at 20. Note the
+  cap is **global, not per-caller**: anonymous access means there is no
+  per-user quota, and the edge rule limits request *rate*, not concurrency, so
+  one heavy caller can occupy all of it.
+- **Sync traffic can crowd out async runs.** Async is capped at 5 by the
+  orchestrator's event-source `maximum_concurrency`, so it cannot exhaust the
+  cap alone; but sync calls compete for the same 10 slots. When they win, the
+  orchestrator's call to R gets a 429. It now retries that with bounded backoff
+  (async design D4, amended) so runs wait rather than fail. Before that fix a
+  sync burst could mark queued UI runs permanently `failed`. If the throttle
+  alarm shows this happening for real, raise `maximum_concurrency` and
+  `lambda_r_backend_reserved_concurrency` **together**: raising R alone will not
+  speed async up, and raising the orchestrator alone starves sync.
 - **Column resolution by name (D5)** adds one behavior divergence from legacy
   (which is purely positional). Contained to `/v1`; property-tested in the e2e
   scenario.
-- **Hostname mirroring:** also expose `api.spuriousprecision.com`? Deferred;
-  one canonical hostname keeps docs and rate-limit scoping simple.
+- **Hostname mirroring:** ~~also expose `api.spuriousprecision.com`?~~
+  **Decided:** no. `api.maive.eu` is the single canonical hostname; one
+  hostname keeps docs and rate-limit scoping simple (and on the Free plan the
+  zone gets only one rate-limit rule anyway). `easymeta.org` is GoDaddy
+  domain-forwarding, not a Cloudflare zone, so it could not host an API
+  hostname without moving its DNS first.
 - **Result-shape stability:** `/v1` freezes field names that today mirror
   internal R naming (`petpeese_selected`, `is_quadratic_fit`, …). Accepted;
   they're already the de-facto contract for the UI and reproducibility

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -11,9 +11,7 @@ info:
     [`docs/PUBLIC_API.md`](../PUBLIC_API.md) for a usage guide with copy-paste
     curl / R / Python examples.
 
-    **Status:** this spec documents the target contract. The branded hostname
-    (`api.maive.eu`) goes live in a later rollout phase (Phase 2 of the design
-    doc); it may not resolve yet.
+    **Status:** live. `https://api.maive.eu` serves this contract.
 
     **Access:** anonymous; no accounts, no API keys. Abuse is bounded by
     server-side concurrency caps and edge rate limits, not identity.

--- a/infra/cloudflare/README.md
+++ b/infra/cloudflare/README.md
@@ -1,0 +1,97 @@
+# Cloudflare edge configuration
+
+Cloudflare fronts the UI domains and the public API hostname. It is **not**
+managed by Terraform (unlike everything under `terraform/`); it is configured
+through the Cloudflare API/dashboard. This directory exists so the edge is at
+least reviewable and reproducible in-repo rather than living only in the
+Cloudflare account.
+
+Keep this file in sync when you change anything at the edge.
+
+## Why a Worker at all
+
+Both origins are AWS Lambda **Function URLs**, which reject requests carrying a
+foreign `Host` header. Cloudflare's standard proxy forwards the original `Host`
+(overriding it at the origin is an Enterprise feature), so a plain proxied CNAME
+to a Function URL returns errors/hangs. Each hostname therefore routes through a
+Worker that re-issues the request as a subrequest to the `.on.aws` origin with
+`Host`/SNI rewritten.
+
+## Account / zone
+
+| | |
+|---|---|
+| Account | `e3f44e904f9ace6427b6a47cb28a3917` (T.havranek@gmail.com's Account) |
+| Zone | `maive.eu` (`921f07a73f48aa3e80ac2cead44f76ec`, Free plan) |
+
+`spuriousprecision.com` is a separate zone; `easymeta.org` is GoDaddy
+domain-forwarding, not a Cloudflare zone.
+
+## Workers
+
+| Script | Source | Routes |
+|---|---|---|
+| `ui-origin-proxy` | [`workers/ui-origin-proxy.js`](workers/ui-origin-proxy.js) | `maive.eu/*`, `www.maive.eu/*` |
+| `api-origin-proxy` | [`workers/api-origin-proxy.js`](workers/api-origin-proxy.js) | `api.maive.eu/*` |
+
+`api-origin-proxy` path-routes between the two Lambda origins and whitelists
+only the documented `/v1` endpoints (everything else 404s, keeping the legacy
+`/run-model`, `/echo`, `/ping` routes off the public hostname). See
+[`docs/PUBLIC_API_DESIGN.md`](../../docs/PUBLIC_API_DESIGN.md) §5.
+
+Origins (both public; the R URL is already exposed to browsers via
+`/api/runtime-config`):
+
+- R backend: `5jvqw3f3wnogn24sb3tfpg2wqy0htdys.lambda-url.eu-central-1.on.aws`
+- UI: `zekrvvwo2u3fcbmvzlkozy56du0jqwdu.lambda-url.eu-central-1.on.aws`
+
+If a Function URL is ever recreated, these hostnames change and both the Worker
+sources and the DNS records below must be updated.
+
+### Deploying a worker
+
+```bash
+# token needs Account:Workers Scripts:Edit on the account above
+bash infra/cloudflare/deploy-worker.sh api-origin-proxy
+```
+
+## DNS (zone `maive.eu`)
+
+| Record | Type | Content | Proxied |
+|---|---|---|---|
+| `maive.eu` | CNAME | UI Function URL host | yes |
+| `www` | CNAME | UI Function URL host | yes |
+| `api` | CNAME | UI Function URL host | yes |
+| `*` | CNAME | UI Function URL host | yes |
+
+The record **content for `api` is a placeholder**: the Worker route intercepts
+the request and picks the origin per path, so the CNAME target is never used.
+It exists only so the hostname resolves through Cloudflare without depending on
+the `*` wildcard.
+
+Note the wildcard means *any* subdomain resolves through Cloudflare. Subdomains
+with no Worker route (e.g. `foo.maive.eu`) proxy straight to the UI Function
+URL, which rejects the foreign Host, so they hang. Pre-existing; harmless, but
+surprising if you hit it.
+
+## Rate limiting
+
+The zone is on the **Free** plan: exactly **one** rate-limiting rule, and the
+window is locked to 10s. That single rule covers all three hostnames:
+
+- Ruleset: `http_ratelimit` phase, `249833cdb85e4b6ebb17757de27bc98a`
+- Rule: `ba0f0b4af0644677bbff97e336279f4f`
+- Expression: `(http.host eq "maive.eu" or http.host eq "www.maive.eu" or http.host eq "api.maive.eu")`
+- Action: `block`, 100 requests / 10s per `(ip.src, cf.colo.id)`, mitigation 10s
+
+Because it is one shared rule, UI and API traffic count toward the same per-IP
+budget. This is a speed bump, not the main defense: the real cost control is the
+R Lambda's reserved concurrency (`lambda_r_backend_reserved_concurrency`, in
+Terraform), per `PUBLIC_API_DESIGN.md` D2.
+
+## Rollback
+
+- **API hostname:** delete the `api.maive.eu/*` Worker route. `api.maive.eu`
+  reverts to hanging (via the wildcard); the UI is unaffected.
+- **UI:** the `maive.eu/*` and `www.maive.eu/*` routes are load-bearing; do not
+  delete them without a plan.

--- a/infra/cloudflare/deploy-worker.sh
+++ b/infra/cloudflare/deploy-worker.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Deploy a Cloudflare Worker from infra/cloudflare/workers/ to the account that
+# owns maive.eu.
+#
+# Cloudflare is not managed by Terraform (see README.md), so this script is the
+# reproducible path for worker changes. Routes, DNS, and rate-limit rules are
+# documented in README.md and change rarely enough to be done in the dashboard.
+#
+# Auth: expects a scoped API token with Account:Workers Scripts:Edit, either in
+# $CLOUDFLARE_API_TOKEN or in the file below. The token is never echoed.
+#
+# Usage:
+#   bash infra/cloudflare/deploy-worker.sh api-origin-proxy
+#   bash infra/cloudflare/deploy-worker.sh ui-origin-proxy
+set -euo pipefail
+
+SCRIPT_NAME="${1:-}"
+if [ -z "$SCRIPT_NAME" ]; then
+  echo "Usage: $0 <worker-name>   (e.g. api-origin-proxy)" >&2
+  exit 1
+fi
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SRC="$HERE/workers/$SCRIPT_NAME.js"
+if [ ! -f "$SRC" ]; then
+  echo "No such worker source: $SRC" >&2
+  exit 1
+fi
+
+# Account that owns the maive.eu zone (see README.md).
+ACCOUNT_ID="e3f44e904f9ace6427b6a47cb28a3917"
+API="https://api.cloudflare.com/client/v4"
+TOKEN_FILE="${CLOUDFLARE_TOKEN_FILE:-$HOME/.config/cloudflare/maive_token}"
+COMPAT_DATE="2026-07-08"
+
+if [ -n "${CLOUDFLARE_API_TOKEN:-}" ]; then
+  TOKEN="$CLOUDFLARE_API_TOKEN"
+elif [ -s "$TOKEN_FILE" ]; then
+  TOKEN="$(cat "$TOKEN_FILE")"
+else
+  echo "No token: set \$CLOUDFLARE_API_TOKEN or write one to $TOKEN_FILE" >&2
+  exit 1
+fi
+
+echo "Deploying $SCRIPT_NAME from $SRC ..."
+response="$(curl -sS -X PUT "$API/accounts/$ACCOUNT_ID/workers/scripts/$SCRIPT_NAME" \
+  -H "Authorization: Bearer $TOKEN" \
+  -F "metadata={\"main_module\":\"worker.js\",\"compatibility_date\":\"$COMPAT_DATE\"};type=application/json" \
+  -F "worker.js=@$SRC;type=application/javascript+module;filename=worker.js")"
+
+if printf '%s' "$response" | grep -q '"success":true'; then
+  echo "Deployed $SCRIPT_NAME."
+  echo "Verify: curl -s https://api.maive.eu/v1/health"
+else
+  echo "Deploy failed:" >&2
+  printf '%s\n' "$response" | python3 -m json.tool 2>/dev/null || printf '%s\n' "$response"
+  exit 1
+fi

--- a/infra/cloudflare/workers/api-origin-proxy.js
+++ b/infra/cloudflare/workers/api-origin-proxy.js
@@ -1,0 +1,67 @@
+// api-origin-proxy: fronts the public MAIVE API on api.maive.eu.
+// See docs/PUBLIC_API_DESIGN.md (section 5) and docs/api/openapi.yaml.
+//
+// Lambda Function URLs reject a foreign Host header, so each request is
+// re-issued as a subrequest to the .on.aws origin with Host/SNI rewritten
+// (same approach as the ui-origin-proxy worker).
+//
+// Routing:
+//   /v1/runs, /v1/runs/*                    -> UI Lambda (async submit/poll).
+//                                              Next.js serves these under
+//                                              /api/v1/runs, so the path is
+//                                              rewritten; the public contract
+//                                              keeps the /v1/runs form.
+//   /v1/run-model, /v1/run-rtma, /v1/health -> R Lambda (sync; paths match 1:1).
+//
+// Any other path returns 404. Only the documented /v1 endpoints are exposed, so
+// the legacy internal routes (/run-model, /run-rtma, /echo, /ping) stay off the
+// public hostname even though they exist on the R origin.
+
+const R_ORIGIN = "5jvqw3f3wnogn24sb3tfpg2wqy0htdys.lambda-url.eu-central-1.on.aws";
+const UI_ORIGIN = "zekrvvwo2u3fcbmvzlkozy56du0jqwdu.lambda-url.eu-central-1.on.aws";
+
+const R_PATHS = new Set(["/v1/run-model", "/v1/run-rtma", "/v1/health"]);
+
+function notFound() {
+  const body = {
+    error: {
+      code: "not_found",
+      message:
+        "Unknown endpoint. Available: /v1/run-model, /v1/run-rtma, /v1/runs, /v1/runs/{jobId}, /v1/health.",
+    },
+  };
+  return new Response(JSON.stringify(body), {
+    status: 404,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+export default {
+  async fetch(request) {
+    const url = new URL(request.url);
+    const path = url.pathname.replace(/\/+$/, "") || "/";
+
+    let origin;
+    if (path === "/v1/runs" || path.startsWith("/v1/runs/")) {
+      origin = UI_ORIGIN;
+      url.pathname = "/api" + path;
+    } else if (R_PATHS.has(path)) {
+      origin = R_ORIGIN;
+      url.pathname = path;
+    } else {
+      return notFound();
+    }
+
+    url.hostname = origin;
+
+    const headers = new Headers(request.headers);
+    headers.set("host", origin);
+
+    return fetch(url, {
+      method: request.method,
+      headers,
+      body: request.body,
+      redirect: "manual",
+    });
+  },
+};

--- a/infra/cloudflare/workers/ui-origin-proxy.js
+++ b/infra/cloudflare/workers/ui-origin-proxy.js
@@ -1,0 +1,27 @@
+// ui-origin-proxy: fronts the Next.js UI on maive.eu and www.maive.eu.
+//
+// Lambda Function URLs reject a foreign Host header, so the request is
+// re-issued as a subrequest to the .on.aws origin with Host/SNI rewritten.
+// See docs/SERVER_SIDE_API_ARCHITECTURE.md.
+//
+// NOTE: this file was recovered from the deployed worker (created 2026-06-04,
+// originally configured by hand in the Cloudflare dashboard) and committed here
+// so the edge is reviewable in-repo. It is reproduced verbatim; if you change
+// it, redeploy with infra/cloudflare/deploy-worker.sh and keep this file in
+// sync.
+
+export default {
+  async fetch(request) {
+    const ORIGIN = "zekrvvwo2u3fcbmvzlkozy56du0jqwdu.lambda-url.eu-central-1.on.aws";
+    const url = new URL(request.url);
+    url.hostname = ORIGIN;
+    const headers = new Headers(request.headers);
+    headers.set("host", ORIGIN);
+    return fetch(url, {
+      method: request.method,
+      headers,
+      body: request.body,
+      redirect: "manual",
+    });
+  },
+};


### PR DESCRIPTION
## Summary

Follow-up to the public API going live at **https://api.maive.eu**. Three things, all consequences of Phase 2 landing:

1. **Fix: queued runs no longer fail when the concurrency cap is saturated** (behavior change)
2. **Capture the Cloudflare edge in-repo** — it previously existed only in the Cloudflare account
3. **Correct the docs**, which still claimed the hostname wasn't live

## 1. The 429 fix (the important part)

[PR #472](https://github.com/PetrCala/maive-ui/pull/472) capped the R Lambda at 10 reserved concurrent executions. That introduced a failure mode that didn't previously exist: the orchestrator treated **any** non-OK HTTP from R as terminal `failed`, with `maxReceiveCount=1` meaning no retry. Before the cap R was unreserved and never throttled, so this path was unreachable. Now:

> A burst of synchronous traffic occupies the 10 slots → the orchestrator's call to R returns **429** → a queued UI run is marked permanently **`failed`** ("R backend returned HTTP 429") instead of waiting for a slot.

Async alone can't cause this (the orchestrator's `maximum_concurrency=5` ≤ 10), but sync calls compete for the same pool, and the public sync API makes that traffic much more likely.

**The fix:** retry **only** on 429, in-process, with jittered exponential backoff (~62s nominal), always bounded by the run's overall deadline. Every other response, including 5xx, stays terminal exactly as before.

The key insight is that this doesn't violate the async design's D4 ("no auto-retry") — it clarifies it. D4 refuses retries because MCMC is nondeterministic and pathological datasets re-time-out at double cost. **Both rationales only apply to runs that actually executed.** A 429 means the invocation was refused and no analysis ran, so retrying is deterministic-safe and free. D4 is amended accordingly in `ASYNC_RUNS_DESIGN.md`.

## 2. Cloudflare edge in-repo (`infra/cloudflare/`)

The edge was configured by hand and lived only in the Cloudflare account — which is exactly why setting up `api.maive.eu` required reverse-engineering it through the API first. Now committed:

- `workers/api-origin-proxy.js` — the new API Worker (verified byte-identical to what's deployed)
- `workers/ui-origin-proxy.js` — the **pre-existing** UI Worker, recovered from the deployed script so the whole edge is captured, not just the new half
- `deploy-worker.sh` — reproducible deploy path
- `README.md` — account/zone IDs, routes, DNS (incl. the wildcard-CNAME quirk that makes every subdomain hang), the rate-limit rule, and rollback

## 3. Docs corrected

- `openapi.yaml` + `PUBLIC_API.md`: "goes live in a later rollout phase; may not resolve yet" → **live**
- `PUBLIC_API_DESIGN.md`: status → Phases 1-2 done; Phase 2 checklist ticked; records the two deviations from plan (Free plan allows **one** rate-limit rule with a 10s window, so the specced per-method limits became one extended shared rule; a pre-existing wildcard CNAME meant `api.maive.eu` already resolved)
- Resolved the open question on hostname mirroring: **no**, `api.maive.eu` is canonical (`easymeta.org` isn't even a Cloudflare zone)
- Documented the concurrency economics: **~$0.12/hour (~$86/month) of worst-case exposure per unit**, and that the cap is global, not per-caller

## Verification

- **Retry logic tested against the real compiled module** with a stubbed `fetch` — 18 assertions, all passing: 200 → no retry; **500 → not retried** (D4 preserved); 429→200 → retries once; always-429 → bounded at 6 attempts then returns 429 for terminal recording; expired deadline → throws without calling fetch; tight deadline → stops early rather than overrunning budget
- Orchestrator `typecheck` + `bundle` clean (CI rebuilds `dist/`, which is gitignored)
- `redocly lint docs/api/openapi.yaml` valid
- UI vitest 117/117 (untouched)
- Committed Worker source diffed against the live deployed script: identical

## Note

The orchestrator has no test runner (only `typecheck` + `bundle`), so the retry harness above isn't committed. Worth adding vitest there as a follow-up if you want regression cover on this path.

Needs `release` + `v-patch` to deploy the orchestrator change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)