### PR TITLE
feat: cost circuit breaker, budget alerts, concurrency and row caps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,8 +85,9 @@ node_modules/
 **/backend.tf
 **/versions.tf
 
-# Orchestrator zip built by Terraform's archive_file (built in CI)
+# Lambda zips built by Terraform's archive_file
 terraform/stacks/prod-runtime/orchestrator.zip
+terraform/stacks/prod-runtime/kill_switch.zip
 **/*.tfstate
 **/*.tfstate.*
 **/*.out

--- a/apps/kill-switch/index.mjs
+++ b/apps/kill-switch/index.mjs
@@ -1,0 +1,47 @@
+// Cost circuit breaker.
+//
+// When the R backend has been throttling continuously (its reserved-concurrency
+// cap saturated by abnormal load), a CloudWatch alarm publishes to SNS, which
+// invokes this handler. It sets the reserved concurrency of each protected
+// function to 0, which makes every further invocation throttle (HTTP 429) and
+// halts compute spend.
+//
+// Recovery is deliberate, never automatic: once the load has been dealt with
+// (for example blocked at the edge), an operator restores the cap with
+// `terraform apply` (which resets reserved concurrency to the configured
+// value) or from the Lambda console. See docs/COST_CONTROLS.md.
+//
+// No bundling: @aws-sdk/client-lambda ships in the nodejs20.x runtime.
+
+import {
+  LambdaClient,
+  PutFunctionConcurrencyCommand,
+} from "@aws-sdk/client-lambda";
+
+const client = new LambdaClient({});
+
+export const handler = async () => {
+  const targets = (process.env.PROTECTED_FUNCTIONS || "")
+    .split(",")
+    .map((name) => name.trim())
+    .filter(Boolean);
+
+  const stopped = [];
+  for (const functionName of targets) {
+    // Sequential on purpose: at most a couple of functions, and a failure on
+    // one should not prevent the attempt on the next.
+    // eslint-disable-next-line no-await-in-loop
+    await client.send(
+      new PutFunctionConcurrencyCommand({
+        FunctionName: functionName,
+        ReservedConcurrentExecutions: 0,
+      }),
+    );
+    console.log(
+      `Circuit breaker tripped: set reserved concurrency to 0 for ${functionName}`,
+    );
+    stopped.push(functionName);
+  }
+
+  return { stopped };
+};

--- a/apps/lambda-r-backend/r_scripts/api_v1.R
+++ b/apps/lambda-r-backend/r_scripts/api_v1.R
@@ -24,6 +24,14 @@ API_V1_SE_TREATMENTS <- c(
 API_V1_MAIVE_CANONICAL <- c("effect", "se", "n_obs")
 API_V1_RTMA_CANONICAL <- c("effect", "se")
 
+# Upper bound on dataset rows accepted by any HTTP route. A cost/abuse control
+# (docs/COST_CONTROLS.md), not a statistical limit: it caps the per-request work
+# an anonymous caller can trigger through the public Function URL, independent of
+# the reserved-concurrency cap and the Lambda timeout. Set far above any
+# realistic meta-analysis so it never blocks genuine use. Keep in sync with
+# MAX_INPUT_ROWS in index.R and MAX_ROWS in the UI's datasetValidation.ts.
+MAX_INPUT_ROWS <- 50000L
+
 API_V1_MAIVE_PLOT_FIELDS <- c("funnelPlot", "funnelPlotWidth", "funnelPlotHeight")
 API_V1_RTMA_PLOT_FIELDS <- c("zScorePlot", "zScorePlotWidth", "zScorePlotHeight")
 
@@ -145,7 +153,18 @@ api_v1_data_columns <- function(data) {
     if (nrow(data) == 0 || ncol(data) == 0) {
       api_v1_abort_validation("The `data` array must contain at least one row.")
     }
+    if (nrow(data) > MAX_INPUT_ROWS) {
+      api_v1_abort_validation(
+        sprintf("Data must contain at most %d rows; found %d.", MAX_INPUT_ROWS, nrow(data))
+      )
+    }
     return(as.list(data))
+  }
+
+  if (is.list(data) && length(data) > MAX_INPUT_ROWS) {
+    api_v1_abort_validation(
+      sprintf("Data must contain at most %d rows; found %d.", MAX_INPUT_ROWS, length(data))
+    )
   }
 
   if (!is.list(data) || length(data) == 0 || !is.null(names(data))) {

--- a/apps/lambda-r-backend/r_scripts/index.R
+++ b/apps/lambda-r-backend/r_scripts/index.R
@@ -3,6 +3,33 @@
 # Load required libraries
 library(plumber) # nolint: undesirable_function_linter.
 
+# Upper bound on dataset rows accepted by the legacy routes. A cost/abuse
+# control (docs/COST_CONTROLS.md), not a statistical limit: the legacy routes
+# are reachable anonymously on the raw Function URL, bypassing the edge, so the
+# guard lives at the compute boundary. Keep in sync with MAX_INPUT_ROWS in
+# api_v1.R and MAX_ROWS in the UI's datasetValidation.ts.
+MAX_INPUT_ROWS <- 50000L
+
+# Abort a legacy request whose dataset exceeds MAX_INPUT_ROWS. `data` is the raw
+# JSON string the route received; parsing failures fall through to the model
+# function, which reports them in its own error envelope.
+enforce_max_input_rows <- function(data) {
+  n_rows <- tryCatch(
+    {
+      parsed <- jsonlite::fromJSON(data, simplifyVector = TRUE)
+      if (is.data.frame(parsed)) nrow(parsed) else length(parsed)
+    },
+    error = function(e) 0L
+  )
+  if (isTRUE(n_rows > MAX_INPUT_ROWS)) {
+    cli::cli_abort(
+      "Data must contain at most {MAX_INPUT_ROWS} rows; found {n_rows}.",
+      call = NULL
+    )
+  }
+  invisible(n_rows)
+}
+
 #* Echo back the input
 #* @usage curl --data "a=4&b=3" "http://localhost:8787/sum"
 #* @param msg The message to echo
@@ -38,6 +65,8 @@ function(data, parameters) {
         cli::cli_abort("Missing data or parameters")
       }
 
+      enforce_max_input_rows(data)
+
       results <- run_maive_model(data, parameters)
       list(data = results)
     },
@@ -68,6 +97,8 @@ function(data, parameters) {
       if (is.null(data) || is.null(parameters)) {
         cli::cli_abort("Missing data or parameters")
       }
+
+      enforce_max_input_rows(data)
 
       results <- run_rtma_model(data, parameters)
       list(data = results)

--- a/apps/react-ui/client/src/api/server/datasetValidation.ts
+++ b/apps/react-ui/client/src/api/server/datasetValidation.ts
@@ -8,6 +8,14 @@ import CONST from "@src/CONST";
 
 export const MIN_MAIVE_ROWS = 4;
 
+// Upper bound on dataset rows accepted by the public API. A cost/abuse control,
+// not a statistical limit: it caps the per-request work an anonymous caller can
+// trigger, independent of the R Lambda's concurrency cap and timeout. Set far
+// above any realistic meta-analysis (largest known are a few thousand
+// estimates), so it never blocks genuine use. Keep in sync with MAX_INPUT_ROWS
+// in the R backend (api_v1.R / index.R).
+export const MAX_ROWS = 50000;
+
 export type ResolvedColumns = {
   effect: string;
   se: string;
@@ -86,6 +94,12 @@ export const validateDataset = (
 ): ValidationError | null => {
   if (!Array.isArray(data) || data.length === 0) {
     return { message: "`data` must be a non-empty array of row objects." };
+  }
+
+  if (data.length > MAX_ROWS) {
+    return {
+      message: `Data must contain at most ${MAX_ROWS} rows; found ${data.length}.`,
+    };
   }
 
   const hasInvalidRow = data.some(

--- a/apps/react-ui/client/src/tests/datasetValidation.test.ts
+++ b/apps/react-ui/client/src/tests/datasetValidation.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from "vitest";
-import { resolveColumns, validateDataset } from "@api/server/datasetValidation";
+import {
+  MAX_ROWS,
+  resolveColumns,
+  validateDataset,
+} from "@api/server/datasetValidation";
 
 const maiveRow = (
   effect: number,
@@ -86,6 +90,20 @@ describe("validateDataset: MAIVE-family", () => {
   it("rejects fewer than 4 rows", () => {
     const data = [maiveRow(0.4, 0.1, 100), maiveRow(0.3, 0.1, 90)];
     expect(validateDataset(data, "MAIVE")?.message).toMatch(/at least 4 rows/);
+  });
+
+  it("rejects more than MAX_ROWS rows", () => {
+    const data = Array.from({ length: MAX_ROWS + 1 }, () =>
+      maiveRow(0.4, 0.1, 100),
+    );
+    expect(validateDataset(data, "MAIVE")?.message).toMatch(/at most .* rows/);
+  });
+
+  it("accepts exactly MAX_ROWS rows", () => {
+    const data = Array.from({ length: MAX_ROWS }, () =>
+      maiveRow(0.4, 0.1, 100),
+    );
+    expect(validateDataset(data, "MAIVE")).toBeNull();
   });
 
   it("rejects a 2-column dataset (missing n_obs)", () => {

--- a/docs/COST_CONTROLS.md
+++ b/docs/COST_CONTROLS.md
@@ -26,7 +26,7 @@ that adds up to.
 | Max dataset rows = 50,000 | R `api_v1.R` / `index.R` (`MAX_INPUT_ROWS`), UI `datasetValidation.ts` (`MAX_ROWS`) | Per-request work; caps payload-driven CPU/output amplification on every HTTP route including the raw legacy path. |
 | **Cost circuit breaker** | `prod-runtime/circuit_breaker.tf` | The **monthly total**. Auto-throttles the R backend to 0 on sustained abuse. |
 | Budget notifications ($10, 50/80/forecast) | `prod-foundation/budget.tf` | Human awareness; email backstop. |
-| Cost Anomaly Detection | `prod-foundation/cost_anomaly.tf` | Human awareness; faster/smarter than a fixed threshold. |
+| Cost Anomaly Detection | `prod-foundation/cost_anomaly.tf` | Human awareness; catches deviation from baseline rather than a fixed threshold. Daily digest, on ~24h-lagged billing data. |
 | Alarm notifications (errors/throttles/duration/DLQ) | `prod-runtime/monitoring.tf` + the alarms | Human awareness; previously these alarms notified no one. |
 
 Reserved concurrency bounds the *rate* of spend but not the *total*: 10 slots

--- a/docs/COST_CONTROLS.md
+++ b/docs/COST_CONTROLS.md
@@ -1,0 +1,94 @@
+# Cost controls & denial-of-wallet protection
+
+MAIVE runs on a fully serverless, anonymous, publicly reachable stack (two
+Lambda Function URLs with `authorization_type = "NONE"`). Expected spend at the
+site's real traffic is a few cents a month. This document describes the controls
+that bound worst-case spend when someone deliberately tries to run up the bill.
+
+See also `PUBLIC_API_DESIGN.md` §7 (the original abuse/cost analysis) and
+`SERVER_SIDE_API_ARCHITECTURE.md` (topology).
+
+## Threat: denial of wallet
+
+The R backend is reachable directly at its raw `*.on.aws` Function URL (the
+browser is handed that URL via `/api/runtime-config`), so Cloudflare's edge rate
+limit is a speed bump, not a wall: an attacker can hit Lambda directly. One
+request can occupy a 2 GB Lambda for up to 600 s. The controls below bound what
+that adds up to.
+
+## The layers
+
+| Layer | Where | What it bounds |
+|---|---|---|
+| Reserved concurrency = 10 (R backend) | `prod-runtime/variables.tf` (`lambda_r_backend_reserved_concurrency`) | Concurrent R executions, regardless of entry path. Excess gets `429`. Bounds the *rate* of spend (~$0.12/hr per slot). |
+| Reserved concurrency = 30 (UI) | `prod-runtime/variables.tf` (`ui_lambda_reserved_concurrency`) | UI Lambda spend and its share of the account concurrency pool. |
+| Async fan-out = 5 | `prod-runtime/orchestrator_lambda.tf` (`maximum_concurrency`) | Concurrent async runs; kept below the R cap so async never starves sync. |
+| Max dataset rows = 50,000 | R `api_v1.R` / `index.R` (`MAX_INPUT_ROWS`), UI `datasetValidation.ts` (`MAX_ROWS`) | Per-request work; caps payload-driven CPU/output amplification on every HTTP route including the raw legacy path. |
+| **Cost circuit breaker** | `prod-runtime/circuit_breaker.tf` | The **monthly total**. Auto-throttles the R backend to 0 on sustained abuse. |
+| Budget notifications ($10, 50/80/forecast) | `prod-foundation/budget.tf` | Human awareness; email backstop. |
+| Cost Anomaly Detection | `prod-foundation/cost_anomaly.tf` | Human awareness; faster/smarter than a fixed threshold. |
+| Alarm notifications (errors/throttles/duration/DLQ) | `prod-runtime/monitoring.tf` + the alarms | Human awareness; previously these alarms notified no one. |
+
+Reserved concurrency bounds the *rate* of spend but not the *total*: 10 slots
+pinned at 2 GB around the clock is still ~$860/month. The circuit breaker is what
+turns the rate limit into an enforced ceiling.
+
+## The cost circuit breaker
+
+The free equivalent of AWS Budgets Actions (a paid feature). Wiring:
+
+```
+R backend throttling (sustained) → CloudWatch alarm → SNS → kill-switch Lambda
+                                                              → PutFunctionConcurrency(R backend, 0)
+```
+
+- **Trigger:** the `-saturation` alarm fires when the R backend throttles
+  continuously for `cost_circuit_breaker_throttle_periods` 5-minute periods
+  (default 6 ≈ 30 min). Throttling only happens when demand exceeds the
+  reserved-concurrency cap, so sustained throttling is a strong abuse signal with
+  a near-zero false-positive rate for a low-traffic site.
+- **Action:** the kill-switch Lambda (`apps/kill-switch/index.mjs`) sets the R
+  backend's reserved concurrency to 0. Every further invocation then throttles
+  (`429`) and compute spend stops. The worst-case bleed before it trips is ~30
+  min × 10 slots ≈ well under $1 per episode.
+- **Notification:** the same alarm emails `var.email` (via the circuit-breaker
+  SNS topic), so an operator knows the service was shut off.
+- **Toggle:** `cost_circuit_breaker_enabled` (default `true`). When `false`, the
+  condition still emails but no automatic shutoff happens.
+
+### Recovery (deliberate, never automatic)
+
+When the breaker trips, analysis is down (the site's pages still load; runs
+return `429`). Recovery is a conscious operator action, after confirming the
+abusive traffic has stopped (e.g. blocked at Cloudflare):
+
+1. Confirm the source of load has stopped.
+2. Restore the cap, either:
+   - `cd terraform/stacks/prod-runtime && terragrunt apply` (resets reserved
+     concurrency to `lambda_r_backend_reserved_concurrency`), or
+   - Lambda console → `maive-lambda-r-backend` → Configuration → Concurrency →
+     set reserved concurrency back to 10.
+
+Note: because the Lambda sets concurrency out of band, Terraform state shows
+drift (it wants 10, actual is 0) until the next apply reconciles it. That is
+expected.
+
+## What this does and does not guarantee
+
+- **Does:** stop runaway compute automatically and bound each abuse episode to
+  well under a dollar. Keep expected spend in the cents.
+- **Does not:** give a hard, instant monthly cap. AWS has no native "stop at
+  $X." All spend-based signals (budgets, anomaly detection) lag AWS billing data
+  by up to a day, which is why the primary automatic control keys off the
+  in-region throttle metric (minutes, not a day) instead. A determined attacker
+  could still incur a small, bounded cost per episode before the breaker trips
+  and before an operator restores service.
+
+## Tuning
+
+- Raise `lambda_r_backend_reserved_concurrency` (and `maximum_concurrency`
+  together) if legitimate traffic grows and the throttle alarm fires on real
+  load. Each unit is ~$0.12/hr (~$86/month) of worst-case exposure.
+- Raise `ui_lambda_reserved_concurrency` if the UI throttles under real traffic.
+- Adjust `cost_circuit_breaker_throttle_periods` to trade sensitivity against
+  false positives.

--- a/terraform/stacks/prod-foundation/budget.tf
+++ b/terraform/stacks/prod-foundation/budget.tf
@@ -1,7 +1,14 @@
+# Monthly cost guardrail for the account. Email-only notifications: these are
+# free budget notifications, not the paid AWS Budgets Actions feature. The
+# automatic shutoff is the cost circuit breaker in the runtime stack
+# (terraform/stacks/prod-runtime/circuit_breaker.tf). Thresholds are low to
+# match the intended ~$5-10/month envelope for this low-traffic service; the
+# forecast notification fires earlier than actual spend when a trend points
+# over the ceiling. See docs/COST_CONTROLS.md.
 resource "aws_budgets_budget" "monthly_limit" {
   name         = "monthly-${var.project}-budget"
   budget_type  = "COST"
-  limit_amount = "100"
+  limit_amount = "10"
   limit_unit   = "USD"
   time_unit    = "MONTHLY"
 
@@ -10,10 +17,29 @@ resource "aws_budgets_budget" "monthly_limit" {
     values = [data.aws_caller_identity.current.account_id]
   }
 
+  # Actual spend crossed half the monthly ceiling ($5).
   notification {
     comparison_operator        = "GREATER_THAN"
     notification_type          = "ACTUAL"
-    threshold                  = 10
+    threshold                  = 50
+    threshold_type             = "PERCENTAGE"
+    subscriber_email_addresses = [var.email]
+  }
+
+  # Actual spend crossed 80% of the monthly ceiling ($8).
+  notification {
+    comparison_operator        = "GREATER_THAN"
+    notification_type          = "ACTUAL"
+    threshold                  = 80
+    threshold_type             = "PERCENTAGE"
+    subscriber_email_addresses = [var.email]
+  }
+
+  # Projected to exceed the ceiling by month end; fires before actual does.
+  notification {
+    comparison_operator        = "GREATER_THAN"
+    notification_type          = "FORECASTED"
+    threshold                  = 100
     threshold_type             = "PERCENTAGE"
     subscriber_email_addresses = [var.email]
   }
@@ -21,8 +47,4 @@ resource "aws_budgets_budget" "monthly_limit" {
   tags = {
     Project = var.project
   }
-}
-
-resource "aws_sns_topic" "budget_alarm" {
-  name = "${var.project}-budget-alarm-topic"
 }

--- a/terraform/stacks/prod-foundation/cost_anomaly.tf
+++ b/terraform/stacks/prod-foundation/cost_anomaly.tf
@@ -1,0 +1,33 @@
+# AWS Cost Anomaly Detection (free). Against this account's near-zero baseline,
+# any few-dollar spike reads as an anomaly, so this catches abuse or misconfig
+# faster and more intelligently than a fixed budget threshold and emails
+# var.email. Complements the budget notifications and the runtime circuit
+# breaker. Must be created in us-east-1 (Cost Explorer's global endpoint); see
+# providers.tf. docs/COST_CONTROLS.md.
+resource "aws_ce_anomaly_monitor" "services" {
+  provider          = aws.us_east_1
+  name              = "${var.project}-service-monitor"
+  monitor_type      = "DIMENSIONAL"
+  monitor_dimension = "SERVICE"
+}
+
+resource "aws_ce_anomaly_subscription" "alerts" {
+  provider         = aws.us_east_1
+  name             = "${var.project}-anomaly-alerts"
+  frequency        = "IMMEDIATE"
+  monitor_arn_list = [aws_ce_anomaly_monitor.services.arn]
+
+  subscriber {
+    type    = "EMAIL"
+    address = var.email
+  }
+
+  # Alert as soon as a detected anomaly's total cost impact reaches $5.
+  threshold_expression {
+    dimension {
+      key           = "ANOMALY_TOTAL_IMPACT_ABSOLUTE"
+      match_options = ["GREATER_THAN_OR_EQUAL"]
+      values        = ["5"]
+    }
+  }
+}

--- a/terraform/stacks/prod-foundation/cost_anomaly.tf
+++ b/terraform/stacks/prod-foundation/cost_anomaly.tf
@@ -1,20 +1,41 @@
-# AWS Cost Anomaly Detection (free). Against this account's near-zero baseline,
-# any few-dollar spike reads as an anomaly, so this catches abuse or misconfig
-# faster and more intelligently than a fixed budget threshold and emails
-# var.email. Complements the budget notifications and the runtime circuit
-# breaker. Must be created in us-east-1 (Cost Explorer's global endpoint); see
-# providers.tf. docs/COST_CONTROLS.md.
+# AWS Cost Anomaly Detection (free). Against this account's near-zero baseline
+# (~$0.24/month), any few-dollar spike reads as an anomaly, so this catches
+# abuse or misconfig and emails var.email. Complements the budget notifications
+# and the runtime circuit breaker. docs/COST_CONTROLS.md.
+#
+# Must be created in us-east-1 (Cost Explorer's global endpoint); see
+# providers.tf.
+#
+# The monitor is ADOPTED, not created: AWS enables Cost Anomaly Detection by
+# default and allows only ONE dimensional (SERVICE) monitor per account, so
+# creating a second one fails with "Limit exceeded on dimensional spend monitor
+# creation". This resource was therefore imported from the account's existing
+# `Default-Services-Monitor`, and its name is kept as-is to avoid renaming an
+# account-level default. On a fresh account, import AWS's default rather than
+# letting Terraform create one:
+#
+#   terragrunt import aws_ce_anomaly_monitor.services <monitor-arn>
+#
+# Note this means `cloud:destroy` would remove the account's default monitor.
 resource "aws_ce_anomaly_monitor" "services" {
   provider          = aws.us_east_1
-  name              = "${var.project}-service-monitor"
+  name              = "Default-Services-Monitor"
   monitor_type      = "DIMENSIONAL"
   monitor_dimension = "SERVICE"
 }
 
+# A monitor can carry several subscriptions. AWS's own default subscription only
+# fires at >= $100 AND >= 40%, which would never catch a problem at this
+# project's scale, so this adds a much tighter one alongside it.
+#
+# DAILY rather than IMMEDIATE: the API rejects IMMEDIATE for anything but an SNS
+# topic subscriber ("Immediate frequencies only support SNSTopic subscriptions").
+# Anomaly detection runs on billing data that lags ~24h anyway, so a daily digest
+# loses nothing; the fast abuse signal is the runtime throttle alarm, not this.
 resource "aws_ce_anomaly_subscription" "alerts" {
   provider         = aws.us_east_1
   name             = "${var.project}-anomaly-alerts"
-  frequency        = "IMMEDIATE"
+  frequency        = "DAILY"
   monitor_arn_list = [aws_ce_anomaly_monitor.services.arn]
 
   subscriber {

--- a/terraform/stacks/prod-foundation/providers.tf
+++ b/terraform/stacks/prod-foundation/providers.tf
@@ -1,0 +1,8 @@
+# Cost Explorer, including its Cost Anomaly Detection resources, is a global
+# service reachable only through us-east-1. Terragrunt generates the default
+# provider (region = var.region) in provider.tf; this adds an aliased us-east-1
+# provider used by the anomaly-detection resources in cost_anomaly.tf.
+provider "aws" {
+  alias  = "us_east_1"
+  region = "us-east-1"
+}

--- a/terraform/stacks/prod-runtime/circuit_breaker.tf
+++ b/terraform/stacks/prod-runtime/circuit_breaker.tf
@@ -1,0 +1,158 @@
+# Cost circuit breaker (docs/COST_CONTROLS.md).
+#
+# The reserved-concurrency cap on the R backend bounds the *rate* of spend but
+# not the monthly total: 10 concurrent 2 GB executions pinned around the clock
+# is still ~$860/month. This is the free automatic backstop that enforces a
+# ceiling. When the backend throttles continuously for
+# var.cost_circuit_breaker_throttle_periods 5-minute periods (demand exceeding
+# the cap for ~30 minutes straight, a strong abuse signal with near-zero
+# false-positive rate for a low-traffic site), a CloudWatch alarm publishes to
+# SNS, which invokes a Lambda that sets the backend's reserved concurrency to 0.
+# All further compute then throttles (429) until an operator restores the cap.
+#
+# This is the free equivalent of AWS Budgets Actions (which is a paid feature):
+# CloudWatch alarm -> SNS -> Lambda, entirely within AWS free tiers.
+
+locals {
+  circuit_breaker_count = var.cost_circuit_breaker_enabled ? 1 : 0
+}
+
+# Topic the saturation alarm publishes to. Always created so the alarm has a
+# valid target and an operator is emailed when the breaker condition is met;
+# the auto-shutoff Lambda subscribes only when the breaker is enabled.
+resource "aws_sns_topic" "cost_circuit_breaker" {
+  name = "${var.project}-cost-circuit-breaker"
+  tags = { Project = var.project }
+}
+
+resource "aws_sns_topic_subscription" "cost_circuit_breaker_email" {
+  topic_arn = aws_sns_topic.cost_circuit_breaker.arn
+  protocol  = "email"
+  endpoint  = var.email
+}
+
+# Sustained throttling of the R backend. Distinct from the single-period
+# throttle alarm in lambda.tf (a fast FYI): this one requires continuous
+# throttling across the full window before it acts, so it is the deliberate
+# auto-shutoff trigger rather than a notification.
+resource "aws_cloudwatch_metric_alarm" "lambda_r_backend_saturation" {
+  alarm_name          = "${local.lambda_r_backend_function_name}-saturation"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = var.cost_circuit_breaker_throttle_periods
+  datapoints_to_alarm = var.cost_circuit_breaker_throttle_periods
+  metric_name         = "Throttles"
+  namespace           = "AWS/Lambda"
+  period              = "300"
+  statistic           = "Sum"
+  threshold           = "0"
+  treat_missing_data  = "notBreaching"
+  alarm_description   = "R backend throttling continuously; cost circuit breaker trips."
+  alarm_actions       = [aws_sns_topic.cost_circuit_breaker.arn]
+  # No ok_actions: after a trip the backend sits at 0 concurrency, so a quiet
+  # spell returns the alarm to OK while the service is still deliberately off.
+  # Recovery is an explicit operator action, not an automated "recovered" email.
+
+  dimensions = {
+    FunctionName = aws_lambda_function.r_backend.function_name
+  }
+}
+
+# --- Auto-shutoff Lambda (only when the breaker is enabled) ------------------
+
+data "archive_file" "kill_switch" {
+  count       = local.circuit_breaker_count
+  type        = "zip"
+  source_dir  = "${path.module}/../../../apps/kill-switch"
+  output_path = "${path.module}/kill_switch.zip"
+}
+
+resource "aws_iam_role" "kill_switch" {
+  count = local.circuit_breaker_count
+  name  = "${var.project}-cost-circuit-breaker-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action    = "sts:AssumeRole"
+        Effect    = "Allow"
+        Principal = { Service = "lambda.amazonaws.com" }
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "kill_switch_basic" {
+  count      = local.circuit_breaker_count
+  role       = aws_iam_role.kill_switch[0].name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+}
+
+# The kill switch only needs to throttle the R backend to 0. Scoped to that one
+# function ARN.
+resource "aws_iam_policy" "kill_switch" {
+  count       = local.circuit_breaker_count
+  name        = "${var.project}-cost-circuit-breaker-policy"
+  description = "Allow the cost circuit breaker to set reserved concurrency on the R backend"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect   = "Allow"
+        Action   = ["lambda:PutFunctionConcurrency"]
+        Resource = aws_lambda_function.r_backend.arn
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "kill_switch" {
+  count      = local.circuit_breaker_count
+  role       = aws_iam_role.kill_switch[0].name
+  policy_arn = aws_iam_policy.kill_switch[0].arn
+}
+
+resource "aws_cloudwatch_log_group" "kill_switch" {
+  count             = local.circuit_breaker_count
+  name              = "/aws/lambda/${var.project}-cost-circuit-breaker"
+  retention_in_days = var.ui_lambda_log_retention_days
+  tags              = { Project = var.project }
+}
+
+resource "aws_lambda_function" "kill_switch" {
+  count            = local.circuit_breaker_count
+  function_name    = "${var.project}-cost-circuit-breaker"
+  role             = aws_iam_role.kill_switch[0].arn
+  runtime          = "nodejs20.x"
+  handler          = "index.handler"
+  timeout          = 30
+  memory_size      = 128
+  filename         = data.archive_file.kill_switch[0].output_path
+  source_code_hash = data.archive_file.kill_switch[0].output_base64sha256
+
+  environment {
+    variables = {
+      PROTECTED_FUNCTIONS = aws_lambda_function.r_backend.function_name
+    }
+  }
+
+  depends_on = [aws_cloudwatch_log_group.kill_switch]
+  tags       = { Project = var.project }
+}
+
+resource "aws_sns_topic_subscription" "cost_circuit_breaker_lambda" {
+  count     = local.circuit_breaker_count
+  topic_arn = aws_sns_topic.cost_circuit_breaker.arn
+  protocol  = "lambda"
+  endpoint  = aws_lambda_function.kill_switch[0].arn
+}
+
+resource "aws_lambda_permission" "cost_circuit_breaker_sns" {
+  count         = local.circuit_breaker_count
+  statement_id  = "AllowSNSInvoke"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.kill_switch[0].function_name
+  principal     = "sns.amazonaws.com"
+  source_arn    = aws_sns_topic.cost_circuit_breaker.arn
+}

--- a/terraform/stacks/prod-runtime/lambda.tf
+++ b/terraform/stacks/prod-runtime/lambda.tf
@@ -79,7 +79,7 @@ resource "aws_cloudwatch_metric_alarm" "lambda_r_backend_errors" {
   statistic           = "Sum"
   threshold           = "0"
   alarm_description   = "Lambda R backend has errors"
-  alarm_actions       = []
+  alarm_actions       = [aws_sns_topic.alarm_notifications.arn]
 
   dimensions = {
     FunctionName = aws_lambda_function.r_backend.function_name
@@ -99,7 +99,7 @@ resource "aws_cloudwatch_metric_alarm" "lambda_r_backend_throttles" {
   statistic           = "Sum"
   threshold           = "0"
   alarm_description   = "Lambda R backend is being throttled (reserved concurrency cap reached)"
-  alarm_actions       = []
+  alarm_actions       = [aws_sns_topic.alarm_notifications.arn]
 
   dimensions = {
     FunctionName = aws_lambda_function.r_backend.function_name
@@ -116,7 +116,7 @@ resource "aws_cloudwatch_metric_alarm" "lambda_r_backend_duration" {
   statistic           = "Average"
   threshold           = var.lambda_r_backend_timeout * 1000 # Convert seconds to milliseconds
   alarm_description   = "Lambda R backend execution time is high"
-  alarm_actions       = []
+  alarm_actions       = [aws_sns_topic.alarm_notifications.arn]
 
   dimensions = {
     FunctionName = aws_lambda_function.r_backend.function_name

--- a/terraform/stacks/prod-runtime/monitoring.tf
+++ b/terraform/stacks/prod-runtime/monitoring.tf
@@ -1,0 +1,21 @@
+# Operational alarm notifications.
+#
+# A single SNS topic that the operational CloudWatch alarms (errors, throttles,
+# duration, DLQ) publish to, delivered by email so an operator actually learns
+# when something fires. Previously every alarm had empty `alarm_actions` and
+# notified no one. This is notification only; the automatic cost shutoff lives
+# in circuit_breaker.tf and uses a separate topic.
+#
+# The email subscription must be confirmed once (AWS sends a confirmation link
+# to var.email on first apply).
+
+resource "aws_sns_topic" "alarm_notifications" {
+  name = "${var.project}-alarm-notifications"
+  tags = { Project = var.project }
+}
+
+resource "aws_sns_topic_subscription" "alarm_notifications_email" {
+  topic_arn = aws_sns_topic.alarm_notifications.arn
+  protocol  = "email"
+  endpoint  = var.email
+}

--- a/terraform/stacks/prod-runtime/orchestrator_lambda.tf
+++ b/terraform/stacks/prod-runtime/orchestrator_lambda.tf
@@ -86,8 +86,9 @@ resource "aws_lambda_function" "orchestrator" {
 }
 
 # SQS -> orchestrator. maximum_concurrency caps how many queued runs fan out to
-# the R backend at once (bounds cost without throttling synchronous browser
-# calls, which is why the R Lambda itself stays unreserved).
+# the R backend at once, and must stay below the R backend's reserved
+# concurrency (lambda_r_backend_reserved_concurrency) so async runs never starve
+# synchronous UI/API calls.
 resource "aws_lambda_event_source_mapping" "orchestrator" {
   event_source_arn = aws_sqs_queue.runs.arn
   function_name    = aws_lambda_function.orchestrator.arn

--- a/terraform/stacks/prod-runtime/runs_queue.tf
+++ b/terraform/stacks/prod-runtime/runs_queue.tf
@@ -1,5 +1,5 @@
 # Async runs queue. The orchestrator consumes this; failures are NOT retried
-# (maxReceiveCount = 1) — model/analysis failures are recorded as terminal
+# (maxReceiveCount = 1). Model/analysis failures are recorded as terminal
 # states by the orchestrator, and only infra failures (a thrown handler) reach
 # the DLQ. MCMC is nondeterministic, so auto-retry is intentionally disabled.
 
@@ -31,7 +31,7 @@ resource "aws_cloudwatch_metric_alarm" "runs_dlq_not_empty" {
   statistic           = "Maximum"
   threshold           = "0"
   alarm_description   = "Async runs DLQ has messages (orchestrator/infra failure)"
-  alarm_actions       = []
+  alarm_actions       = [aws_sns_topic.alarm_notifications.arn]
 
   dimensions = {
     QueueName = aws_sqs_queue.runs_dlq.name

--- a/terraform/stacks/prod-runtime/ui_lambda.tf
+++ b/terraform/stacks/prod-runtime/ui_lambda.tf
@@ -83,10 +83,11 @@ resource "aws_cloudwatch_log_group" "ui_lambda" {
 }
 
 resource "aws_lambda_function" "ui" {
-  function_name = "${var.project}-ui"
-  role          = aws_iam_role.ui_lambda.arn
-  timeout       = var.ui_lambda_timeout
-  memory_size   = var.ui_lambda_memory_size
+  function_name                  = "${var.project}-ui"
+  role                           = aws_iam_role.ui_lambda.arn
+  timeout                        = var.ui_lambda_timeout
+  memory_size                    = var.ui_lambda_memory_size
+  reserved_concurrent_executions = var.ui_lambda_reserved_concurrency
 
   package_type = "Image"
   image_uri    = "${local.ecr_urls["react-ui"]}:${var.image_tag}"

--- a/terraform/stacks/prod-runtime/variables.tf
+++ b/terraform/stacks/prod-runtime/variables.tf
@@ -37,6 +37,19 @@ variable "ui_lambda_log_retention_days" {
   default     = 3
 }
 
+variable "ui_lambda_reserved_concurrency" {
+  description = <<-EOT
+    Reserved concurrency for the UI Lambda (-1 = unreserved). Caps how much the
+    public UI Function URL can spend and stops a flood from consuming the
+    account-wide concurrency pool that the R backend and orchestrator also draw
+    from. UI requests are short (page loads and lightweight API routes), so a
+    small cap is ample for minimal traffic; raise it if legitimate traffic grows
+    (docs/COST_CONTROLS.md).
+  EOT
+  type        = number
+  default     = 30
+}
+
 variable "lambda_r_backend_function_base_name" {
   type        = string
   description = "The base name of the Lambda function"
@@ -74,4 +87,28 @@ variable "lambda_r_backend_log_retention_days" {
   type        = number
   description = "Number of days to retain Lambda R backend CloudWatch logs"
   default     = 3
+}
+
+variable "cost_circuit_breaker_enabled" {
+  description = <<-EOT
+    When true, sustained throttling of the R backend automatically trips the
+    circuit breaker: an SNS-triggered Lambda sets the R backend's reserved
+    concurrency to 0, halting all further compute spend until an operator
+    restores it (docs/COST_CONTROLS.md). When false, the same condition only
+    emails; no automatic shutoff happens.
+  EOT
+  type        = bool
+  default     = true
+}
+
+variable "cost_circuit_breaker_throttle_periods" {
+  description = <<-EOT
+    Number of consecutive 5-minute periods of continuous R-backend throttling
+    that must occur before the circuit breaker trips. Throttling only happens
+    when demand exceeds the reserved-concurrency cap, so sustained throttling is
+    a strong abuse signal; a multi-period window avoids tripping on brief
+    organic bursts. Default 6 = ~30 minutes.
+  EOT
+  type        = number
+  default     = 6
 }


### PR DESCRIPTION
Implements the cost / denial-of-wallet controls from the security analysis of the current serverless setup. Goal: keep the site's real spend in the cents while bounding worst-case abuse toward the intended ~$5-10/month envelope, using only free AWS features.

New doc: [`docs/COST_CONTROLS.md`](docs/COST_CONTROLS.md).

## Deploy status

**The foundation stack is already deployed** (`cloud:init`, account `396608806362` / eu-central-1). Foundation is applied out of band by design; CI only applies `prod-runtime`. Verified live:

- Budget: **$10** with notifications at 50% actual, 80% actual, and 100% **forecast**.
- Cost Anomaly Detection: `maive-anomaly-alerts`, daily, threshold $5, to the admin email.
- Orphaned `maive-budget-alarm-topic` SNS topic: removed (confirmed zero subscribers, no alarm referenced it).

**The runtime stack is not deployed yet** — the circuit breaker, UI reserved concurrency, and alarm wiring go live when this PR merges with the `release` label. Account concurrency headroom checked: 990 unreserved of a 1000 limit, so the UI's 30-unit reservation is safe.

## What's here

**1. Cost circuit breaker (the real ceiling enforcer)** — `prod-runtime/circuit_breaker.tf`, `apps/kill-switch/index.mjs`
The free equivalent of AWS Budgets Actions: a CloudWatch alarm on **sustained** R-backend throttling (default 6 consecutive 5-min periods) publishes to SNS, which invokes a tiny Lambda that sets the R backend's reserved concurrency to `0`. Further compute then throttles (429) until an operator restores the cap. Worst-case bleed before it trips is well under $1 per episode. Toggle via `cost_circuit_breaker_enabled` (default on); when off, the condition only emails. Recovery is a deliberate `terraform apply`, documented.

**2. Alarm notifications** — `monitoring.tf`, `lambda.tf`, `runs_queue.tf`
The errors / throttles / duration / DLQ alarms had empty `alarm_actions` and notified no one. They now publish to an SNS topic delivered by email.

**3. UI Lambda reserved concurrency** — `ui_lambda.tf`, `variables.tf`
Was fully unreserved; now capped (default 30) so a UI flood can't consume the account concurrency pool.

**4. Budget alerts** — `prod-foundation/budget.tf`
$100 → $10, with 50/80% actual and a forecast notification. Removed the dead SNS topic.

**5. Cost Anomaly Detection (free)** — `prod-foundation/cost_anomaly.tf`, `providers.tf`
Two things differed from plan and are reflected in the code:
- **The monitor is adopted, not created.** AWS enables anomaly detection by default and permits only **one** dimensional (SERVICE) monitor per account, so creating a second returned `Limit exceeded on dimensional spend monitor creation`. The existing `Default-Services-Monitor` was imported; its name is kept to avoid renaming an account default. Its only pre-existing subscription fires at >= $100 **and** >= 40%, which would never catch a problem at this project's scale, so ours is added alongside it.
- **Daily, not immediate.** The API rejects `IMMEDIATE` for non-SNS subscribers (`Immediate frequencies only support SNSTopic subscriptions`). Anomaly detection runs on ~24h-lagged billing data anyway, so a daily digest loses nothing; the fast abuse signal is the runtime throttle alarm.

**6. Max dataset rows = 50,000** — `api_v1.R`, `index.R`, `datasetValidation.ts`
Caps per-request work on every HTTP route, including the raw legacy path an attacker would use. Far above any realistic meta-analysis, so it never blocks genuine use.

The R backend timeout stays at 600s (deliberately unchanged).

## Verification

- Foundation: applied and verified against the live account (above).
- `terraform validate` passes on both stacks; `terraform fmt` clean.
- UI test suite: **119 passed**, including new `MAX_ROWS` cases. ESLint clean on changed files.
- R files parse; the row-count guard exercised directly (correct count, aborts only past the limit, malformed JSON falls through to the model's own error envelope).
- `apps/kill-switch/index.mjs` passes `node --check`; uses only `@aws-sdk/client-lambda`, which ships in the nodejs20.x runtime (no bundling).

## Note for the reviewer

**SNS email subscriptions need one-time confirmation.** On the runtime apply, AWS emails confirmation links for the alarm-notifications and circuit-breaker topics; alerts are silent until those are clicked.

## What this does and does not guarantee

It stops runaway compute automatically and keeps expected spend in the cents. It does **not** give a hard, instant monthly cap: AWS has no native "stop at $X," and all spend-based signals lag billing data by up to a day, which is why the automatic control keys off the in-region throttle metric (minutes) rather than a budget. A determined attacker can still incur a small, bounded cost per episode before the breaker trips.
