### PR TITLE
feat: add public API docs page

### DIFF
--- a/apps/react-ui/client/src/CONST.ts
+++ b/apps/react-ui/client/src/CONST.ts
@@ -31,6 +31,14 @@ const CONST = {
       HOMEPAGE: `https://github.com/${GH_OWNER}/${GH_REPO_UI}`,
       ISSUES: `https://github.com/${GH_OWNER}/${GH_REPO_UI}/issues`,
     },
+    PUBLIC_API: {
+      // Branded hostname for the public /v1 model API (see docs/PUBLIC_API.md).
+      BASE_URL: "https://api.maive.eu",
+      // In-app docs page. Kept off /api, which is the Next.js API-routes namespace.
+      DOCS_ROUTE: "/api-docs",
+      SPEC: `https://github.com/${GH_OWNER}/${GH_REPO_UI}/blob/master/docs/api/openapi.yaml`,
+      GUIDE: `https://github.com/${GH_OWNER}/${GH_REPO_UI}/blob/master/docs/PUBLIC_API.md`,
+    },
     APPLICATIONS_URL: "https://meta-analysis.cz/",
     CREATOR_URL: `https://github.com/${GH_OWNER}`,
     CONTACT_WEBSITE_URL: "https://irsova.com/",

--- a/apps/react-ui/client/src/components/ApiDocs/CodeBlock.tsx
+++ b/apps/react-ui/client/src/components/ApiDocs/CodeBlock.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import { copyToClipboard } from "@src/utils/citationUtils";
+
+type CodeBlockProps = {
+  code: string;
+  /** Accessible name for the copy button, e.g. "curl example". */
+  label: string;
+  className?: string;
+};
+
+const CodeBlock = ({ code, label, className = "" }: CodeBlockProps) => {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = useCallback(() => {
+    void (async () => {
+      const succeeded = await copyToClipboard(code);
+      if (!succeeded) {
+        return;
+      }
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    })();
+  }, [code]);
+
+  return (
+    <div className={`relative ${className}`}>
+      <button
+        type="button"
+        onClick={handleCopy}
+        aria-label={`Copy ${label}`}
+        className="absolute right-2 top-2 rounded-md border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 px-2 py-1 text-xs font-medium text-secondary hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
+      >
+        {copied ? "Copied!" : "Copy"}
+      </button>
+      <pre className="bg-gray-100 dark:bg-gray-800 rounded-lg p-4 pr-16 overflow-x-auto">
+        <code className="text-sm font-mono text-gray-800 dark:text-gray-200 whitespace-pre">
+          {code}
+        </code>
+      </pre>
+    </div>
+  );
+};
+
+export default CodeBlock;

--- a/apps/react-ui/client/src/components/ApiDocs/CodeExampleTabs.tsx
+++ b/apps/react-ui/client/src/components/ApiDocs/CodeExampleTabs.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { useId, useState } from "react";
+import { getToggleButtonClasses } from "@src/styles/formStyles";
+import CodeBlock from "./CodeBlock";
+import type { CodeSample } from "./apiDocsContent";
+
+type CodeExampleTabsProps = {
+  samples: CodeSample[];
+  /** Names the tab group for screen readers, e.g. "Synchronous run examples". */
+  label: string;
+  className?: string;
+};
+
+const CodeExampleTabs = ({
+  samples,
+  label,
+  className = "",
+}: CodeExampleTabsProps) => {
+  const groupId = useId();
+  const [activeLanguage, setActiveLanguage] = useState(samples[0].language);
+  const active =
+    samples.find((sample) => sample.language === activeLanguage) ?? samples[0];
+
+  return (
+    <div className={`space-y-3 ${className}`}>
+      <div role="tablist" aria-label={label} className="flex flex-wrap gap-2">
+        {samples.map((sample) => {
+          const isActive = sample.language === active.language;
+          return (
+            <button
+              key={sample.language}
+              type="button"
+              role="tab"
+              id={`${groupId}-tab-${sample.language}`}
+              aria-selected={isActive}
+              aria-controls={`${groupId}-panel-${sample.language}`}
+              onClick={() => setActiveLanguage(sample.language)}
+              className={`${getToggleButtonClasses(isActive)} rounded-lg`}
+            >
+              {sample.label}
+            </button>
+          );
+        })}
+      </div>
+      <div
+        role="tabpanel"
+        id={`${groupId}-panel-${active.language}`}
+        aria-labelledby={`${groupId}-tab-${active.language}`}
+      >
+        <CodeBlock code={active.code} label={`${label}, ${active.label}`} />
+      </div>
+    </div>
+  );
+};
+
+export default CodeExampleTabs;

