### PR TITLE
fix: round repro-script verification against 4dp-rounded API results

### DIFF
--- a/apps/react-ui/client/src/lib/reproducibility/generators/wrapperScript.test.ts
+++ b/apps/react-ui/client/src/lib/reproducibility/generators/wrapperScript.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+import { generateWrapperScript } from "@src/lib/reproducibility/generators/wrapperScript";
+import type { ModelParameters, ModelResults } from "@src/types/api";
+import type { VersionInfo } from "@src/types/reproducibility";
+
+const versionInfo: VersionInfo = {
+  uiVersion: "0.0.0",
+  maiveTag: "0.2.5",
+  gitCommitHash: "abc1234",
+  rVersion: "4.4.1",
+  timestamp: "2026-01-01T00:00:00.000Z",
+};
+
+const parameters: ModelParameters = {
+  modelType: "MAIVE",
+  includeStudyDummies: false,
+  includeStudyClustering: false,
+  standardErrorTreatment: "not_clustered",
+  computeAndersonRubin: false,
+  maiveMethod: "PET-PEESE",
+  weight: "equal_weights",
+  shouldUseInstrumenting: true,
+  useLogFirstStage: false,
+  winsorize: 0,
+  favorPositive: false,
+};
+
+const results: ModelResults = {
+  // Values as they arrive in the browser: already rounded to 4 decimal
+  // places by the R backend's JSON serializer (jsonlite digits = 4).
+  effectEstimate: 0.0879,
+  standardError: 0.0473,
+  isSignificant: false,
+  andersonRubinCI: "NA",
+  publicationBias: {
+    eggerCoef: -1.6399,
+    eggerSE: 1.9405,
+    isSignificant: false,
+    eggerBootCI: "NA",
+    eggerAndersonRubinCI: "NA",
+  },
+  firstStageFStatistic: 2.1303,
+  hausmanTest: {
+    statistic: 0.7742,
+    criticalValue: 3.8415,
+    rejectsNull: false,
+  },
+  seInstrumented: [0.0224, 0.0221],
+  funnelPlot: "",
+  funnelPlotWidth: 400,
+  funnelPlotHeight: 300,
+  bootCI: "NA",
+  bootSE: "NA",
+};
+
+describe("generateWrapperScript", () => {
+  it("rounds the local re-run before comparing against expected_results.json", () => {
+    // MAIVE >= 0.2.5 returns effectEstimate/standardError/eggerCoef at full
+    // double precision from a local re-run, while expected_results.json is
+    // the API response the browser received, which the server always rounds
+    // to 4 decimal places. Comparing the two directly at a 1e-8 tolerance
+    // would fail on nearly every reproducible run; the script must round the
+    // local re-run to the same precision before comparing.
+    const script = generateWrapperScript(versionInfo, parameters, results, 60);
+
+    expect(script).toContain(
+      "abs(round(results$effectEstimate, 4) - expected$effectEstimate) < tolerance",
+    );
+    expect(script).toContain(
+      "abs(round(results$standardError, 4) - expected$standardError) < tolerance",
+    );
+    expect(script).toContain(
+      "abs(round(results$publicationBias$eggerCoef, 4) - expected$publicationBias$eggerCoef) < tolerance",
+    );
+
+    // Guard against a regression back to the old unrounded comparison.
+    expect(script).not.toContain(
+      "abs(results$effectEstimate - expected$effectEstimate) < tolerance",
+    );
+  });
+});

--- a/apps/react-ui/client/src/lib/reproducibility/generators/wrapperScript.ts
+++ b/apps/react-ui/client/src/lib/reproducibility/generators/wrapperScript.ts
@@ -153,9 +153,13 @@ cat("Comparing with expected results from web application...\\n")
 expected <- jsonlite::fromJSON("expected_results.json")
 tolerance <- 1e-8
 
