### PR TITLE
ci: run the react ui vitest suite on pull requests

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,4 +1,4 @@
-name: Lint
+name: Lint and Test
 
 on:
   pull_request:
@@ -26,6 +26,29 @@ jobs:
       - name: Run linters
         run: |
           npm run lint
+
+  test-react-ui:
+    name: Test React UI
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: apps/react-ui/client
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: apps/react-ui/client/package-lock.json
+      - name: Install dependencies
+        run: |
+          npm ci
+      # --run is passed explicitly so the suite never falls into watch mode,
+      # regardless of how CI environment detection behaves.
+      - name: Run tests
+        run: |
+          npm test -- --run
 
   lint-r-backend:
     name: Lint R Backend


### PR DESCRIPTION
## What

Adds a `test-react-ui` job to `.github/workflows/lint.yml` so the frontend Vitest suite runs on every PR to `master`. The workflow display name becomes "Lint and Test"; the individual job names (`Lint React UI`, `Lint R Backend`) are unchanged, so any existing required status checks keep matching.

## Why

`lint.yml` was the only gate on PRs to `master`, and it only linted: `next lint` for the React UI, `lintr`/`styler` for the R backend. Nothing ran the test suite. The regression tests added on 2026-08-08 therefore gated nothing:

- RTMA favored direction handling
- dataset column canonicalization
- the ~900 KiB queue budget assertions in `apiRunsLegacy.test.ts` and `apiV1Runs.test.ts`

Those are exactly the cases where a silent regression is easy to reintroduce and hard to spot in review. This closes that gap.

## The job

Mirrors the existing `lint-react-ui` job: `ubuntu-latest`, `working-directory: apps/react-ui/client`, `actions/setup-node@v4` with Node 20 and npm caching keyed on `apps/react-ui/client/package-lock.json`, `npm ci`, then `npm test -- --run`.

`--run` is passed explicitly rather than relying on Vitest's CI environment detection to switch out of watch mode. A hung watch process would burn the job timeout instead of failing fast.

## R e2e suite: deliberately not included

`npm run r:test-e2e` is left out of CI on purpose. It is not a self-contained test runner:

1. It requires a live Plumber server. `run_e2e_tests.R` probes `E2E_API_BASE_URL` (default `http://localhost:8787`) and exits with status 2 if nothing answers. CI would need to install the backend, start `host.R` in the background, and poll for readiness before the suite could even begin.
2. The dependency tree is heavy. `apps/lambda-r-backend/r_scripts/r-packages.txt` includes `phacking`, which pulls in the rstan/StanHeaders toolchain, plus `metafor`, `clubSandwich`, `plumber`, and `ragg`/`systemfonts`/`textshaping` with their system libraries. On top of that the MAIVE package itself is installed from GitHub at a pinned tag. A cold install compiling Stan on `ubuntu-latest` plausibly runs well past the 10 minute mark, and every dependency bump or cache miss pays that cost again.
3. The RTMA scenarios are known to be sampler-sensitive. The runner already orders `rtma-direction` last with an explicit comment: each additional fit in a long-lived process makes the rstan sampler more likely to wedge. That is a poor fit for a required PR gate.

The cost/benefit does not work yet. Getting the R backend into CI is worth doing as its own piece of work, where the container image can be reused instead of rebuilding the dependency tree per run.

## Verification

Ran the suite locally from `apps/react-ui/client`:

```
Test Files  26 passed (26)
     Tests  173 passed (173)
  Duration  48.11s
```

The workflow YAML parses and resolves to three jobs: `lint-react-ui`, `test-react-ui`, `lint-r-backend`.
