### PR TITLE
fix: preserve API error status and message through the UI stack

### DIFF
--- a/apps/lambda-r-backend/r_scripts/rtma_model.R
+++ b/apps/lambda-r-backend/r_scripts/rtma_model.R
@@ -188,7 +188,7 @@ run_rtma_model <- function(data, parameters) {
         grepl("elapsed time limit", err_message, fixed = TRUE)) {
         cli::cli_abort(c(
           "RTMA timed out after {timeout_sec} seconds.",
-          "i" = "This dataset makes the sampler diverge. Try winsorizing outliers or reducing the number of estimates."
+          "i" = "The run exceeded its time budget before finishing; this does not necessarily mean it diverged. Try winsorizing outliers or reducing the number of estimates."
         ))
       }
       cli::cli_alert_danger(paste("RTMA error:", err_message))

--- a/apps/react-ui/client/src/api/server/runsService.ts
+++ b/apps/react-ui/client/src/api/server/runsService.ts
@@ -48,6 +48,28 @@ export const getSqsClient = (): SQSClient | undefined => {
   return sqsClient;
 };
 
+// Statuses that mean the run did not produce a usable result. The orchestrator
+// (apps/orchestrator/src/index.ts) always writes an errorMessage alongside
+// these, but a caller (this route, or a future writer) should never have to
+// rely on that being true elsewhere: a failed/timed-out run with nothing in
+// errorMessage leaves the caller (including a `/v1` API consumer scripting
+// against `run.errorMessage`) with no way to know what happened.
+const FAILURE_STATUSES: ReadonlySet<RunStatus> = new Set<RunStatus>([
+  "failed",
+  "timedout",
+]);
+const FALLBACK_FAILURE_MESSAGE =
+  "The run failed, but no error details were recorded. Please try again.";
+
+const withFailureFallback = <
+  T extends { status: RunStatus; errorMessage?: string },
+>(
+  item: T,
+): T =>
+  FAILURE_STATUSES.has(item.status) && !item.errorMessage
+    ? { ...item, errorMessage: FALLBACK_FAILURE_MESSAGE }
+    : item;
+
 export type RunsStoreConfig = {
   ddb: DynamoDBDocumentClient;
   tableName: string;
@@ -120,18 +142,20 @@ export const batchGetRunStatuses = async (
   );
 
   const items = out.Responses?.[tableName] ?? [];
-  return items.map((item) => ({
-    jobId: item.jobId as string,
-    status: item.status as RunStatus,
-    modelType: item.modelType as GetRunResponse["modelType"],
-    errorMessage: (item.errorMessage as string | undefined) ?? undefined,
-    runDurationMs:
-      typeof item.runDurationMs === "number" ? item.runDurationMs : undefined,
-    runTimestamp:
-      typeof item.submittedAt === "number"
-        ? new Date(item.submittedAt).toISOString()
-        : undefined,
-  }));
+  return items.map((item) =>
+    withFailureFallback({
+      jobId: item.jobId as string,
+      status: item.status as RunStatus,
+      modelType: item.modelType as GetRunResponse["modelType"],
+      errorMessage: (item.errorMessage as string | undefined) ?? undefined,
+      runDurationMs:
+        typeof item.runDurationMs === "number" ? item.runDurationMs : undefined,
+      runTimestamp:
+        typeof item.submittedAt === "number"
+          ? new Date(item.submittedAt).toISOString()
+          : undefined,
+    }),
+  );
 };
 
 export type RunItem = {
@@ -171,7 +195,7 @@ export const getRunItem = async (
     return undefined;
   }
 
-  return Item as RunItem;
+  return withFailureFallback(Item as RunItem);
 };
 
 export type SubmitRunParams = {

--- a/apps/react-ui/client/src/api/services/modelService.ts
+++ b/apps/react-ui/client/src/api/services/modelService.ts
@@ -50,9 +50,12 @@ export class ModelService {
         },
       );
     } catch (error: unknown) {
-      throw new Error(
-        `Failed to run model: ${error instanceof Error ? error.message : "Unknown error"}`,
-      );
+      // Preserve the original error (e.g. ApiRequestError with its status/code,
+      // or an AbortError) instead of burying it behind a generic message.
+      if (error instanceof Error) {
+        throw error;
+      }
+      throw new Error("Failed to run model.");
     }
   }
 
