### PR TITLE
fix: bump AWS provider to 6.8 for 1 MiB SQS message size support

### DIFF
--- a/terraform/stacks/prod-foundation/terragrunt.hcl
+++ b/terraform/stacks/prod-foundation/terragrunt.hcl
@@ -41,7 +41,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.50"
+      version = "~> 6.8"
     }
   }
 

--- a/terraform/stacks/prod-runtime/terragrunt.hcl
+++ b/terraform/stacks/prod-runtime/terragrunt.hcl
@@ -43,7 +43,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.50"
+      version = "~> 6.8"
     }
   }
 


### PR DESCRIPTION
hashicorp/aws only added support for SQS's max_message_size up to 1 MiB in v6.8.0 (hashicorp/terraform-provider-aws#43710). This repo pins ~> 5.50 in both terraform stacks, so the queue-ceiling change from #499 fails at terraform plan with: expected max_message_size to be in the range (1024 - 262144), got 1048576.

Bumps hashicorp/aws from ~> 5.50 to ~> 6.8 in both prod-runtime and prod-foundation, version constraint only, no other changes. Labeled release so CI actually runs plan/apply and surfaces the real diff across the full provider major-version bump before this reaches production.