-effect_match <- abs(results$effectEstimate - expected$effectEstimate) < tolerance
-se_match <- abs(results$standardError - expected$standardError) < tolerance
-egger_match <- abs(results$publicationBias$eggerCoef - expected$publicationBias$eggerCoef) < tolerance
+# expected_results.json was captured from the web app's JSON API response,
+# which rounds every numeric field to 4 decimal places before it reaches the
+# browser (jsonlite::toJSON default digits = 4). This script's local re-run
+# is not rounded, so round to that same precision before comparing.
+effect_match <- abs(round(results$effectEstimate, 4) - expected$effectEstimate) < tolerance
+se_match <- abs(round(results$standardError, 4) - expected$standardError) < tolerance
+egger_match <- abs(round(results$publicationBias$eggerCoef, 4) - expected$publicationBias$eggerCoef) < tolerance
 
 cat("Effect Estimate Match:  ", ifelse(effect_match, "✓ PASS", "✗ FAIL"), "\\n")
 cat("Standard Error Match:   ", ifelse(se_match, "✓ PASS", "✗ FAIL"), "\\n")


### PR DESCRIPTION
## Context

MAIVE 0.2.5 stopped rounding returned values (beta/SE/egger_coef/etc.) to 3 decimals internally; maive()/waive() now return full double precision, with rounding pushed into the package's own display paths only.

## Audit summary

Ran a full audit of every place maive-ui renders MAIVE outputs (results cards, funnel plot, interpretation text, CSV/XLSX export, reproducibility package), both statically and by installing MAIVE 0.2.5 from GitHub main and running the app end to end locally against a live R backend.

**The live UI is safe.** The R Lambda's Plumber server sets a single global JSON serializer (`apps/lambda-r-backend/r_scripts/host.R:46`, `serializer_unboxed_json()`), which uses jsonlite's default `digits = 4`. Every numeric field in every HTTP response (`/run-model`, `/run-rtma`, and the `/v1` routes) is rounded to 4 decimal places before it reaches the browser, regardless of what MAIVE itself returns. Verified this empirically: a raw local call to `run_maive_model()` with MAIVE 0.2.5 returned `effectEstimate = 0.087918962355665`, but the same request through the live `/run-model` HTTP endpoint returned `0.0879`. The frontend's own formatters (`ResultsSummary.tsx`, `resultsDataUtils.ts`, `RTMAResultsSummary.tsx`, `interpretationTextGenerator.ts`) then round that already-bounded value down further (2-4 decimals depending on location) for display. Ran the demo dataset through the actual Next.js UI against a live MAIVE-0.2.5-backed R server; every results card, the funnel plot, and the interpretation tooltip rendered clean 2-3 decimal values, no long floats.

**One real regression found and fixed here:** the reproducibility package's generated `run_analysis.R` script (`apps/react-ui/client/src/lib/reproducibility/generators/wrapperScript.ts`) calls `run_maive_model()` directly, bypassing the JSON serializer entirely, so its local re-run now gets full double precision. It compares that against `expected_results.json`, which was captured from the (4-decimal-rounded) API response, using a `1e-8` tolerance. With MAIVE 0.2.5, this comparison now fails on essentially every genuinely reproducible run, since the two sides can differ by up to 5e-5. Verified with the actual captured value from the local test run: `abs(0.087918962355665 - 0.0879) < 1e-8` is `FALSE`.

## Fix

Round the local re-run to the same 4-decimal precision as `expected_results.json` before comparing, with a comment explaining why. Added a regression test asserting the generated R script uses the rounded comparison.

## Pre-existing, unrelated observations (not fixed here, out of scope)

- Five independent numeric formatters exist across the frontend (2/3/4/6 decimal places depending on location), so the same value can display at different precisions in different places on the same results page (e.g. results card shows `2.208`, the interpretation tooltip shows `2.21`). This predates 0.2.5 and isn't a regression from it.
- `interpretationTextGenerator.ts` recomputes significance/publication-bias-significance client-side instead of reusing the backend's own `isSignificant`/`publicationBias.isSignificant` flags, which could disagree right at the boundary. Also predates 0.2.5.

## Testing

- Installed MAIVE 0.2.5 from `PetrCala/MAIVE@main` locally, ran the R backend and Next.js UI together, exercised a full analysis run through the browser.
- `npm run ui:lint` passes.
- New unit test (`wrapperScript.test.ts`) passes.