@@ -87,9 +90,10 @@ export class ModelService {
         },
       );
     } catch (error: unknown) {
-      throw new Error(
-        `Failed to run RTMA model: ${error instanceof Error ? error.message : "Unknown error"}`,
-      );
+      if (error instanceof Error) {
+        throw error;
+      }
+      throw new Error("Failed to run RTMA model.");
     }
   }
 
@@ -114,9 +118,10 @@ export class ModelService {
         },
       );
     } catch (error: unknown) {
-      throw new Error(
-        `Failed to fetch runs: ${error instanceof Error ? error.message : "Unknown error"}`,
-      );
+      if (error instanceof Error) {
+        throw error;
+      }
+      throw new Error("Failed to fetch runs.");
     }
   }
 
@@ -153,9 +158,10 @@ export class ModelService {
         },
       );
     } catch (error: unknown) {
-      throw new Error(
-        `Failed to submit run: ${error instanceof Error ? error.message : "Unknown error"}`,
-      );
+      if (error instanceof Error) {
+        throw error;
+      }
+      throw new Error("Failed to submit run.");
     }
   }
 
@@ -176,9 +182,10 @@ export class ModelService {
         },
       );
     } catch (error: unknown) {
-      throw new Error(
-        `Failed to fetch run: ${error instanceof Error ? error.message : "Unknown error"}`,
-      );
+      if (error instanceof Error) {
+        throw error;
+      }
+      throw new Error("Failed to fetch run.");
     }
   }
 }

