### PR TITLE
fix: correct RTMA sign for favor positive no and surface phacking warnings

### DIFF
--- a/apps/lambda-r-backend/r_scripts/rtma_model.R
+++ b/apps/lambda-r-backend/r_scripts/rtma_model.R
@@ -153,16 +153,29 @@ run_rtma_model <- function(data, parameters) {
   # runtimes; the limit converts that into a clean failure instead of a hang.
   # The time-limit interrupt fires inside phacking, which re-throws it as an
   # opaque message, so timeout is detected by elapsed time rather than message.
+  #
+  # phacking_meta() also signals conditions the caller must see, above all
+  # "Favored direction is opposite of the pooled estimate.", which means the fit
+  # truncated nothing and the returned mu is effectively uncorrected. tryCatch
+  # only handles errors, so warnings are collected here and returned in the
+  # response instead of being dropped on the floor.
+  rtma_warnings <- character(0)
   start_time <- Sys.time()
   setTimeLimit(elapsed = timeout_sec, transient = TRUE)
   rtma_res <- tryCatch(
-    phacking::phacking_meta(
-      yi = yi,
-      vi = vi,
-      favor_positive = favor_positive,
-      alpha_select = alpha_select,
-      ci_level = ci_level,
-      parallelize = parallelize
+    withCallingHandlers(
+      phacking::phacking_meta(
+        yi = yi,
+        vi = vi,
+        favor_positive = favor_positive,
+        alpha_select = alpha_select,
+        ci_level = ci_level,
+        parallelize = parallelize
+      ),
+      warning = function(w) {
+        rtma_warnings <<- c(rtma_warnings, conditionMessage(w))
+        invokeRestart("muffleWarning")
+      }
     ),
     error = function(e) {
       setTimeLimit() # clear so error reporting is not itself interrupted
@@ -195,10 +208,47 @@ run_rtma_model <- function(data, parameters) {
   tau_est <- tau_row$mode
   tau_ci <- c(tau_row$ci_lower, tau_row$ci_upper)
 
+  # phacking_meta() does `if (!favor_positive) yi <- -yi` and then reports mu and
+  # its credible interval on that flipped scale, never mapping them back to the
+  # caller's sign convention. Undo the flip here, otherwise favor_positive =
+  # FALSE returns a corrected mean with the wrong sign. Negating an interval also
+  # reverses its bounds. tau is a scale parameter and is sign-invariant, so it is
+  # left alone. Upstream: mathurlabstanford/metabias-apps#1.
+  if (!favor_positive) {
+    mu_est <- -mu_est
+    mu_ci <- c(-mu_ci[2], -mu_ci[1])
+  }
+
   # Nonaffirmative (insignificant) estimates
   k <- rtma_res$values$k
   k_nonaffirmative <- rtma_res$values$k_nonaffirmative
   nonaffirmative_proportion <- if (k > 0) k_nonaffirmative / k else NA_real_
+
+  # Every estimate being nonaffirmative means nothing was truncated, so mu is the
+  # uncorrected pooled mean wearing a corrected label. In practice this always
+  # means the favored direction is set the wrong way round for the data, so say
+  # so explicitly rather than leaving it to phacking's own warning, which is
+  # phrased in terms of the pooled estimate.
+  if (isTRUE(k > 0 && k_nonaffirmative == k)) {
+    rtma_warnings <- c(
+      rtma_warnings,
+      paste(
+        "No estimate is affirmative in the favored direction, so RTMA truncated",
+        "nothing and the reported mean is not corrected for p-hacking. Check the",
+        sprintf("\"favor positive\" setting (currently %s).", favor_positive)
+      )
+    )
+  }
+
+  # Warnings are muffled above so they never reach the Lambda log on their own;
+  # re-emit them here. "{msg}" keeps cli from glue-interpolating the message.
+  rtma_warnings <- unique(rtma_warnings)
+  if (length(rtma_warnings) > 0) {
+    cli::cli_h2("RTMA warnings:")
+    for (msg in rtma_warnings) {
+      cli::cli_alert_warning("{msg}")
+    }
+  }
 
   cli::cli_h2("RTMA summary:")
   cli::cli_bullets(c(
@@ -225,7 +275,10 @@ run_rtma_model <- function(data, parameters) {
     zScorePlotWidth = z_plot$width_px,
     zScorePlotHeight = z_plot$height_px,
     nonaffirmativeCount = k_nonaffirmative,
-    nonaffirmativeProportion = nonaffirmative_proportion
+    nonaffirmativeProportion = nonaffirmative_proportion,
+    # I() so the unboxed-JSON serializer keeps this an array even when a single
+    # warning was raised; callers can always treat it as a list of strings.
+    warnings = I(rtma_warnings)
   )
 
   results

--- a/apps/lambda-r-backend/r_scripts/tests/e2e/run_e2e_tests.R
+++ b/apps/lambda-r-backend/r_scripts/tests/e2e/run_e2e_tests.R
@@ -38,6 +38,7 @@ source(file.path(script_dir, "scenarios/basic_maive_test.R"))
 source(file.path(script_dir, "scenarios/publication_bias_test.R"))
 source(file.path(script_dir, "scenarios/edge_cases_test.R"))
 source(file.path(script_dir, "scenarios/basic_rtma_test.R"))
+source(file.path(script_dir, "scenarios/rtma_direction_test.R"))
 source(file.path(script_dir, "scenarios/api_v1_test.R"))
 
 # Define available test scenarios
@@ -103,6 +104,11 @@ AVAILABLE_SCENARIOS <- list(
     name = "Basic RTMA Test",
     description = "Test basic RTMA functionality with phacking package",
     function_name = "test_basic_rtma"
+  ),
+  "rtma-direction" = list(
+    name = "RTMA Favored Direction Test",
+    description = "Test that RTMA respects the favored direction and flags a wrong one",
+    function_name = "test_rtma_direction"
   ),
 
   # Public /v1 API scenarios
@@ -373,6 +379,21 @@ run_all_scenarios <- function(api_url = NULL, verbose = TRUE) {
     cat("   ✓ API v1 test passed\n")
   } else {
     cat("   ✗ API v1 test failed:", api_v1_result$error, "\n")
+  }
+  test_count <- test_count + 1
+
+  # RTMA favored direction runs last: it fits three more RTMA models, and every
+  # extra fit in this long-lived process makes the rstan sampler more likely to
+  # wedge on a later one. Keeping it at the end leaves every other scenario with
+  # the same process state it had before this test existed.
+  cat("\n8. Running RTMA favored direction test...\n")
+  rtma_direction_result <- test_rtma_direction()
+  all_results$rtma_direction <- rtma_direction_result
+  if (rtma_direction_result$status == "PASS") {
+    passed_count <- passed_count + 1
+    cat("   ✓ RTMA favored direction test passed\n")
+  } else {
+    cat("   ✗ RTMA favored direction test failed:", rtma_direction_result$error, "\n")
   }
   test_count <- test_count + 1
 

--- a/apps/lambda-r-backend/r_scripts/tests/e2e/scenarios/basic_rtma_test.R
+++ b/apps/lambda-r-backend/r_scripts/tests/e2e/scenarios/basic_rtma_test.R
@@ -46,7 +46,8 @@ test_basic_rtma <- function() {
         "zScorePlot", "zScorePlotWidth",
         "zScorePlotHeight",
         "nonaffirmativeCount",
-        "nonaffirmativeProportion"
+        "nonaffirmativeProportion",
+        "warnings"
       )
 
       missing <- setdiff(

--- a/apps/lambda-r-backend/r_scripts/tests/e2e/scenarios/rtma_direction_test.R
+++ b/apps/lambda-r-backend/r_scripts/tests/e2e/scenarios/rtma_direction_test.R
@@ -1,0 +1,208 @@
+# RTMA Favored Direction Test Scenario
+#
+# Regression coverage for the two direction bugs in run_rtma_model():
+#
+#   * phacking_meta() fits on -yi when favor_positive = FALSE and reports mu on
+#     that flipped scale. The unmapped value used to reach the caller, so a
+#     negative literature came back with a positive corrected mean.
+#   * phacking_meta() warns when the favored direction is opposite the pooled
+#     estimate, but the error-only tryCatch swallowed it, so a run that
+#     truncated nothing looked like a clean correction.
+
+#' Fail with a message unless a condition holds
+expect_rtma <- function(condition, message) {
+  if (!isTRUE(condition)) {
+    stop(message)
+  }
+}
+
+#' Build the RTMA parameter JSON with favorPositive overridden
+#' @param favor_positive Value for the favorPositive parameter
+#' @return JSON string of parameters
+rtma_direction_params <- function(favor_positive) {
+  params_to_json(list(
+    modelType = "RTMA",
+    favorPositive = favor_positive,
+    alphaSelect = 0.05,
+    ciLevel = 0.95,
+    winsorize = 0
+  ))
+}
+
+#' Run /run-rtma for one direction setting and return the results object
+#' @param df Data frame of estimates (effect, se in the first two columns)
+#' @param favor_positive Value for the favorPositive parameter
+#' @param label Label used in failure messages
+#' @return Parsed results object
+run_rtma_direction_case <- function(df, favor_positive, label) {
+  cat(sprintf("  %s...\n", label))
+  response <- test_run_rtma(df_to_json(df), rtma_direction_params(favor_positive))
+
+  expect_rtma(
+    is.list(response) && !is.null(response$data),
+    sprintf("%s: response should contain a 'data' field", label)
+  )
+  results <- response$data
+
+  expect_rtma(
+    "warnings" %in% names(results),
+    sprintf("%s: results should carry a 'warnings' field", label)
+  )
+  expect_rtma(
+    is.numeric(results$mu) && length(results$mu) == 1,
+    sprintf("%s: mu should be a single number", label)
+  )
+  expect_rtma(
+    length(results$muCI) == 2,
+    sprintf("%s: muCI should have 2 elements", label)
+  )
+  expect_rtma(
+    results$muCI[[1]] < results$muCI[[2]],
+    sprintf("%s: muCI should be ordered [lower, upper]", label)
+  )
+
+  results
+}
+
+#' Collect the warning messages that name the favored direction
+#' @param results Parsed RTMA results object
+#' @return Character vector of matching messages
+rtma_direction_warnings <- function(results) {
+  messages <- unlist(results$warnings)
+  if (is.null(messages)) {
+    return(character(0))
+  }
+  messages[grepl("direction", messages, ignore.case = TRUE)]
+}
+
+#' Test that RTMA respects the favored direction and reports direction problems
+#' @return Test results
+test_rtma_direction <- function() {
+  test_name <- "RTMA Favored Direction Test"
+
+  tryCatch(
+    {
+      # One dataset and its exact mirror image. Fitting yi with
+      # favorPositive = TRUE and -yi with favorPositive = FALSE is the same
+      # model, so mu must come back negated and the credible interval mirrored.
+      positive_data <- generate_rtma_test_data()
+      negative_data <- positive_data
+      negative_data$bs <- -negative_data$bs
+
+      cat("Running RTMA favored direction test...\n")
+
+      positive_results <- run_rtma_direction_case(
+        positive_data, TRUE, "positive data, favorPositive = TRUE"
+      )
+      negative_results <- run_rtma_direction_case(
+        negative_data, FALSE, "negative data, favorPositive = FALSE"
+      )
+      wrong_results <- run_rtma_direction_case(
+        negative_data, TRUE, "negative data, favorPositive = TRUE (wrong way round)"
+      )
+
+      # 1. Signs follow the data, not phacking's internal orientation
+      expect_rtma(
+        positive_results$mu > 0,
+        sprintf(
+          "Positive data with favorPositive = TRUE should give mu > 0, got %.6f",
+          positive_results$mu
+        )
+      )
+      expect_rtma(
+        negative_results$mu < 0,
+        sprintf(
+          "Negative data with favorPositive = FALSE should give mu < 0, got %.6f",
+          negative_results$mu
+        )
+      )
+      expect_rtma(
+        negative_results$muCI[[2]] < 0,
+        sprintf(
+          "Negative data with favorPositive = FALSE should give a negative muCI, got [%.6f, %.6f]",
+          negative_results$muCI[[1]], negative_results$muCI[[2]]
+        )
+      )
+
+      # 2. The two fits mirror each other. Sampling is unseeded, so compare with
+      # a tolerance well above Monte Carlo noise but far below the sign error
+      # this guards against (which doubles the magnitude).
+      mu_tolerance <- 0.25 * abs(positive_results$mu)
+      # Interval bounds are posterior quantiles, so the long tail carries far
+      # more Monte Carlo noise than the mode. Scale their tolerance to the
+      # interval width: an unflipped bound would miss by more than twice this.
+      ci_tolerance <- 0.75 *
+        (positive_results$muCI[[2]] - positive_results$muCI[[1]])
+      expect_rtma(
+        abs(positive_results$mu + negative_results$mu) < mu_tolerance,
+        sprintf(
+          "Mirrored fits should give negated mu: %.6f vs %.6f",
+          positive_results$mu, negative_results$mu
+        )
+      )
+      expect_rtma(
+        abs(positive_results$muCI[[1]] + negative_results$muCI[[2]]) < ci_tolerance &&
+          abs(positive_results$muCI[[2]] + negative_results$muCI[[1]]) < ci_tolerance,
+        sprintf(
+          "Mirrored fits should give a mirrored muCI: [%.6f, %.6f] vs [%.6f, %.6f]",
+          positive_results$muCI[[1]], positive_results$muCI[[2]],
+          negative_results$muCI[[1]], negative_results$muCI[[2]]
+        )
+      )
+
+      # 3. tau is a scale parameter, so it is not flipped and stays positive
+      expect_rtma(
+        negative_results$tau > 0,
+        sprintf("tau should stay positive, got %.6f", negative_results$tau)
+      )
+      expect_rtma(
+        abs(positive_results$tau - negative_results$tau) < 0.25 * positive_results$tau,
+        sprintf(
+          "Mirrored fits should give the same tau: %.6f vs %.6f",
+          positive_results$tau, negative_results$tau
+        )
+      )
+
+      # 4. Fitting the correct direction raises no direction warning; fitting
+      # the wrong one surfaces it instead of silently returning an uncorrected
+      # estimate.
+      expect_rtma(
+        length(rtma_direction_warnings(negative_results)) == 0,
+        paste(
+          "Correctly oriented fit should raise no direction warning, got:",
+          paste(rtma_direction_warnings(negative_results), collapse = " | ")
+        )
+      )
+      expect_rtma(
+        length(rtma_direction_warnings(wrong_results)) > 0,
+        paste(
+          "Wrong-direction fit should surface a direction warning, got:",
+          paste(unlist(wrong_results$warnings), collapse = " | ")
+        )
+      )
+
+      log_test_result(
+        test_name, "PASS",
+        "RTMA reports mu on the caller's sign convention and flags a wrong favored direction"
+      )
+
+      return(list(
+        status = "PASS",
+        test_name = test_name,
+        results = list(
+          positive = positive_results,
+          negative = negative_results,
+          wrong_direction = wrong_results
+        )
+      ))
+    },
+    error = function(e) {
+      log_test_result(test_name, "FAIL", e$message)
+      return(list(
+        status = "FAIL",
+        test_name = test_name,
+        error = e$message
+      ))
+    }
+  )
+}

--- a/apps/lambda-r-backend/r_scripts/tests/e2e/utils/test_helpers.R
+++ b/apps/lambda-r-backend/r_scripts/tests/e2e/utils/test_helpers.R
@@ -37,6 +37,27 @@ generate_test_data <- function(n_studies = 20, include_study_id = TRUE) {
   return(df)
 }
 
+#' Generate sample data for RTMA
+#'
+#' generate_test_data() produces very precise estimates, which leaves RTMA only
+#' a handful of nonaffirmative ones to fit on and makes the sampler crawl. This
+#' generator keeps standard errors on the same order as the effects, so roughly
+#' two thirds of the estimates are nonaffirmative and the fit is well identified.
+#'
+#' @param n Number of estimates
+#' @param mean_effect Mean underlying effect
+#' @param tau Between-estimate heterogeneity
+#' @param seed Random seed, for reproducible tests
+#' @return Data frame with effect (bs) and standard error (sebs) columns
+generate_rtma_test_data <- function(n = 40, mean_effect = 0.15, tau = 0.08, seed = 2026) {
+  set.seed(seed)
+
+  se <- runif(n, 0.06, 0.20)
+  effects <- rnorm(n, mean_effect, sqrt(tau^2 + se^2))
+
+  data.frame(bs = effects, sebs = se)
+}
+
 #' Generate data with known publication bias
 #' @param n_studies Number of studies
 #' @param bias_strength Strength of publication bias

--- a/apps/react-ui/client/src/components/RTMAResultsSummary.tsx
+++ b/apps/react-ui/client/src/components/RTMAResultsSummary.tsx
@@ -1,8 +1,10 @@
 "use client";
 
 import type { RTMAResults } from "@src/types/api";
+import Alert from "@components/Alert";
 import Tooltip from "@components/Tooltip";
 import CONFIG from "@src/CONFIG";
+import CONST from "@src/CONST";
 
 type RTMAResultsSummaryProps = {
   results: RTMAResults;
@@ -43,9 +45,22 @@ export default function RTMAResultsSummary({
     },
   ];
 
+  const warnings = results.warnings ?? [];
+
   return (
     <div className="p-4 bg-gray-50 dark:bg-gray-700 rounded-lg">
       <h2 className="text-xl font-semibold mb-4">RTMA Results</h2>
+      {warnings.length > 0 ? (
+        <div className="mb-4 space-y-2">
+          {warnings.map((warning) => (
+            <Alert
+              key={warning}
+              message={warning}
+              type={CONST.ALERT_TYPES.WARNING}
+            />
+          ))}
+        </div>
+      ) : null}
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
         {metrics.map((metric) => {
           const content = (

--- a/apps/react-ui/client/src/types/api.ts
+++ b/apps/react-ui/client/src/types/api.ts
@@ -108,6 +108,10 @@ type RTMAResults = {
   zScorePlotHeight: number;
   nonaffirmativeCount: number;
   nonaffirmativeProportion: number;
+  // Conditions raised while fitting, most importantly a favored direction that
+  // is opposite the pooled estimate. Optional because runs stored before the
+  // backend started returning the field have no value for it.
+  warnings?: string[];
 };
 
 type PingResponse = {

--- a/docs/PUBLIC_API_DESIGN.md
+++ b/docs/PUBLIC_API_DESIGN.md
@@ -233,8 +233,20 @@ plus `funnelPlot`/`funnelPlotWidth`/`funnelPlotHeight` only with
 Same envelope; parameters (all optional): `favorPositive` (default `true`),
 `alphaSelect` (`0.05`), `ciLevel` (`0.95`), `winsorize` (`0`). The internal
 `parallelize` / `timeoutSeconds` knobs are **not** exposed. Response: `mu`,
-`muCI`, `tau`, `tauCI`, `nonaffirmativeCount`, `nonaffirmativeProportion`
-(+ `zScorePlot*` with `?include=plot`).
+`muCI`, `tau`, `tauCI`, `nonaffirmativeCount`, `nonaffirmativeProportion`,
+`warnings` (+ `zScorePlot*` with `?include=plot`).
+
+`mu` and `muCI` are reported on the sign convention of the submitted data:
+`phacking_meta()` fits on `-yi` when `favorPositive` is `false`, and
+`run_rtma_model()` maps the result back so a negative literature analysed with
+`favorPositive: false` returns a negative `mu`. `tau` is a scale parameter and is
+unaffected.
+
+`warnings` is an array of strings, empty on a clean fit. It carries the
+conditions `phacking_meta()` raises, most importantly a favored direction
+opposite the pooled estimate, plus an explicit flag when every estimate is
+nonaffirmative, in which case nothing was truncated and `mu` is not corrected for
+p-hacking.
 
 ### 6.5 Async: `POST /v1/runs`, `GET /v1/runs/{jobId}`
 

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -772,9 +772,14 @@ components:
         - tauCI
         - nonaffirmativeCount
         - nonaffirmativeProportion
+        - warnings
       properties:
         mu:
           type: number
+          description: >-
+            Posterior mode of the bias-corrected mean, on the sign convention of
+            the submitted data (so a negative literature analysed with
+            `favorPositive: false` returns a negative `mu`).
         muCI:
           type: array
           items:
@@ -793,6 +798,15 @@ components:
           type: integer
         nonaffirmativeProportion:
           type: number
+        warnings:
+          type: array
+          items:
+            type: string
+          description: >-
+            Conditions raised while fitting; empty when the fit was clean. The
+            most important one reports a favored direction opposite the pooled
+            estimate, which means nothing was truncated and `mu` is not actually
+            corrected for p-hacking.
         zScorePlot:
           type: string
           description: 'Base64-encoded PNG data URI. Only present with `?include=plot`.'


### PR DESCRIPTION
Fixes #477
Fixes #478

## What

Two RTMA correctness bugs in the R backend, plus regression coverage and a minimal UI surface for the new warnings.

### Sign flip for favor positive = no (#477)

`phacking::phacking_meta()` negates `yi` internally when `favor_positive = FALSE` and reports `mu` and its credible interval on that flipped scale without mapping them back. `run_rtma_model()` now undoes the flip: `mu` is negated and the CI bounds are negated and swapped. `tau` is a scale parameter and is left alone. With this fix the app returns -0.039 for the published example instead of +0.0392.

### Swallowed direction warning (#478)

`phacking_meta()` warns "Favored direction is opposite of the pooled estimate." but the existing `tryCatch` only handled errors, so the app silently returned an effectively uncorrected estimate. Warnings are now captured with `withCallingHandlers`, returned in a new `warnings` array on the RTMA results, and re-emitted to the Lambda logs. An app-level warning is also added when every estimate is nonaffirmative (nothing truncated, mean not corrected). Both the legacy `/run-rtma` route and `/v1/run-rtma` pass the field through unchanged, so the public API, CSV export, and reproducibility script all inherit it.

## Verification

- Mirror check (direct R): favor+ on `yi` vs favor- on `-yi` gives mu 0.119880 vs -0.119842 (sum 3.75e-05), mirrored CI bounds, tau equal to 1.8e-05.
- Wrong-direction run (negated data, favor+): 40/40 nonaffirmative, both warnings surfaced.
- New e2e scenario `rtma-direction` (sign, mirror, and warning assertions): passes 6/6 standalone runs and within the full suite. Tolerances are wide because RTMA sampling is unseeded (#479).
- `basic-rtma` updated for the new `warnings` field; UI vitest 126/126.

## Notes

- The new e2e scenario runs last in the suite: each extra rstan fit in the long-lived test server process makes the sampler more likely to wedge on a later fit, and running it last leaves every other scenario with the same process state as before.
- The "Parameter Combinations" scenario flakes intermittently (2 of 3 full-suite runs here). It is MAIVE-only, runs before any RTMA code, and is untouched by this diff; pre-existing.
- UI change is minimal: `RTMAResultsSummary` renders the warnings as alert banners above the metrics grid. Richer treatment can be a follow-up.
- #486 (z-score plot direction) is out of scope.
