### PR TITLE
fix: canonicalize async run columns before queuing for RTMA/MAIVE

### DIFF
--- a/apps/react-ui/client/src/api/server/datasetValidation.ts
+++ b/apps/react-ui/client/src/api/server/datasetValidation.ts
@@ -35,9 +35,12 @@ const findKeyCaseInsensitive = (
 
 /**
  * Resolves the effect/se/n_obs/study_id columns from the first row: by
- * canonical name when `effect`, `se`, and `n_obs` are all present; otherwise
- * positionally, taking the first 3-4 keys in order (D5). Positional fallback
- * also covers RTMA's 2-column (effect, se) shape.
+ * canonical name whenever `effect` and `se` are both present, picking up
+ * `n_obs`/`study_id` by name too when they're there; otherwise positionally,
+ * taking the first 3-4 keys in order (D5). Positional fallback also covers
+ * RTMA's 2-column (effect, se) shape when neither key is named (#488: an
+ * earlier version required `n_obs` too, so a named-but-swapped RTMA payload
+ * always fell through to positional resolution).
  */
 export const resolveColumns = (
   rows: Array<Record<string, unknown>>,
@@ -52,7 +55,7 @@ export const resolveColumns = (
   const nObsKey = findKeyCaseInsensitive(first, "n_obs");
   const studyIdKey = findKeyCaseInsensitive(first, "study_id");
 
-  if (effectKey && seKey && nObsKey) {
+  if (effectKey && seKey) {
     return {
       effect: effectKey,
       se: seKey,
@@ -74,6 +77,33 @@ export const resolveColumns = (
     byName: false,
   };
 };
+
+/**
+ * Reorders each row into canonical column order (effect, se, n_obs?,
+ * study_id?) per `resolveColumns`' resolution. The async queue path (design
+ * D8) hands rows to the orchestrator, which posts them to the legacy R
+ * routes that read columns positionally rather than by name; canonicalizing
+ * here before queuing keeps that positional read in sync with whatever this
+ * validator resolved by name (#488), rather than the two paths silently
+ * relying on two different resolution rules.
+ */
+export const canonicalizeRows = (
+  rows: Array<Record<string, unknown>>,
+  columns: ResolvedColumns,
+): Array<Record<string, unknown>> =>
+  rows.map((row) => {
+    const canonical: Record<string, unknown> = {
+      effect: row[columns.effect],
+      se: row[columns.se],
+    };
+    if (columns.nObs) {
+      canonical.n_obs = row[columns.nObs];
+    }
+    if (columns.studyId) {
+      canonical.study_id = row[columns.studyId];
+    }
+    return canonical;
+  });
 
 const isFiniteNumber = (value: unknown): boolean => {
   if (typeof value === "number") {

--- a/apps/react-ui/client/src/pages/api/v1/runs.ts
+++ b/apps/react-ui/client/src/pages/api/v1/runs.ts
@@ -9,7 +9,11 @@ import {
   submitRun,
 } from "@api/server/runsService";
 import { resolveRunParameters } from "@api/server/modelParameterDefaults";
-import { validateDataset } from "@api/server/datasetValidation";
+import {
+  canonicalizeRows,
+  resolveColumns,
+  validateDataset,
+} from "@api/server/datasetValidation";
 import { sendApiError, type ApiErrorBody } from "@api/server/errorEnvelope";
 
 // Public re-skin of `/api/runs` (design D8, §6.5): same DynamoDB/SQS
@@ -87,12 +91,24 @@ const handler = async (
     return sendApiError(res, "validation_error", validationError.message);
   }
 
+  // Queue rows in canonical column order, not as originally submitted: the
+  // orchestrator posts queued rows to the legacy R routes, which read
+  // columns positionally, so this must match the column resolution
+  // validateDataset just used above (#488).
+  const rows = data as Array<Record<string, unknown>>;
+  const columns = resolveColumns(rows);
+  const canonicalData = columns ? canonicalizeRows(rows, columns) : data;
+
   const submission = await submitRun(
     store.ddb,
     queue.sqs,
     store.tableName,
     queue.queueUrl,
-    { data, parameters: resolved.parameters, modelType: resolved.modelType },
+    {
+      data: canonicalData,
+      parameters: resolved.parameters,
+      modelType: resolved.modelType,
+    },
   );
 
   if (submission.outcome === "too_large") {

--- a/apps/react-ui/client/src/tests/apiV1Runs.test.ts
+++ b/apps/react-ui/client/src/tests/apiV1Runs.test.ts
@@ -43,6 +43,15 @@ type PutCall = {
 const getLastPutCall = (): PutCall =>
   ddbSendMock.mock.calls[ddbSendMock.mock.calls.length - 1][0] as PutCall;
 
+type SendMessageCall = { input: { MessageBody: string } };
+
+const getLastQueuedMessage = (): Record<string, unknown> => {
+  const call = sqsSendMock.mock.calls[
+    sqsSendMock.mock.calls.length - 1
+  ][0] as SendMessageCall;
+  return JSON.parse(call.input.MessageBody) as Record<string, unknown>;
+};
+
 beforeEach(() => {
   ENV_KEYS.forEach((key) => {
     savedEnv[key] = process.env[key];
@@ -202,6 +211,55 @@ describe("POST /api/v1/runs", () => {
       ciLevel: 0.95,
       winsorize: 0,
     });
+  });
+
+  it("queues RTMA rows in canonical column order even when effect/se keys are swapped (#488)", async () => {
+    setConfigured();
+    ddbSendMock.mockResolvedValue({});
+    sqsSendMock.mockResolvedValue({});
+    const { default: handler } = await import("@src/pages/api/v1/runs");
+    const req = createMockReq({
+      method: "POST",
+      body: {
+        // Same repro shape as the issue: `se` named first, `effect` second.
+        // The orchestrator posts queued rows to the legacy positional
+        // /run-rtma route, so this must land in the queue as effect-then-se
+        // regardless of the submitted key order.
+        data: [
+          { se: 0.12, effect: -0.4 },
+          { se: 0.08, effect: 0.25 },
+        ],
+        modelType: "RTMA",
+      },
+    });
+    const res = createMockRes();
+
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(200);
+    const queued = getLastQueuedMessage();
+    expect(queued.data).toEqual([
+      { effect: -0.4, se: 0.12 },
+      { effect: 0.25, se: 0.08 },
+    ]);
+  });
+
+  it("leaves already-canonical MAIVE rows unchanged in the queued message", async () => {
+    setConfigured();
+    ddbSendMock.mockResolvedValue({});
+    sqsSendMock.mockResolvedValue({});
+    const { default: handler } = await import("@src/pages/api/v1/runs");
+    const req = createMockReq({
+      method: "POST",
+      body: { data: validMaiveData },
+    });
+    const res = createMockRes();
+
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(200);
+    const queued = getLastQueuedMessage();
+    expect(queued.data).toEqual(validMaiveData);
   });
 
   it("405s with method_not_allowed for unsupported methods", async () => {

--- a/apps/react-ui/client/src/tests/datasetValidation.test.ts
+++ b/apps/react-ui/client/src/tests/datasetValidation.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import {
   MAX_ROWS,
+  canonicalizeRows,
   resolveColumns,
   validateDataset,
 } from "@api/server/datasetValidation";
@@ -67,6 +68,62 @@ describe("resolveColumns", () => {
 
   it("returns null for an empty row", () => {
     expect(resolveColumns([{}])).toBeNull();
+  });
+
+  it("resolves a 2-column RTMA payload by name even with keys in swapped order (#488)", () => {
+    // Same shape as the issue's repro: `se` is the first key, `effect` the
+    // second, and `n_obs` is absent (RTMA is a 2-column model). Requiring
+    // `n_obs` before trusting the names used to force this through the
+    // positional branch, which read `se`'s values as `effect` and vice versa.
+    const columns = resolveColumns([{ se: 0.12, effect: -0.4 }]);
+    expect(columns).toEqual({
+      effect: "effect",
+      se: "se",
+      nObs: undefined,
+      studyId: undefined,
+      byName: true,
+    });
+  });
+});
+
+const resolveColumnsOrThrow = (rows: Array<Record<string, unknown>>) => {
+  const columns = resolveColumns(rows);
+  if (!columns) {
+    throw new Error("expected resolveColumns to resolve columns");
+  }
+  return columns;
+};
+
+describe("canonicalizeRows", () => {
+  it("reorders swapped effect/se keys into canonical column order (#488)", () => {
+    const rows = [
+      { se: 0.12, effect: -0.4 },
+      { se: 0.08, effect: 0.25 },
+    ];
+    const columns = resolveColumnsOrThrow(rows);
+    expect(columns.byName).toBe(true);
+    expect(canonicalizeRows(rows, columns)).toEqual([
+      { effect: -0.4, se: 0.12 },
+      { effect: 0.25, se: 0.08 },
+    ]);
+  });
+
+  it("is a no-op reshuffle for already-canonical MAIVE rows", () => {
+    const rows = [
+      { effect: 0.1, se: 0.2, n_obs: 10, study_id: "A" },
+      { effect: 0.3, se: 0.1, n_obs: 20, study_id: "B" },
+    ];
+    const columns = resolveColumnsOrThrow(rows);
+    expect(canonicalizeRows(rows, columns)).toEqual(rows);
+  });
+
+  it("keeps positional resolution's column order for non-canonical names", () => {
+    const rows = [{ b: 0.5, s: 0.1, n: 100, study: "A" }];
+    const columns = resolveColumnsOrThrow(rows);
+    expect(columns.byName).toBe(false);
+    expect(canonicalizeRows(rows, columns)).toEqual([
+      { effect: 0.5, se: 0.1, n_obs: 100, study_id: "A" },
+    ]);
   });
 });
 
@@ -221,5 +278,17 @@ describe("validateDataset: RTMA", () => {
       { effect: 0.2, se: -1 },
     ];
     expect(validateDataset(data, "RTMA")?.message).toMatch(/se.*positive/);
+  });
+
+  it("does not misfire the se-positivity check when effect/se keys are swapped (#488)", () => {
+    // Same repro shape as the issue: `se` named first, `effect` second, with
+    // a negative effect value. Before the fix, positional fallback read the
+    // `effect` values as `se` and tripped this check even though every real
+    // `se` value is positive.
+    const data = [
+      { se: 0.12, effect: -0.4 },
+      { se: 0.08, effect: 0.25 },
+    ];
+    expect(validateDataset(data, "RTMA")).toBeNull();
   });
 });


### PR DESCRIPTION
## The bug

`resolveColumns` in datasetValidation.ts only resolved effect/se/n_obs by canonical name when all three were present. RTMA payloads have just two columns (effect, se), so they always fell through to positional resolution, even when both columns were correctly named. `pages/api/v1/runs.ts` then queued the original, unreordered row objects; the orchestrator posts those to the legacy `/run-rtma` route, and `rtma_model.R` reads `df[[1]]` and `df[[2]]` positionally. A payload with effect/se named but in swapped key order fit correctly on the sync `/v1/run-rtma` endpoint but broke, or worse, silently fit the wrong model, on the async `/v1/runs` path.

## The fix

The issue offers two options: canonicalize rows in the validator before queuing, or point the orchestrator at the /v1 handler so both paths share one resolution rule. I picked the first. It is a change confined to the TS layer (datasetValidation.ts and runs.ts), while repointing the orchestrator would also mean reworking its request and response shapes to match /v1's plain-JSON body and nested error envelope, touching both the MAIVE and RTMA legacy contracts along the way. Canonicalizing keeps that surface untouched and gets to the same outcome: one resolution rule, used before both the sync R call and the async queue.

Two changes:

- `resolveColumns` now resolves effect/se by name whenever both are present, instead of requiring `n_obs` too. That was the actual root cause: a 2-column RTMA payload can never satisfy "effect, se, and n_obs all present," so it always fell to positional resolution regardless of how the caller named its columns.
- `runs.ts` now reorders each row into canonical column order (effect, se, n_obs?, study_id?) before handing it to `submitRun`, so the orchestrator's positional read of the legacy R routes lines up with what the validator resolved by name.

This also closes the same class of bug for MAIVE's 3/4-column payloads (maive_model.R renames columns positionally too), not just RTMA. The MAIVE async path is unchanged for the canonical, in-order case that's actually tested and used.

## Testing

- `npx vitest run`: 155 tests pass across 24 files, including new regression tests reproducing the issue's exact swapped-key shape at both the validator level (`datasetValidation.test.ts`) and the queued-message level (`apiV1Runs.test.ts`).
- `npx tsc --noEmit`: one pre-existing error in `src/tests/integration/results.test.tsx`, unrelated to this change.
- Traced both request paths by hand: `api_v1.R`'s `api_v1_resolve_rtma_columns` (sync) and the newly canonicalized queue payload (async) now select the same effect/se columns from a swapped-key body.

Fixes #488.