--- a/apps/react-ui/client/src/api/utils/http.ts
+++ b/apps/react-ui/client/src/api/utils/http.ts
@@ -1,4 +1,31 @@
-import type { ApiConfig, ApiError } from "@src/types";
+import type { ApiConfig } from "@src/types";
+
+/**
+ * Error thrown for a non-2xx HTTP response. Carries the response's status
+ * code and, when the backend returned a structured error envelope
+ * (`{ error: { code, message } }`, used by the public `/v1` API) or the
+ * legacy `{ error: string }` / `{ message: string }` shape, the parsed
+ * message and code. Being a real `Error` subclass, it survives the
+ * `error instanceof Error` check in `httpRequest` below instead of being
+ * replaced with a generic message, and callers can branch on `status`/`code`
+ * (e.g. to show tailored guidance for a 429) instead of losing that
+ * information.
+ */
+export class ApiRequestError extends Error {
+  readonly status: number;
+
+  readonly code?: string;
+
+  constructor(message: string, status: number, code?: string) {
+    super(message);
+    this.name = "ApiRequestError";
+    this.status = status;
+    this.code = code;
+    // Keeps `instanceof ApiRequestError` working after transpilation, which
+    // can otherwise break the prototype chain for classes extending Error.
+    Object.setPrototypeOf(this, ApiRequestError.prototype);
+  }
+}
 
 /**
  * Create an AbortController for request timeout
@@ -11,33 +38,41 @@ function createTimeoutController(timeout: number): AbortController {
   return controller;
 }
 
+type ErrorResponseBody = {
+  message?: string;
+  error?: string | { code?: string; message?: string };
+};
+
 /**
  * Handle HTTP response and throw errors if needed
  * @param response - Fetch response
  * @returns Response if successful
- * @throws Error if response is not ok
+ * @throws ApiRequestError if response is not ok
  */
 async function handleResponse<T>(response: Response): Promise<T> {
   if (!response.ok) {
     let errorMessage = `HTTP ${response.status}: ${response.statusText}`;
+    let errorCode: string | undefined;
 
     try {
-      const errorData = (await response.json()) as {
-        message?: string;
-        error?: string;
-      };
-      errorMessage = errorData.message ?? errorData.error ?? errorMessage;
+      const errorData = (await response.json()) as ErrorResponseBody;
+
+      if (errorData.error && typeof errorData.error === "object") {
+        // Structured `/v1` envelope: { error: { code, message } }
+        errorMessage = errorData.error.message ?? errorMessage;
+        errorCode = errorData.error.code;
+      } else {
+        // Legacy shape: { error: string } or { message: string }
+        errorMessage =
+          errorData.message ??
+          (typeof errorData.error === "string" ? errorData.error : undefined) ??
+          errorMessage;
+      }
     } catch {
       // If we can't parse the error response, use the default message
     }
 
-    const error: ApiError = {
-      message: errorMessage,
-      status: response.status,
-    };
-
-    // eslint-disable-next-line @typescript-eslint/no-throw-literal
-    throw error;
+    throw new ApiRequestError(errorMessage, response.status, errorCode);
   }
 
   return response.json() as Promise<T>;

--- a/apps/react-ui/client/src/pages/model/index.tsx
+++ b/apps/react-ui/client/src/pages/model/index.tsx
@@ -26,7 +26,7 @@ import { modelOptionsConfig } from "@src/config/optionsConfig";
 import { hasNObsColumn, hasStudyIdColumn } from "@src/utils/dataUtils";
 import { useEnterKeyAction } from "@src/hooks/useEnterKeyAction";
 import { detectAndDispatchAlerts } from "@src/utils/parameterChangeTracking";
-import { cleanCliErrorMessage } from "@src/utils/errorMessageUtils";
+import { getUserFacingRunErrorMessage } from "@src/utils/errorMessageUtils";
 import { requestNotificationPermission } from "@src/utils/notifications";
 import { getUploadedData as getCachedUploadedData } from "@src/utils/dataCacheDb";
 
@@ -911,11 +911,7 @@ export default function ModelPage() {
         }
         console.error("Error running model:", error);
         if (isMountedRef.current) {
-          const msg = cleanCliErrorMessage(
-            "An error occurred while running the model: " +
-              (error instanceof Error ? error.message : String(error)),
-          );
-          showAlert(msg, "error");
+          showAlert(getUserFacingRunErrorMessage(error), "error");
           setLoading(false);
           setHasRunModel(false);
         }

--- a/apps/react-ui/client/src/tests/apiRunsJobIdLegacy.test.ts
+++ b/apps/react-ui/client/src/tests/apiRunsJobIdLegacy.test.ts
@@ -76,6 +76,27 @@ describe("legacy /api/runs/[jobId] (unchanged behavior)", () => {
     expect(res.body).toEqual({ error: "Run not found or expired." });
   });
 
+  it("always includes an errorMessage for a failed run, even if the store has none", async () => {
+    setConfigured();
+    ddbSendMock.mockResolvedValue({
+      Item: {
+        jobId: "abc",
+        status: "failed",
+        modelType: "MAIVE",
+      },
+    });
+    const { default: handler } = await import("@src/pages/api/runs/[jobId]");
+    const req = createMockReq({ method: "GET", query: { jobId: "abc" } });
+    const res = createMockRes();
+
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(200);
+    const body = res.body as { status: string; errorMessage?: string };
+    expect(body.status).toBe("failed");
+    expect(body.errorMessage).toBeTruthy();
+  });
+
   it("returns `result` as the raw stored string (not parsed)", async () => {
     setConfigured();
     const storedResult = JSON.stringify({

--- a/apps/react-ui/client/src/tests/apiV1Runs.test.ts
+++ b/apps/react-ui/client/src/tests/apiV1Runs.test.ts
@@ -256,4 +256,22 @@ describe("GET /api/v1/runs (batch status)", () => {
       },
     ]);
   });
+
+  it("fills in an errorMessage for a failed run the store has none for", async () => {
+    setConfigured();
+    const responses: Record<string, unknown[]> = {};
+    responses["runs-table"] = [
+      { jobId: "a", status: "failed", modelType: "MAIVE" },
+    ];
+    ddbSendMock.mockResolvedValue({ Responses: responses });
+    const { default: handler } = await import("@src/pages/api/v1/runs");
+    const req = createMockReq({ method: "GET", query: { ids: "a" } });
+    const res = createMockRes();
+
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(200);
+    const body = res.body as Array<{ errorMessage?: string }>;
+    expect(body[0].errorMessage).toBeTruthy();
+  });
 });