--- a/apps/react-ui/client/src/components/ApiDocs/apiDocsContent.ts
+++ b/apps/react-ui/client/src/components/ApiDocs/apiDocsContent.ts
@@ -1,0 +1,365 @@
+/**
+ * Copy and code samples for the public API docs page.
+ *
+ * Mirrors docs/PUBLIC_API.md; docs/api/openapi.yaml is the source of truth for
+ * the contract, so keep the tables below in sync with it when /v1 changes.
+ */
+
+import CONST from "@src/CONST";
+
+const BASE_URL = CONST.LINKS.PUBLIC_API.BASE_URL;
+
+export type EndpointRow = {
+  method: string;
+  path: string;
+  kind: "Sync" | "Async" | "Meta";
+  description: string;
+};
+
+export const ENDPOINTS: EndpointRow[] = [
+  {
+    method: "POST",
+    path: "/v1/run-model",
+    kind: "Sync",
+    description: "Run MAIVE, WAIVE, or WLS and get the result in the response.",
+  },
+  {
+    method: "POST",
+    path: "/v1/run-rtma",
+    kind: "Sync",
+    description: "Run RTMA and get the result in the response.",
+  },
+  {
+    method: "POST",
+    path: "/v1/runs",
+    kind: "Async",
+    description: "Queue a run; returns a jobId immediately.",
+  },
+  {
+    method: "GET",
+    path: "/v1/runs/{jobId}",
+    kind: "Async",
+    description: "Poll a run; returns the result once it has succeeded.",
+  },
+  {
+    method: "GET",
+    path: "/v1/health",
+    kind: "Meta",
+    description: "Health check.",
+  },
+];
+
+export type DataFieldRow = {
+  field: string;
+  type: string;
+  requiredFor: string;
+  notes: string;
+};
+
+export const DATA_FIELDS: DataFieldRow[] = [
+  {
+    field: "effect",
+    type: "number",
+    requiredFor: "MAIVE-family, RTMA",
+    notes: "Estimated effect size.",
+  },
+  {
+    field: "se",
+    type: "number",
+    requiredFor: "MAIVE-family, RTMA",
+    notes: "Standard error; must be greater than 0.",
+  },
+  {
+    field: "n_obs",
+    type: "integer",
+    requiredFor: "MAIVE-family",
+    notes: "Number of observations; must be a positive integer.",
+  },
+  {
+    field: "study_id",
+    type: "string",
+    requiredFor: "Optional",
+    notes:
+      "Enables study clustering. If present, rows must be at least unique studies plus 3.",
+  },
+];
+
+export type ParameterRow = {
+  name: string;
+  values: string;
+  defaultValue: string;
+};
+
+export const MODEL_PARAMETERS: ParameterRow[] = [
+  { name: "modelType", values: "MAIVE | WAIVE | WLS", defaultValue: "MAIVE" },
+  {
+    name: "maiveMethod",
+    values: "PET | PEESE | PET-PEESE | EK",
+    defaultValue: "PET-PEESE",
+  },
+  {
+    name: "weight",
+    values:
+      "equal_weights | standard_weights | adjusted_weights | study_weights",
+    defaultValue: "equal_weights",
+  },
+  {
+    name: "standardErrorTreatment",
+    values: "not_clustered | clustered | clustered_cr2 | bootstrap",
+    defaultValue: "clustered_cr2",
+  },
+  { name: "includeStudyDummies", values: "boolean", defaultValue: "false" },
+  { name: "includeStudyClustering", values: "boolean", defaultValue: "false" },
+  { name: "computeAndersonRubin", values: "boolean", defaultValue: "false" },
+  { name: "useLogFirstStage", values: "boolean", defaultValue: "false" },
+  {
+    name: "winsorize",
+    values: "number (percent, 0 disables)",
+    defaultValue: "0",
+  },
+  {
+    name: "shouldUseInstrumenting",
+    values: "boolean",
+    defaultValue: "derived: false for WLS, true otherwise",
+  },
+];
+
+export const RTMA_PARAMETERS: ParameterRow[] = [
+  { name: "favorPositive", values: "boolean", defaultValue: "true" },
+  { name: "alphaSelect", values: "number", defaultValue: "0.05" },
+  { name: "ciLevel", values: "number", defaultValue: "0.95" },
+  {
+    name: "winsorize",
+    values: "number (percent, 0 disables)",
+    defaultValue: "0",
+  },
+];
+
+export type CodeSample = {
+  language: string;
+  label: string;
+  code: string;
+};
+
+export const SYNC_EXAMPLES: CodeSample[] = [
+  {
+    language: "bash",
+    label: "curl",
+    code: `curl -s ${BASE_URL}/v1/run-model \\
+  -H 'Content-Type: application/json' \\
+  -d '{
+    "data": [
+      {"effect": 0.42, "se": 0.11, "n_obs": 120},
+      {"effect": 0.31, "se": 0.06, "n_obs": 90},
+      {"effect": 0.55, "se": 0.20, "n_obs": 45},
+      {"effect": 0.12, "se": 0.04, "n_obs": 200}
+    ]
+  }'`,
+  },
+  {
+    language: "r",
+    label: "R (httr2)",
+    code: `library(httr2)
+
+body <- list(
+  data = list(
+    list(effect = 0.42, se = 0.11, n_obs = 120),
+    list(effect = 0.31, se = 0.06, n_obs = 90),
+    list(effect = 0.55, se = 0.20, n_obs = 45),
+    list(effect = 0.12, se = 0.04, n_obs = 200)
+  )
+)
+
+resp <- request("${BASE_URL}/v1/run-model") |>
+  req_body_json(body) |>
+  req_perform()
+
+results <- resp_body_json(resp)
+str(results)`,
+  },
+  {
+    language: "python",
+    label: "Python (requests)",
+    code: `import requests
+
+body = {
+    "data": [
+        {"effect": 0.42, "se": 0.11, "n_obs": 120},
+        {"effect": 0.31, "se": 0.06, "n_obs": 90},
+        {"effect": 0.55, "se": 0.20, "n_obs": 45},
+        {"effect": 0.12, "se": 0.04, "n_obs": 200},
+    ]
+}
+
+resp = requests.post("${BASE_URL}/v1/run-model", json=body, timeout=120)
+resp.raise_for_status()
+results = resp.json()
+print(results["effectEstimate"], results["standardError"])`,
+  },
+];
+
+export const ASYNC_EXAMPLES: CodeSample[] = [
+  {
+    language: "bash",
+    label: "curl",
+    code: `# 1. Submit
+job=$(curl -s ${BASE_URL}/v1/runs \\
+  -H 'Content-Type: application/json' \\
+  -d '{
+    "modelType": "MAIVE",
+    "data": [
+      {"effect": 0.42, "se": 0.11, "n_obs": 120},
+      {"effect": 0.31, "se": 0.06, "n_obs": 90},
+      {"effect": 0.55, "se": 0.20, "n_obs": 45},
+      {"effect": 0.12, "se": 0.04, "n_obs": 200}
+    ]
+  }' | jq -r '.jobId')
+
+echo "jobId: $job"
+
+# 2. Poll until terminal
+while true; do
+  status=$(curl -s "${BASE_URL}/v1/runs/$job" | tee /tmp/run.json | jq -r '.status')
+  echo "status: $status"
+  [[ "$status" == "succeeded" || "$status" == "failed" || "$status" == "timedout" ]] && break
+  sleep 3
+done
+
+# 3. Read the result
+jq '.result' /tmp/run.json`,
+  },
+  {
+    language: "r",
+    label: "R (httr2)",
+    code: `library(httr2)
+
+submit_body <- list(
+  modelType = "MAIVE",
+  data = list(
+    list(effect = 0.42, se = 0.11, n_obs = 120),
+    list(effect = 0.31, se = 0.06, n_obs = 90),
+    list(effect = 0.55, se = 0.20, n_obs = 45),
+    list(effect = 0.12, se = 0.04, n_obs = 200)
+  )
+)
+
+submit_resp <- request("${BASE_URL}/v1/runs") |>
+  req_body_json(submit_body) |>
+  req_perform()
+
+job_id <- resp_body_json(submit_resp)$jobId
+cat("jobId:", job_id, "\\n")
+
+terminal_statuses <- c("succeeded", "failed", "timedout")
+repeat {
+  run <- request(sprintf("${BASE_URL}/v1/runs/%s", job_id)) |>
+    req_perform() |>
+    resp_body_json()
+
+  cat("status:", run$status, "\\n")
+  if (run$status %in% terminal_statuses) break
+  Sys.sleep(3)
+}
+
+if (run$status == "succeeded") {
+  str(run$result)
+} else {
+  stop(run$errorMessage)
+}`,
+  },
+  {
+    language: "python",
+    label: "Python (requests)",
+    code: `import time
+import requests
+
+submit_body = {
+    "modelType": "MAIVE",
+    "data": [
+        {"effect": 0.42, "se": 0.11, "n_obs": 120},
+        {"effect": 0.31, "se": 0.06, "n_obs": 90},
+        {"effect": 0.55, "se": 0.20, "n_obs": 45},
+        {"effect": 0.12, "se": 0.04, "n_obs": 200},
+    ],
+}
+
+submit_resp = requests.post("${BASE_URL}/v1/runs", json=submit_body, timeout=30)
+submit_resp.raise_for_status()
+job_id = submit_resp.json()["jobId"]
+print("jobId:", job_id)
+
+terminal_statuses = {"succeeded", "failed", "timedout"}
+while True:
+    run = requests.get(f"${BASE_URL}/v1/runs/{job_id}", timeout=30).json()
+    print("status:", run["status"])
+    if run["status"] in terminal_statuses:
+        break
+    time.sleep(3)
+
+if run["status"] == "succeeded":
+    print(run["result"])
+else:
+    raise RuntimeError(run.get("errorMessage"))`,
+  },
+];
+
+export const ERROR_ENVELOPE_EXAMPLE = `{
+  "error": {
+    "code": "validation_error",
+    "message": "Data must have 3 or 4 columns; found 6."
+  }
+}`;
+
+export const MINIMAL_REQUEST_EXAMPLE = `{
+  "data": [
+    {"effect": 0.42, "se": 0.11, "n_obs": 120},
+    {"effect": 0.31, "se": 0.06, "n_obs": 90},
+    {"effect": 0.55, "se": 0.20, "n_obs": 45},
+    {"effect": 0.12, "se": 0.04, "n_obs": 200}
+  ]
+}`;
+
+export type ErrorCodeRow = {
+  code: string;
+  status: string;
+  meaning: string;
+};
+
+export const ERROR_CODES: ErrorCodeRow[] = [
+  {
+    code: "validation_error",
+    status: "400",
+    meaning: "The request body failed validation.",
+  },
+  {
+    code: "not_found",
+    status: "404",
+    meaning: "Unknown or expired jobId.",
+  },
+  {
+    code: "method_not_allowed",
+    status: "405",
+    meaning: "The HTTP method is not supported on this route.",
+  },
+  {
+    code: "payload_too_large",
+    status: "413",
+    meaning:
+      "The dataset is too large to queue (roughly 200KB of JSON). Use a synchronous endpoint instead.",
+  },
+  {
+    code: "rate_limited",
+    status: "429",
+    meaning: "Edge rate limit or the backend concurrency cap was hit.",
+  },
+  {
+    code: "internal_error",
+    status: "500",
+    meaning: "An unexpected server-side error occurred.",
+  },
+  {
+    code: "not_configured",
+    status: "503",
+    meaning: "This deployment has no async runs infrastructure configured.",
+  },
+];

