### PR TITLE
fix: raise SQS queue ceiling from 256KB to 1MiB

### DIFF
--- a/apps/react-ui/client/src/api/server/runsService.ts
+++ b/apps/react-ui/client/src/api/server/runsService.ts
@@ -20,9 +20,11 @@ export const runsTableName = process.env.RUNS_TABLE_NAME;
 export const runsQueueUrl = process.env.RUNS_QUEUE_URL;
 
 export const TTL_SECONDS = CONST.RUNS.TTL_SECONDS; // 48h pickup buffer
-// Keep the SQS message under the 256KB hard limit; larger datasets fall back
-// to the synchronous path (which posts directly to the R Lambda).
-export const MAX_QUEUE_BODY_BYTES = 200 * 1024;
+// SQS raised its hard message-size limit to 1 MiB in August 2025 (was 256KB).
+// Budget ~900 KiB of that for the message body, leaving headroom for the
+// envelope (jobId, modelType, parameters); larger datasets fall back to the
+// synchronous path (which posts directly to the R Lambda).
+export const MAX_QUEUE_BODY_BYTES = 900 * 1024;
 export const MAX_BATCH_IDS = 100; // DynamoDB BatchGetItem caps at 100 keys
 
 let ddbDocClient: DynamoDBDocumentClient | undefined;