--- a/apps/react-ui/client/src/tests/apiV1RunsJobId.test.ts
+++ b/apps/react-ui/client/src/tests/apiV1RunsJobId.test.ts
@@ -141,6 +141,49 @@ describe("GET /api/v1/runs/[jobId]", () => {
     expect(body.result).toEqual(storedResult);
   });
 
+  it("always includes an errorMessage for a failed run, even if the store has none", async () => {
+    setConfigured();
+    ddbSendMock.mockResolvedValue({
+      Item: {
+        jobId: "abc",
+        status: "failed",
+        modelType: "MAIVE",
+        // No errorMessage stored (see #491: the store must not surface a
+        // terminal failure with nothing for the caller to act on).
+      },
+    });
+    const { default: handler } = await import("@src/pages/api/v1/runs/[jobId]");
+    const req = createMockReq({ method: "GET", query: { jobId: "abc" } });
+    const res = createMockRes();
+
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(200);
+    const body = res.body as { status: string; errorMessage?: string };
+    expect(body.status).toBe("failed");
+    expect(body.errorMessage).toBeTruthy();
+  });
+
+  it("preserves a stored errorMessage for a failed run instead of the fallback", async () => {
+    setConfigured();
+    ddbSendMock.mockResolvedValue({
+      Item: {
+        jobId: "abc",
+        status: "timedout",
+        modelType: "RTMA",
+        errorMessage: "RTMA timed out after 480 seconds.",
+      },
+    });
+    const { default: handler } = await import("@src/pages/api/v1/runs/[jobId]");
+    const req = createMockReq({ method: "GET", query: { jobId: "abc" } });
+    const res = createMockRes();
+
+    await handler(req, res);
+
+    const body = res.body as { errorMessage?: string };
+    expect(body.errorMessage).toBe("RTMA timed out after 480 seconds.");
+  });
+
   it("strips zScorePlot fields for RTMA results", async () => {
     setConfigured();
     const storedResult = {

--- a/apps/react-ui/client/src/tests/errorMessageUtils.test.ts
+++ b/apps/react-ui/client/src/tests/errorMessageUtils.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from "vitest";
+import { ApiRequestError } from "@api/utils/http";
+import {
+  cleanCliErrorMessage,
+  getUserFacingRunErrorMessage,
+} from "@src/utils/errorMessageUtils";
+
+// Covers the error-mapping half of #491: a 429, a genuine 500, and a network
+// failure must reach the user as three distinct, actionable messages instead
+// of all collapsing into "An unexpected error occurred", and a structured
+// API error's message (the `{ error: { code, message } }` envelope, or its
+// legacy equivalent) must survive unchanged to the page layer.
+describe("getUserFacingRunErrorMessage", () => {
+  it("shows retry guidance for a 429, regardless of message/code", () => {
+    const message = getUserFacingRunErrorMessage(
+      new ApiRequestError("Too many requests.", 429, "rate_limited"),
+    );
+
+    expect(message).toMatch(/busy/i);
+    expect(message).toMatch(/try again/i);
+  });
+
+  it("preserves the envelope message for a non-429 ApiRequestError", () => {
+    const message = getUserFacingRunErrorMessage(
+      new ApiRequestError("R backend returned HTTP 500", 500),
+    );
+
+    expect(message).toBe("R backend returned HTTP 500");
+  });
+
+  it("strips a generic server prefix but keeps the underlying message", () => {
+    const message = getUserFacingRunErrorMessage(
+      new ApiRequestError(
+        "Internal server error: Data must have exactly 3 or 4 columns.",
+        500,
+      ),
+    );
+
+    expect(message).toBe("Data must have exactly 3 or 4 columns.");
+  });
+
+  it("gives network failures a distinct, connection-focused message", () => {
+    const message = getUserFacingRunErrorMessage(
+      new TypeError("Failed to fetch"),
+    );
+
+    expect(message).toMatch(/network/i);
+    expect(message).toMatch(/connection/i);
+  });
+
+  it("falls back to a generic message for a non-Error throw", () => {
+    const message = getUserFacingRunErrorMessage("boom");
+
+    expect(message).toMatch(/unexpected error/i);
+  });
+
+  it("produces three distinct messages for 429 vs 500 vs a network failure", () => {
+    const rateLimited = getUserFacingRunErrorMessage(
+      new ApiRequestError("Too many requests.", 429, "rate_limited"),
+    );
+    const serverError = getUserFacingRunErrorMessage(
+      new ApiRequestError("Internal server error: boom", 500),
+    );
+    const networkFailure = getUserFacingRunErrorMessage(
+      new TypeError("Failed to fetch"),
+    );
+
+    const messages = new Set([rateLimited, serverError, networkFailure]);
+    expect(messages.size).toBe(3);
+  });
+});
+
+describe("cleanCliErrorMessage", () => {
+  it("strips ANSI escape codes", () => {
+    expect(cleanCliErrorMessage("[1mBold[22m text")).toBe("Bold text");
+  });
+
+  it("strips a leading cli cross marker", () => {
+    expect(cleanCliErrorMessage("✖ Something went wrong")).toBe(
+      "Something went wrong",
+    );
+  });
+});

--- a/apps/react-ui/client/src/tests/httpErrorMapping.test.ts
+++ b/apps/react-ui/client/src/tests/httpErrorMapping.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { ApiRequestError } from "@api/utils/http";
+import { modelService } from "@api/services/modelService";
+
+// Covers apps/react-ui/client/src/api/utils/http.ts: a non-2xx response must
+// throw a real ApiRequestError (an Error subclass carrying status/code), not
+// a plain object, so a 429 and a 500 stay distinguishable all the way up to
+// the page layer instead of being flattened into "An unexpected error
+// occurred" by the `error instanceof Error` check in httpRequest().
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("httpRequest error mapping", () => {
+  it("throws an ApiRequestError with status/code from the /v1 error envelope", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          error: { code: "rate_limited", message: "Too many requests." },
+        }),
+        { status: 429 },
+      ),
+    );
+
+    const error = await modelService.getRun("job-1").catch((e: unknown) => e);
+
+    expect(error).toBeInstanceOf(ApiRequestError);
+    expect(error).toBeInstanceOf(Error);
+    const apiError = error as ApiRequestError;
+    expect(apiError.status).toBe(429);
+    expect(apiError.code).toBe("rate_limited");
+    expect(apiError.message).toBe("Too many requests.");
+  });
+
+  it("throws an ApiRequestError with the legacy { error: string } message for a 500", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ error: "Failed to fetch run." }), {
+        status: 500,
+      }),
+    );
+
+    const error = await modelService.getRun("job-1").catch((e: unknown) => e);
+
+    expect(error).toBeInstanceOf(ApiRequestError);
+    const apiError = error as ApiRequestError;
+    expect(apiError.status).toBe(500);
+    expect(apiError.code).toBeUndefined();
+    expect(apiError.message).toBe("Failed to fetch run.");
+  });
+
+  it("falls back to a generic status message when the error body isn't JSON", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response("<html>Bad Gateway</html>", {
+        status: 502,
+        statusText: "Bad Gateway",
+      }),
+    );
+
+    const error = await modelService.getRun("job-1").catch((e: unknown) => e);
+
+    expect(error).toBeInstanceOf(ApiRequestError);
+    const apiError = error as ApiRequestError;
+    expect(apiError.status).toBe(502);
+    expect(apiError.message).toContain("502");
+  });
+
+  it("propagates a network failure as the original Error, not a generic one", async () => {
+    const networkError = new TypeError("Failed to fetch");
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(networkError);
+
+    const error = await modelService.getRun("job-1").catch((e: unknown) => e);
+
+    expect(error).toBe(networkError);
+    expect(error).not.toBeInstanceOf(ApiRequestError);
+  });
+});