--- a/apps/react-ui/client/src/components/ApiDocs/index.ts
+++ b/apps/react-ui/client/src/components/ApiDocs/index.ts
@@ -1,0 +1,3 @@
+export { default as CodeBlock } from "./CodeBlock";
+export { default as CodeExampleTabs } from "./CodeExampleTabs";
+export * from "./apiDocsContent";

--- a/apps/react-ui/client/src/components/Footer.tsx
+++ b/apps/react-ui/client/src/components/Footer.tsx
@@ -16,6 +16,7 @@ import {
   FaFileAlt,
   FaGlobe,
   FaRProject,
+  FaTerminal,
   FaTimes,
 } from "react-icons/fa";
 
@@ -54,6 +55,25 @@ const FooterHrefLinkItem = ({
       href={href}
       target="_blank"
       rel="noopener noreferrer"
+      className="hover:text-blue-600 dark:hover:text-blue-400 transition-colors duration-200 flex items-center"
+    >
+      <FooterLinkItemContents icon={icon} text={text} />
+    </Link>
+  );
+};
+
+const FooterInternalLinkItem = ({
+  icon,
+  href,
+  text,
+}: {
+  icon: React.ReactNode;
+  text: string;
+  href: string;
+}) => {
+  return (
+    <Link
+      href={href}
       className="hover:text-blue-600 dark:hover:text-blue-400 transition-colors duration-200 flex items-center"
     >
       <FooterLinkItemContents icon={icon} text={text} />
@@ -322,6 +342,11 @@ const Footer = ({ className = "" }: FooterProps) => {
             onClick={handleCitationClick}
             icon={<FaFileAlt />}
             text="Cite"
+          />
+          <FooterInternalLinkItem
+            href={CONST.LINKS.PUBLIC_API.DOCS_ROUTE}
+            icon={<FaTerminal />}
+            text="API"
           />
           <FooterHrefLinkItem
             href={CONST.LINKS.APPLICATIONS_URL}

--- a/apps/react-ui/client/src/pages/api-docs.tsx
+++ b/apps/react-ui/client/src/pages/api-docs.tsx
@@ -1,0 +1,408 @@
+import Head from "next/head";
+import Link from "next/link";
+import CONST from "@src/CONST";
+import CitationBox from "@components/CitationBox";
+import SectionHeading from "@components/SectionHeading";
+import { GoBackButton } from "@components/Buttons";
+import {
+  ASYNC_EXAMPLES,
+  CodeBlock,
+  CodeExampleTabs,
+  DATA_FIELDS,
+  ENDPOINTS,
+  ERROR_CODES,
+  ERROR_ENVELOPE_EXAMPLE,
+  MINIMAL_REQUEST_EXAMPLE,
+  MODEL_PARAMETERS,
+  RTMA_PARAMETERS,
+  SYNC_EXAMPLES,
+} from "@components/ApiDocs";
+import type { ParameterRow } from "@components/ApiDocs";
+
+const API = CONST.LINKS.PUBLIC_API;
+
+const TABLE_CELL_CLASSES = "px-3 py-2 align-top text-sm text-secondary";
+const TABLE_HEAD_CELL_CLASSES =
+  "px-3 py-2 text-left text-xs font-semibold uppercase tracking-wide text-muted";
+const CODE_CLASSES =
+  "font-mono text-[0.85em] rounded bg-gray-100 dark:bg-gray-800 px-1.5 py-0.5 text-primary";
+
+const ExternalLink = ({
+  href,
+  children,
+}: {
+  href: string;
+  children: React.ReactNode;
+}) => (
+  <Link
+    href={href}
+    target="_blank"
+    rel="noopener noreferrer"
+    className="text-blue-600 dark:text-blue-400 hover:underline"
+  >
+    {children}
+  </Link>
+);
+
+const ParameterTable = ({
+  caption,
+  rows,
+}: {
+  caption: string;
+  rows: ParameterRow[];
+}) => (
+  <div className="overflow-x-auto rounded-lg border border-gray-200 dark:border-gray-700">
+    <table className="w-full border-collapse">
+      <caption className="sr-only">{caption}</caption>
+      <thead className="bg-gray-50 dark:bg-gray-800/60">
+        <tr>
+          <th scope="col" className={TABLE_HEAD_CELL_CLASSES}>
+            Parameter
+          </th>
+          <th scope="col" className={TABLE_HEAD_CELL_CLASSES}>
+            Values
+          </th>
+          <th scope="col" className={TABLE_HEAD_CELL_CLASSES}>
+            Default
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        {rows.map((row) => (
+          <tr
+            key={row.name}
+            className="border-t border-gray-200 dark:border-gray-700"
+          >
+            <td className={TABLE_CELL_CLASSES}>
+              <code className={CODE_CLASSES}>{row.name}</code>
+            </td>
+            <td className={TABLE_CELL_CLASSES}>{row.values}</td>
+            <td className={TABLE_CELL_CLASSES}>
+              <code className={CODE_CLASSES}>{row.defaultValue}</code>
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  </div>
+);
+
+export default function ApiDocsPage() {
+  return (
+    <>
+      <Head>
+        <title>{`${CONST.APP_DISPLAY_NAME} - Public API`}</title>
+        <meta
+          name="description"
+          content="Run MAIVE, WAIVE, WLS, and RTMA meta-analysis models programmatically over a free, anonymous HTTP API."
+        />
+      </Head>
+      <main className="content-page-container">
+        <div className="max-w-5xl w-full px-2 sm:px-0">
+          <GoBackButton href="/" text="Back to Home" />
+
+          <div className="card p-6 sm:p-8 space-y-10">
+            <header className="space-y-4">
+              <SectionHeading
+                level="h1"
+                text="Public API"
+                description="Run MAIVE, WAIVE, WLS, and RTMA models from your own scripts and pipelines."
+              />
+              <p className="text-secondary text-sm leading-relaxed">
+                The API is free and anonymous: no accounts, no API keys, no
+                sign-up. It is the same compute this web app uses, given a
+                documented JSON contract. Abuse is bounded by server-side
+                concurrency caps and edge rate limits rather than by identity.
+              </p>
+              <div className="space-y-2">
+                <p className="text-sm text-secondary">Base URL</p>
+                <CodeBlock code={API.BASE_URL} label="the base URL" />
+                <p className="text-sm text-secondary">
+                  Content type is{" "}
+                  <code className={CODE_CLASSES}>application/json</code> in both
+                  directions. The machine-readable contract is the{" "}
+                  <ExternalLink href={API.SPEC}>OpenAPI 3 spec</ExternalLink>,
+                  which is the source of truth; the{" "}
+                  <ExternalLink href={API.GUIDE}>usage guide</ExternalLink> has
+                  the same examples in narrative form.
+                </p>
+              </div>
+            </header>
+
+            <section className="space-y-4">
+              <SectionHeading level="h2" text="Endpoints" />
+              <div className="overflow-x-auto rounded-lg border border-gray-200 dark:border-gray-700">
+                <table className="w-full border-collapse">
+                  <caption className="sr-only">Public API endpoints</caption>
+                  <thead className="bg-gray-50 dark:bg-gray-800/60">
+                    <tr>
+                      <th scope="col" className={TABLE_HEAD_CELL_CLASSES}>
+                        Endpoint
+                      </th>
+                      <th scope="col" className={TABLE_HEAD_CELL_CLASSES}>
+                        Kind
+                      </th>
+                      <th scope="col" className={TABLE_HEAD_CELL_CLASSES}>
+                        Description
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {ENDPOINTS.map((endpoint) => (
+                      <tr
+                        key={`${endpoint.method} ${endpoint.path}`}
+                        className="border-t border-gray-200 dark:border-gray-700"
+                      >
+                        <td className={TABLE_CELL_CLASSES}>
+                          <code className={CODE_CLASSES}>
+                            {`${endpoint.method} ${endpoint.path}`}
+                          </code>
+                        </td>
+                        <td className={TABLE_CELL_CLASSES}>{endpoint.kind}</td>
+                        <td className={TABLE_CELL_CLASSES}>
+                          {endpoint.description}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </section>
+
+            <section className="space-y-4">
+              <SectionHeading
+                level="h2"
+                text="Synchronous or asynchronous"
+                description="Async is the recommended default."
+              />
+              <p className="text-secondary text-sm leading-relaxed">
+                Synchronous endpoints return the result in the same response,
+                which is the simplest thing to call, but they are subject to the
+                edge&apos;s roughly 100 second proxy cap. That is comfortable
+                for typical runs (about 15 to 60 seconds including a cold start)
+                and unsuitable for anything larger.
+              </p>
+              <p className="text-secondary text-sm leading-relaxed">
+                The asynchronous path (
+                <code className={CODE_CLASSES}>POST /v1/runs</code> then poll{" "}
+                <code className={CODE_CLASSES}>GET /v1/runs/{"{jobId}"}</code>{" "}
+                every 2 to 5 seconds) holds no long-lived connection, so it has
+                no failure mode tied to run duration. Use it by default,
+                especially for batch or CI usage. Batch status for several runs
+                at once:{" "}
+                <code className={CODE_CLASSES}>GET /v1/runs?ids=a,b,c</code> (up
+                to 100 ids, statuses only).
+              </p>
+            </section>
+
+            <section className="space-y-4">
+              <SectionHeading level="h2" text="Data" />
+              <p className="text-secondary text-sm leading-relaxed">
+                Send <code className={CODE_CLASSES}>data</code> as an array of
+                row objects. Columns are resolved by canonical key name when
+                present (matched case-insensitively); otherwise the first 3 or 4
+                keys are read positionally in the order effect, se, n_obs,
+                study_id.
+              </p>
+              <div className="overflow-x-auto rounded-lg border border-gray-200 dark:border-gray-700">
+                <table className="w-full border-collapse">
+                  <caption className="sr-only">Data row fields</caption>
+                  <thead className="bg-gray-50 dark:bg-gray-800/60">
+                    <tr>
+                      <th scope="col" className={TABLE_HEAD_CELL_CLASSES}>
+                        Field
+                      </th>
+                      <th scope="col" className={TABLE_HEAD_CELL_CLASSES}>
+                        Type
+                      </th>
+                      <th scope="col" className={TABLE_HEAD_CELL_CLASSES}>
+                        Required for
+                      </th>
+                      <th scope="col" className={TABLE_HEAD_CELL_CLASSES}>
+                        Notes
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {DATA_FIELDS.map((row) => (
+                      <tr
+                        key={row.field}
+                        className="border-t border-gray-200 dark:border-gray-700"
+                      >
+                        <td className={TABLE_CELL_CLASSES}>
+                          <code className={CODE_CLASSES}>{row.field}</code>
+                        </td>
+                        <td className={TABLE_CELL_CLASSES}>{row.type}</td>
+                        <td className={TABLE_CELL_CLASSES}>
+                          {row.requiredFor}
+                        </td>
+                        <td className={TABLE_CELL_CLASSES}>{row.notes}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+              <p className="text-secondary text-sm leading-relaxed">
+                The MAIVE family (
+                <code className={CODE_CLASSES}>/v1/run-model</code>) needs 3 or
+                4 columns and at least 4 rows. RTMA (
+                <code className={CODE_CLASSES}>/v1/run-rtma</code>) needs 2
+                columns (<code className={CODE_CLASSES}>effect</code>,{" "}
+                <code className={CODE_CLASSES}>se</code>); rows with a missing
+                or non-positive <code className={CODE_CLASSES}>se</code> are
+                silently dropped. These rules mirror the app&apos;s own
+                validation page and run server-side, so you get a structured{" "}
+                <code className={CODE_CLASSES}>400</code> instead of a raw R
+                error.
+              </p>
+            </section>
+
+            <section className="space-y-4">
+              <SectionHeading
+                level="h2"
+                text="Parameters"
+                description="Every parameter is optional; unset ones fall back to the defaults below."
+              />
+              <p className="text-secondary text-sm leading-relaxed">
+                A minimal valid request is just{" "}
+                <code className={CODE_CLASSES}>{'{"data": [...]}'}</code>:
+              </p>
+              <CodeBlock
+                code={MINIMAL_REQUEST_EXAMPLE}
+                label="the minimal request body"
+              />
+              <h3 className="text-base font-semibold text-primary">
+                MAIVE, WAIVE, and WLS
+              </h3>
+              <ParameterTable
+                caption="MAIVE-family model parameters and defaults"
+                rows={MODEL_PARAMETERS}
+              />
+              <h3 className="text-base font-semibold text-primary">RTMA</h3>
+              <ParameterTable
+                caption="RTMA parameters and defaults"
+                rows={RTMA_PARAMETERS}
+              />
+              <p className="text-secondary text-sm leading-relaxed">
+                Plots (<code className={CODE_CLASSES}>funnelPlot</code>,{" "}
+                <code className={CODE_CLASSES}>zScorePlot</code>, and their
+                width and height companions) are excluded by default: each is a
+                base64 PNG of roughly 50KB that most callers do not need. Add{" "}
+                <code className={CODE_CLASSES}>?include=plot</code> to any run
+                or poll request to embed them.
+              </p>
+            </section>
+
+            <section className="space-y-4">
+              <SectionHeading level="h2" text="Example: synchronous run" />
+              <CodeExampleTabs
+                samples={SYNC_EXAMPLES}
+                label="Synchronous run example"
+              />
+            </section>
+
+            <section className="space-y-4">
+              <SectionHeading
+                level="h2"
+                text="Example: asynchronous run"
+                description="Submit, poll until terminal, then read the result."
+              />
+              <CodeExampleTabs
+                samples={ASYNC_EXAMPLES}
+                label="Asynchronous run example"
+              />
+            </section>
+
+            <section className="space-y-4">
+              <SectionHeading level="h2" text="Errors and rate limits" />
+              <p className="text-secondary text-sm leading-relaxed">
+                Every error shares one envelope:
+              </p>
+              <CodeBlock
+                code={ERROR_ENVELOPE_EXAMPLE}
+                label="the error envelope"
+              />
+              <div className="overflow-x-auto rounded-lg border border-gray-200 dark:border-gray-700">
+                <table className="w-full border-collapse">
+                  <caption className="sr-only">Error codes</caption>
+                  <thead className="bg-gray-50 dark:bg-gray-800/60">
+                    <tr>
+                      <th scope="col" className={TABLE_HEAD_CELL_CLASSES}>
+                        Code
+                      </th>
+                      <th scope="col" className={TABLE_HEAD_CELL_CLASSES}>
+                        Status
+                      </th>
+                      <th scope="col" className={TABLE_HEAD_CELL_CLASSES}>
+                        Meaning
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {ERROR_CODES.map((row) => (
+                      <tr
+                        key={row.code}
+                        className="border-t border-gray-200 dark:border-gray-700"
+                      >
+                        <td className={TABLE_CELL_CLASSES}>
+                          <code className={CODE_CLASSES}>{row.code}</code>
+                        </td>
+                        <td className={TABLE_CELL_CLASSES}>{row.status}</td>
+                        <td className={TABLE_CELL_CLASSES}>{row.meaning}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+              <p className="text-secondary text-sm leading-relaxed">
+                Two guardrails apply: a hard concurrency cap on the compute
+                backend, and per-IP rate limiting at the edge. Both are tuned
+                from observed load, so treat any{" "}
+                <code className={CODE_CLASSES}>429</code> as &quot;retry with
+                backoff&quot; rather than a hard quota.
+              </p>
+            </section>
+
+            <section className="space-y-4">
+              <SectionHeading level="h2" text="jobId and privacy" />
+              <ul className="list-disc pl-5 space-y-2 text-secondary text-sm leading-relaxed">
+                <li>
+                  A <code className={CODE_CLASSES}>jobId</code> is an opaque
+                  bearer token, not an account-scoped identifier. Anyone holding
+                  it can read that run&apos;s status and result, so treat it
+                  like a share link.
+                </li>
+                <li>
+                  Runs and their results expire after 48 hours; polling after
+                  that returns{" "}
+                  <code className={CODE_CLASSES}>404 not_found</code>.
+                </li>
+                <li>
+                  Synchronous runs are stateless. Asynchronous runs persist the
+                  parameters and the result for up to 48 hours; the input
+                  dataset itself is not persisted beyond the transient queue
+                  message.
+                </li>
+                <li>
+                  Do not submit confidential or personally identifiable data.
+                  There is no data-classification or redaction layer; treat
+                  every request the way you would treat a request to any other
+                  unauthenticated public web service.
+                </li>
+              </ul>
+            </section>
+
+            <section className="space-y-4">
+              <SectionHeading level="h2" text="Citation" />
+              <p className="text-secondary text-sm leading-relaxed">
+                If you use MAIVE in published or reported work, please cite the
+                paper:
+              </p>
+              <CitationBox variant="full" useBlueStyling />
+            </section>
+          </div>
+        </div>
+      </main>
+    </>
+  );
+}

--- a/apps/react-ui/client/src/tests/ApiDocsPage.test.tsx
+++ b/apps/react-ui/client/src/tests/ApiDocsPage.test.tsx
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent, within } from "@testing-library/react";
+import ApiDocsPage from "@src/pages/api-docs";
+import Footer from "@components/Footer";
+import CONST from "@src/CONST";
+
+// GoBackButton uses the Pages-Router useRouter (next/router), which the global
+// setup (next/navigation only) does not cover.
+vi.mock("next/router", () => ({
+  useRouter: () => ({ push: vi.fn() }),
+}));
+
+describe("ApiDocsPage", () => {
+  it("documents the base URL and every endpoint", () => {
+    render(<ApiDocsPage />);
+
+    expect(
+      screen.getAllByText(CONST.LINKS.PUBLIC_API.BASE_URL).length,
+    ).toBeGreaterThan(0);
+
+    const table = within(
+      screen.getByRole("table", { name: "Public API endpoints" }),
+    );
+    const endpoints = [
+      "POST /v1/run-model",
+      "POST /v1/run-rtma",
+      "POST /v1/runs",
+      "GET /v1/runs/{jobId}",
+      "GET /v1/health",
+    ];
+    endpoints.forEach((endpoint) => {
+      expect(table.getByText(endpoint)).toBeInTheDocument();
+    });
+  });
+
+  it("states that the API is anonymous and steers callers to async", () => {
+    render(<ApiDocsPage />);
+
+    expect(
+      screen.getByText(/free and anonymous: no accounts, no API keys/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: "Synchronous or asynchronous" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/Async is the recommended default/i),
+    ).toBeInTheDocument();
+  });
+
+  it("links out to the OpenAPI spec as the source of truth", () => {
+    render(<ApiDocsPage />);
+
+    expect(
+      screen.getByRole("link", { name: /OpenAPI 3 spec/i }),
+    ).toHaveAttribute("href", CONST.LINKS.PUBLIC_API.SPEC);
+  });
+
+  it("surfaces the Nature Communications citation", () => {
+    render(<ApiDocsPage />);
+
+    expect(
+      screen.getByText(
+        /Irsova, Z., Bom, P\.R\.D\., Havranek, T\., & Rachinger, H\. \(2025\)/,
+      ),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /paper/i })).toHaveAttribute(
+      "href",
+      CONST.LINKS.MAIVE.PAPER,
+    );
+  });
+
+  it("switches the example language when a tab is selected", () => {
+    render(<ApiDocsPage />);
+
+    const tablist = screen.getByRole("tablist", {
+      name: "Synchronous run example",
+    });
+    const pythonTab = within(tablist).getByRole("tab", {
+      name: "Python (requests)",
+    });
+    expect(pythonTab).toHaveAttribute("aria-selected", "false");
+
+    fireEvent.click(pythonTab);
+
+    expect(pythonTab).toHaveAttribute("aria-selected", "true");
+    expect(
+      screen.getByRole("button", {
+        name: /Copy Synchronous run example, Python \(requests\)/i,
+      }),
+    ).toBeInTheDocument();
+  });
+});
+
+describe("Footer", () => {
+  it("links to the API docs page", () => {
+    render(<Footer />);
+
+    expect(screen.getByRole("link", { name: "API" })).toHaveAttribute(
+      "href",
+      CONST.LINKS.PUBLIC_API.DOCS_ROUTE,
+    );
+  });
+});

--- a/docs/PUBLIC_API_DESIGN.md
+++ b/docs/PUBLIC_API_DESIGN.md
@@ -1,6 +1,6 @@
 # Public Model API: Design & Implementation Plan
 
-**Status:** Phases 1-2 implemented and live at `https://api.maive.eu`; Phase 3 (UI docs page, announcement) pending
+**Status:** Phases 1-2 implemented and live at `https://api.maive.eu`; Phase 3 UI docs page shipped, announcement pending
 **Date:** 2026-07-08
 **Related:** [ASYNC_RUNS_DESIGN.md](ASYNC_RUNS_DESIGN.md) (async runs infra this design reuses);
 [SERVER_SIDE_API_ARCHITECTURE.md](SERVER_SIDE_API_ARCHITECTURE.md) (current serving topology)
@@ -370,10 +370,13 @@ Two things differed from the plan as written:
 
 **Phase 3, publication:**
 
-- [ ] Docs page in the UI (e.g. `/api`) rendering the OpenAPI spec + examples;
-      link from the footer next to the reproducibility material.
-- [ ] Citation requirement surfaced in the docs (Nature Communications 2025,
-      per repo policy).
+- [x] Docs page in the UI (`/api-docs`, kept clear of the Next.js `/api`
+      route namespace): endpoint/data/parameter tables plus curl/R/Python
+      examples, hand-written against `docs/PUBLIC_API.md` with a link out to
+      the OpenAPI spec on GitHub as the source of truth; linked from the
+      footer next to the citation/code material.
+- [x] Citation requirement surfaced in the docs (Nature Communications 2025,
+      per repo policy), via the shared `CitationBox`.
 - [ ] Announce; monitor throttles/alarms; tune rate limits and the
       concurrency cap from observed load.
 


### PR DESCRIPTION
Phase 3 (publication) of the public MAIVE API: a user-facing docs page plus a footer link. No backend, `/v1`, orchestrator, or infra changes.

## What's here

- **`/api-docs` page** (`src/pages/api-docs.tsx`). Route kept clear of `src/pages/api/`, which is the Next.js API-routes namespace. Covers what the API is and that it's free/anonymous, the base URL, the five endpoints, the data contract, the parameter tables with defaults, sync-vs-async guidance (async recommended; sync is subject to the ~100s edge cap), copy-paste curl/R/Python examples for both a sync run and a full async submit/poll/result cycle, the `?include=plot` opt-in, the error envelope and codes, `jobId` bearer-token semantics with the 48h TTL, the privacy note, and rate-limit expectations.
- **Footer link** ("API"), next to the existing Cite/Code items.
- **Citation** via the shared `CitationBox`, per repo policy.
- **Tests** (`src/tests/ApiDocsPage.test.tsx`): endpoint list, base URL, anonymous framing, spec link, citation, example tab switching, and the footer route.

## Rendering approach

Hand-written React mirroring `docs/PUBLIC_API.md`, with a prominent link out to `docs/api/openapi.yaml` on GitHub named as the source of truth. No new dependencies: there's no yaml parser or MDX pipeline in the client, `docs/` lives outside the Next.js app dir and can't be read at runtime on Lambda's read-only filesystem, and Swagger UI / Redoc would be a lot of weight for five endpoints. Content was cross-checked against the OpenAPI spec, which won on wording where the two differed.

All URLs live in `CONST.LINKS.PUBLIC_API`. Styling uses the shared system (`.card`, `formStyles` toggles); verified in light and dark mode at desktop width.

## Gates

- `npm run ui:test`: 123 passed (18 files)
- `npm run ui:lint`: clean
- `npx tsc --noEmit`: only the pre-existing unrelated `import.meta.vitest` error in `src/tests/integration/results.test.tsx`

Also ticks the Phase 3 checkboxes in `docs/PUBLIC_API_DESIGN.md` §9 and updates its Status line. The "announce" item is left for the maintainer, and no release/`v-*` labels are set.