--- a/apps/react-ui/client/src/components/ApiDocs/apiDocsContent.ts
+++ b/apps/react-ui/client/src/components/ApiDocs/apiDocsContent.ts
@@ -345,7 +345,7 @@ export const ERROR_CODES: ErrorCodeRow[] = [
     code: "payload_too_large",
     status: "413",
     meaning:
-      "The dataset is too large to queue (roughly 200KB of JSON). Use a synchronous endpoint instead.",
+      "The dataset is too large to queue (roughly 900KB of JSON). Use a synchronous endpoint instead.",
   },
   {
     code: "rate_limited",

--- a/apps/react-ui/client/src/pages/api/v1/runs.ts
+++ b/apps/react-ui/client/src/pages/api/v1/runs.ts
@@ -99,7 +99,7 @@ const handler = async (
     return sendApiError(
       res,
       "payload_too_large",
-      "Dataset is too large to queue for async processing (~200KB limit). Use the synchronous endpoint (POST /v1/run-model or /v1/run-rtma) instead.",
+      "Dataset is too large to queue for async processing (~900KB limit). Use the synchronous endpoint (POST /v1/run-model or /v1/run-rtma) instead.",
     );
   }
 

--- a/apps/react-ui/client/src/tests/apiRunsLegacy.test.ts
+++ b/apps/react-ui/client/src/tests/apiRunsLegacy.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { createMockReq, createMockRes } from "@tests/helpers/nextApiMocks";
+import { MAX_QUEUE_BODY_BYTES } from "@api/server/runsService";
 
 const { ddbSendMock, sqsSendMock } = vi.hoisted(() => ({
   ddbSendMock: vi.fn(),
@@ -61,13 +62,37 @@ describe("legacy /api/runs (unchanged behavior)", () => {
     expect(res.body).toEqual({ error: "Async runs are not configured." });
   });
 
-  it("returns 200 { tooLarge: true } for an oversized submission", async () => {
+  it("queues a submission between the 200 KiB and ~900 KiB budget instead of falling back", async () => {
+    setConfigured();
+    ddbSendMock.mockResolvedValue({});
+    sqsSendMock.mockResolvedValue({});
+    const { default: handler } = await import("@src/pages/api/runs");
+    const req = createMockReq({
+      method: "POST",
+      body: {
+        // Above the old 200 KiB cap, comfortably under the ~900 KiB budget.
+        data: "x".repeat(500 * 1024),
+        parameters: {},
+        modelType: "MAIVE",
+      },
+    });
+    const res = createMockRes();
+
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toHaveProperty("jobId");
+    expect(ddbSendMock).toHaveBeenCalledTimes(1);
+    expect(sqsSendMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns 200 { tooLarge: true } for a submission just above the ~900 KiB budget", async () => {
     setConfigured();
     const { default: handler } = await import("@src/pages/api/runs");
     const req = createMockReq({
       method: "POST",
       body: {
-        data: "x".repeat(300 * 1024),
+        data: "x".repeat(MAX_QUEUE_BODY_BYTES + 1024),
         parameters: {},
         modelType: "MAIVE",
       },

--- a/apps/react-ui/client/src/tests/apiV1Runs.test.ts
+++ b/apps/react-ui/client/src/tests/apiV1Runs.test.ts
@@ -103,6 +103,7 @@ describe("POST /api/v1/runs", () => {
   it("413s with payload_too_large for an oversized submission (not the legacy tooLarge signal)", async () => {
     setConfigured();
     const { default: handler } = await import("@src/pages/api/v1/runs");
+    // Comfortably above the ~900 KiB budget.
     const bigData = Array.from({ length: 4 }, (_, i) => ({
       effect: 0.1 + i,
       se: 0.1,
@@ -116,6 +117,29 @@ describe("POST /api/v1/runs", () => {
 
     expect(res.statusCode).toBe(413);
     expect(res.body).toMatchObject({ error: { code: "payload_too_large" } });
+  });
+
+  it("queues a submission between the 200 KiB and ~900 KiB budget instead of 413ing", async () => {
+    setConfigured();
+    ddbSendMock.mockResolvedValue({});
+    sqsSendMock.mockResolvedValue({});
+    const { default: handler } = await import("@src/pages/api/v1/runs");
+    // Above the old 200 KiB cap, comfortably under the ~900 KiB budget.
+    const midData = Array.from({ length: 4 }, (_, i) => ({
+      effect: 0.1 + i,
+      se: 0.1,
+      n_obs: 10,
+      study_id: "x".repeat(100 * 1024),
+    }));
+    const req = createMockReq({ method: "POST", body: { data: midData } });
+    const res = createMockRes();
+
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toHaveProperty("jobId");
+    expect(ddbSendMock).toHaveBeenCalledTimes(1);
+    expect(sqsSendMock).toHaveBeenCalledTimes(1);
   });
 
   it("applies CONFIG.DEFAULT_MODEL_PARAMETERS defaults and derives shouldUseInstrumenting when parameters/modelType are omitted", async () => {

--- a/docs/PUBLIC_API.md
+++ b/docs/PUBLIC_API.md
@@ -276,7 +276,7 @@ Two independent guardrails apply, load-bearing in this order:
 
 Both are documented starting points and may be tuned based on observed load
 Treat any `429` as "retry with backoff," not a hard quota. Datasets that
-are too large to queue asynchronously (roughly 200KB of JSON) get `413
+are too large to queue asynchronously (roughly 900KB of JSON) get `413
 payload_too_large` pointing you at the synchronous endpoint instead.
 
 All errors share one envelope:

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -394,7 +394,7 @@ components:
               message: "Method Not Allowed"
     PayloadTooLarge:
       description: >-
-        The dataset is too large to queue (SQS message budget, ~200KB). Use
+        The dataset is too large to queue (SQS message budget, ~900KB). Use
         the synchronous endpoint instead.
       content:
         application/json:

--- a/terraform/stacks/prod-runtime/runs_queue.tf
+++ b/terraform/stacks/prod-runtime/runs_queue.tf
@@ -6,13 +6,15 @@
 resource "aws_sqs_queue" "runs_dlq" {
   name                      = "${var.project}-runs-dlq"
   message_retention_seconds = 1209600 # 14 days
+  max_message_size          = 1048576 # 1 MiB (SQS max since Aug 2025, was 256KB)
   tags                      = { Project = var.project }
 }
 
 resource "aws_sqs_queue" "runs" {
   name                       = "${var.project}-runs"
-  visibility_timeout_seconds = 660   # > R Lambda timeout (600s) + overhead
-  message_retention_seconds  = 86400 # 1 day
+  visibility_timeout_seconds = 660     # > R Lambda timeout (600s) + overhead
+  message_retention_seconds  = 86400   # 1 day
+  max_message_size           = 1048576 # 1 MiB (SQS max since Aug 2025, was 256KB)
   redrive_policy = jsonencode({
     deadLetterTargetArn = aws_sqs_queue.runs_dlq.arn
     maxReceiveCount     = 1


### PR DESCRIPTION
Part of #483 (section 4, SQS cap portion only; the S3 input-pointer escape hatch and the pre-flight sync runtime gate are separately scoped for a later session).

## Problem

`MAX_QUEUE_BODY_BYTES` in [runsService.ts](apps/react-ui/client/src/api/server/runsService.ts) capped async queue submissions at 200 KiB, citing a "256KB hard limit" that SQS raised to 1 MiB in August 2025. The UI defaults to async, and `submission.tooLarge` degrades to the synchronous path, so the largest and slowest datasets were the ones pushed onto the route Cloudflare kills at roughly 100s (observed HTTP 524 on a 1,159-estimate dataset that the async route completes).

## Changes

- `terraform/stacks/prod-runtime/runs_queue.tf`: set `max_message_size = 1048576` (1 MiB) on both the `runs` and `runs_dlq` queues.
- `runsService.ts`: raise `MAX_QUEUE_BODY_BYTES` from 200 KiB to 900 KiB, leaving roughly 124 KiB of headroom under the 1 MiB SQS ceiling for the message envelope (jobId, modelType, parameters).
- Updated the handful of places that echoed the old "~200KB" figure back to API callers so they stay accurate: the `/v1/runs` `payload_too_large` message, the in-app API docs page, `docs/api/openapi.yaml`, and `docs/PUBLIC_API.md`.
- Tests: a payload between 200 KiB and 900 KiB now queues instead of hitting the tooLarge/413 fallback (both the legacy `/api/runs` and public `/v1/runs` routes); a payload just above the 900 KiB budget still returns the fallback.

## Deployment order

This code change is safe to deploy before `terraform apply` runs (that apply is the user's action to take after this merges), but the order still matters:

**Apply terraform first, then deploy the app.** SQS's `SendMessage` validates the message body against the queue's configured `MaximumMessageSize` and rejects an oversized message synchronously with a client error; it does not truncate or silently accept it. Today, with `max_message_size` unset on both queues, they sit at SQS's default of 262,144 bytes (256 KiB). If the app's 900 KiB budget ships before the queue's cap is raised, any submission between 256 KiB and 900 KiB would pass the client-side check, have its DynamoDB "queued" record written, and then fail on `SendMessageCommand` with a thrown error, i.e. an orphaned DynamoDB record and a 500 instead of a clean fallback. Applying the terraform change first removes that gap entirely, since the client budget (900 KiB) stays under the queue's ceiling (1 MiB) either way.

## Verification

- `npx vitest run`: all suites pass (150 tests, including the new/updated ones above).
- `npx tsc --noEmit`: no new errors (the pre-existing `src/tests/integration/results.test.tsx` error is unrelated).
- Formatting checked per changed file via `git show :path | npx prettier --stdin-filepath path` against the staged content (avoids CRLF noise from `core.autocrlf=true`); no diffs on any touched TypeScript file.