--- a/apps/react-ui/client/src/tests/modelServiceGetRuns.test.ts
+++ b/apps/react-ui/client/src/tests/modelServiceGetRuns.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { modelService } from "@api/services/modelService";
+import { ApiRequestError } from "@api/utils/http";
 
 describe("modelService.getRuns", () => {
   beforeEach(() => {
@@ -31,13 +32,15 @@ describe("modelService.getRuns", () => {
     expect(String(fetchSpy.mock.calls[0][0])).toBe("/api/runs?ids=a,b");
   });
 
-  it("throws a descriptive error when the endpoint fails", async () => {
+  it("preserves the backend's message and status instead of a generic wrapper", async () => {
     vi.spyOn(globalThis, "fetch").mockResolvedValue(
       new Response(JSON.stringify({ error: "boom" }), { status: 500 }),
     );
 
-    await expect(modelService.getRuns(["a"])).rejects.toThrow(
-      /Failed to fetch runs/,
-    );
+    const error = await modelService.getRuns(["a"]).catch((e: unknown) => e);
+
+    expect(error).toBeInstanceOf(ApiRequestError);
+    expect((error as ApiRequestError).status).toBe(500);
+    expect((error as Error).message).toBe("boom");
   });
 });

--- a/apps/react-ui/client/src/types/api.ts
+++ b/apps/react-ui/client/src/types/api.ts
@@ -175,13 +175,6 @@ type ApiConfig = {
   signal?: AbortSignal;
 };
 
-// Error types
-type ApiError = {
-  message: string;
-  status?: number;
-  code?: string;
-};
-
 export type {
   ModelParameters,
   ModelRequest,
@@ -191,7 +184,6 @@ export type {
   RTMAResults,
   PingResponse,
   ApiConfig,
-  ApiError,
   ApiResponse,
   RunStatus,
   SubmitRunResponse,

--- a/apps/react-ui/client/src/types/index.tsx
+++ b/apps/react-ui/client/src/types/index.tsx
@@ -9,7 +9,6 @@ import type {
   ModelResults,
   PingResponse,
   ApiConfig,
-  ApiError,
 } from "./api";
 import type DataArray from "./data";
 import type {
@@ -28,7 +27,6 @@ type EstimateType = DeepValueOf<typeof CONST.MODEL_TYPES> | "Unknown";
 
 export type {
   ApiConfig,
-  ApiError,
   DataArray,
   SubsampleFilterCondition,
   SubsampleFilterConditionNode,

--- a/apps/react-ui/client/src/utils/errorMessageUtils.ts
+++ b/apps/react-ui/client/src/utils/errorMessageUtils.ts
@@ -1,3 +1,5 @@
+import { ApiRequestError } from "@api/utils/http";
+
 /**
  * Removes ANSI escape codes and other terminal formatting artifacts from error messages.
  *
@@ -18,4 +20,32 @@ export function cleanCliErrorMessage(input: string): string {
 
   // If a layer prepended a generic server prefix, keep only the meaningful MAIVE message.
   return withoutCliMarkers.replace(/^internal server error:\s*/i, "");
+}
+
+const RATE_LIMIT_MESSAGE =
+  "The server is busy right now. Please wait a few seconds and try again.";
+const UNKNOWN_ERROR_MESSAGE =
+  "An unexpected error occurred while running the model.";
+
+/**
+ * Builds the message shown to the user for a failed run, distinguishing a
+ * rate limit (429, either from the edge or the R backend's concurrency cap)
+ * from other failures instead of collapsing both into one generic message.
+ * A structured API error's message (from the `{ error: { code, message } }`
+ * envelope or its legacy equivalent) is preserved as-is; only a genuinely
+ * unrecognized throw falls back to a generic message.
+ */
+export function getUserFacingRunErrorMessage(error: unknown): string {
+  if (error instanceof ApiRequestError && error.status === 429) {
+    return RATE_LIMIT_MESSAGE;
+  }
+  if (error instanceof TypeError) {
+    // fetch() rejects with a TypeError for network failures (offline, DNS,
+    // CORS, connection reset) rather than resolving with a response.
+    return "Network error: please check your connection and try again.";
+  }
+  if (error instanceof Error) {
+    return cleanCliErrorMessage(error.message);
+  }
+  return UNKNOWN_ERROR_MESSAGE;
 }


### PR DESCRIPTION
## Problem

`http.ts` threw a plain object instead of an `Error`. `httpRequest()` then replaced every
non-`Error` throw with "An unexpected error occurred", and two more generic prefixes were
added in `modelService.ts` and `pages/model/index.tsx`. A 429 (rate limit) and a genuine
500 reached the user as the same generic text, with no retry guidance, even though the API
returns a structured envelope (`{"error": {"code": ..., "message": ...}}`).

## Fix

- `http.ts` now throws `ApiRequestError`, an `Error` subclass carrying `status` and `code`,
  and `handleResponse` parses both the `/v1` envelope and the legacy `{ error: string }` /
  `{ message: string }` shapes.
- `modelService.ts` no longer wraps every caught error in a new generic `Error`; it
  rethrows `Error` instances (including `ApiRequestError` and `AbortError`) unchanged, so
  status/code and the original message survive.
- `pages/model/index.tsx` now calls a new `getUserFacingRunErrorMessage()` helper
  (`utils/errorMessageUtils.ts`) that shows dedicated "server is busy, try again in a few
  seconds" guidance for a 429, a distinct message for a network failure, and otherwise
  preserves the backend's own message instead of burying it under another generic prefix.

## Related copy fixes (in scope per the issue)

- Reworded the RTMA timeout message in `rtma_model.R`: it now says the run exceeded its
  time budget instead of asserting the sampler diverged, since the code only measures
  elapsed time and cannot tell the two apart. Real divergence counts are tracked
  separately in #480. Touched only that string; left the surrounding `phacking_meta` call
  and plot block untouched since other work is in flight there.
- `runsService.ts` (`getRunItem` and `batchGetRunStatuses`, shared by the legacy and `/v1`
  run routes) now guarantees a failed or timed-out run always carries an `errorMessage`,
  filling in a fallback if the store has none, so a `GET /v1/runs/{jobId}` (or the batch
  list) never returns a terminal failure with nothing for the caller to act on.

## Tests

Added vitest coverage for the error mapping: a 429, a genuine 500, and a network failure
produce three distinct user-facing messages, and the envelope message survives unchanged
through the service layer to the page layer (`tests/httpErrorMapping.test.ts`,
`tests/errorMessageUtils.test.ts`). Also added coverage for the failed-run `errorMessage`
fallback on both the legacy and `/v1` job routes, and updated `modelServiceGetRuns.test.ts`
for the new preserve-the-original-error behavior.

## Verification

- `npx vitest run`: 26 files, 164 tests, all passing.
- `npx tsc --noEmit`: only the pre-existing unrelated error in
  `src/tests/integration/results.test.tsx`.
- Formatting checked per file via `git show :path | npx prettier --stdin-filepath path`
  (dodges CRLF noise from `core.autocrlf=true`) and `git show :path | npx eslint --stdin
  --stdin-filename path`; both clean on every changed file.

Fixes #491.
