### PR TITLE
perf: preload phacking and warm ragg font cache in host.R

### DIFF
--- a/apps/lambda-r-backend/r_scripts/host.R
+++ b/apps/lambda-r-backend/r_scripts/host.R
@@ -113,4 +113,35 @@ pr$setErrorHandler(function(req, res, err) {
   list(error = "500 - Internal server error")
 })
 
+# ---- PRELOAD PHACKING (issue #483, section 1) -----------------------------
+# rtma_model.R:5 runs `library(phacking)` at source() time, and index.R /
+# api_v1.R source() it on every RTMA request. Loading the namespace costs
+# ~11s, and ragg's first text render separately warms a font cache. Without
+# this, whichever request happens to be the first RTMA call served by a given
+# Lambda container pays both costs. Preload here, once per container, before
+# plumber starts listening, so no request pays them.
+#
+# Trade-off: every container now pays this preload, including ones that end
+# up serving only MAIVE requests, so a cold MAIVE-only container also waits
+# behind it. A scheduled /health keep-warm ping (also proposed in #483) would
+# avoid this by keeping containers warm instead of letting them go cold; that
+# is left as a follow-up, not implemented here.
+cli::cli_alert_info("Preloading phacking and warming ragg font cache...")
+preload_start <- Sys.time()
+
+tryCatch(
+  {
+    # nolint start: undesirable_function_linter.
+    source("rtma_model.R")
+    # nolint end: undesirable_function_linter.
+    render_z_density_plot(yi = c(-2, -1, 0, 1, 2), vi = c(1, 1, 1, 1, 1))
+  },
+  error = function(e) {
+    cli::cli_alert_danger("Phacking preload failed: {conditionMessage(e)}")
+  }
+)
+
+preload_elapsed <- round(as.numeric(Sys.time() - preload_start, units = "secs"), 2)
+cli::cli_alert_success("Phacking preload finished in {preload_elapsed}s")
+
 pr$run(host = R_HOST, port = R_PORT)


### PR DESCRIPTION
Partial fix for #483, section 1 only ("Package loading: ~11 s, once per container"). Sections 2 to 4 (parallel Stan chains, plot gating, the SQS cap) are out of scope here and being handled separately.

## Problem

`rtma_model.R:5` runs `library(phacking)` at `source()` time, and `source()` happens per request (`index.R:94`, `api_v1.R:567`). Nothing preloaded phacking, so the first RTMA request in every fresh Lambda container paid the package load cost, plus ragg warming its font cache on the first plot render.

## Fix

`host.R` now loads `rtma_model.R` (which pulls in phacking) and renders one throwaway `ragg::agg_png` plot via the existing `render_z_density_plot()` helper, once per container, right before `pr$run()` starts listening. No request pays that cost anymore.

## Trade-off

Every container now pays this preload at startup, including containers that end up serving only MAIVE requests. A cold MAIVE-only container waits behind it too, even though it never touches phacking. The issue's suggested follow-up, a scheduled `/health` keep-warm ping, would avoid this by keeping containers warm instead of letting them go cold; that is not implemented here.

## Verification

Local plumber server (`Rscript host.R` via `C:\Program Files\R\R-4.4.2\bin\Rscript.exe`, phacking 0.2.1), fresh process for each measurement, demo dataset (`scripts/mock-csv/data/Havranek Demo.csv`, k=73):

| | first RTMA request | second RTMA request |
|---|---|---|
| Before | 24.64s | 10.77s |
| After | 7.54s | 8.28s |

The first request now costs about the same as the second, confirming the preload absorbed the one-time cost. Both runs returned mu around 5.171 to 5.172, matching the documented reference for this dataset. Startup log shows the preload itself taking about 3.5s, added once to container boot rather than to a request.

Also confirmed post-startup: a MAIVE request and an RTMA request against the same warm server both return 200 with correct results.
