### PR TITLE
ci: validate both terraform stacks under terragrunt on pull requests

### DIFF
--- a/.github/workflows/terraform-validate.yml
+++ b/.github/workflows/terraform-validate.yml
@@ -1,0 +1,102 @@
+name: Terraform Validate
+
+on:
+  pull_request:
+    branches:
+      - master
+    paths:
+      - "terraform/**"
+      - ".github/workflows/terraform-validate.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: terraform-validate-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  # Mirrors the versions pinned by the plan job in release.yml.
+  TF_VERSION: 1.12.0
+  TG_VERSION: 0.62.1
+  # Both terragrunt.hcl files resolve these through get_env at parse time, so they
+  # must be present or terragrunt fails before it reaches terraform. Validation is a
+  # static check that never contacts AWS, so dummy values are enough here.
+  TF_VAR_account_id: "000000000000"
+  TF_VAR_region: eu-central-1
+  TF_VAR_project: maive
+  TF_VAR_email: ci@example.com
+  TF_VAR_image_tag: ci
+
+jobs:
+  fmt:
+    name: Terraform Format
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: ${{ env.TF_VERSION }}
+          terraform_wrapper: false
+
+      # Runs on a clean checkout, before any terragrunt run can drop generated
+      # backend.tf, versions.tf or provider.tf files into the stack directories.
+      - name: Check formatting
+        run: terraform fmt -check -recursive terraform/
+
+  validate:
+    name: Validate ${{ matrix.stack }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        stack:
+          - prod-runtime
+          - prod-foundation
+    defaults:
+      run:
+        working-directory: terraform/stacks/${{ matrix.stack }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: ${{ env.TF_VERSION }}
+          # Terragrunt shells out to the terraform binary on PATH, so the wrapper
+          # script that this action installs by default has to be disabled.
+          terraform_wrapper: false
+
+      - name: Set up Terragrunt
+        run: |
+          curl -sSLo /usr/local/bin/terragrunt \
+            "https://github.com/gruntwork-io/terragrunt/releases/download/v${TG_VERSION}/terragrunt_linux_amd64"
+          chmod +x /usr/local/bin/terragrunt
+          terragrunt --version
+
+      # Terragrunt owns the hashicorp/aws version pin: it lives in the generate
+      # "versions" block of each stack's terragrunt.hcl, not in the committed .tf
+      # files. Running terragrunt here writes versions.tf (plus backend.tf and
+      # provider.tf) into the stack directory so the rest of the job works against
+      # the pinned provider. A bare terraform init in the stack directory would
+      # resolve the newest provider instead and miss version specific errors.
+      #
+      # "version" is used because it is the cheapest terragrunt command that renders
+      # the generate blocks without touching remote state. Terragrunt 0.62.1 tries to
+      # create the S3 state bucket during "terragrunt init" even when -backend=false
+      # is forwarded to terraform, which needs AWS credentials that pull requests do
+      # not have.
+      - name: Render terragrunt generated files
+        run: terragrunt version --terragrunt-no-auto-init --terragrunt-non-interactive
+
+      # -backend=false installs the pinned providers without configuring the S3
+      # backend, so no AWS credentials are needed.
+      - name: Initialize providers without backend
+        run: terraform init -backend=false -input=false
+
+      # Auto init is disabled so terragrunt validates against the providers installed
+      # above instead of re-running init and reaching for the S3 backend.
+      - name: Validate
+        run: terragrunt validate --terragrunt-no-auto-init --terragrunt-non-interactive


### PR DESCRIPTION
Terraform is only checked today when a release-labeled PR merges: the `plan` job in `release.yml` runs terragrunt against `prod-runtime`, and a successful plan auto-applies. Ordinary PRs that touch `terraform/**` get no terraform check at all.

On 2026-08-08 a PR set `max_message_size = 1048576` on the `aws_sqs_queue` resources in `terraform/stacks/prod-runtime/runs_queue.tf`. The pinned provider at the time (`~> 5.50`) capped that attribute at 262144, so the value was invalid. Nothing caught it until the release pipeline's plan job failed. **This check would have caught that at PR time instead of during the release pipeline.** The provider has since been bumped to `~> 6.8`, which allows 1 MiB.

## What this adds

`.github/workflows/terraform-validate.yml`, triggered on pull requests against `master`, with a paths filter for `terraform/**` and the workflow file itself.

* `fmt` job: `terraform fmt -check -recursive terraform/` on a clean checkout.
* `validate` job: a matrix over both stacks, `prod-runtime` and `prod-foundation`.

It pins Terraform 1.12.0 and Terragrunt 0.62.1, the same versions the `plan` job in `release.yml` uses.

## Why terragrunt rather than bare terraform validate

The `hashicorp/aws` pin is not in the committed `.tf` files. It lives in the `generate "versions"` block of each stack's `terragrunt.hcl`. Running `terraform validate` directly in a stack directory would resolve the newest provider and miss exactly the class of error above. So terragrunt renders the generated files first, and validation then runs against the pinned provider.

## Working around the absent AWS credentials

PR CI has no AWS credentials, and both stacks generate an S3 backend through `remote_state`. In Terragrunt 0.62.1, `terragrunt init -backend=false` still performs its own remote state initialization before terraform runs, so it tries to reach the state bucket and fails with `Error finding AWS credentials`. The flag is forwarded to terraform, but it does not stop terragrunt from initializing the backend itself.

The sequence that does work:

1. `terragrunt version --terragrunt-no-auto-init --terragrunt-non-interactive` renders the generate blocks (`versions.tf`, `provider.tf`, `backend.tf`) without touching remote state.
2. `terraform init -backend=false -input=false` installs the pinned providers and skips backend configuration.
3. `terragrunt validate --terragrunt-no-auto-init --terragrunt-non-interactive` validates against those providers, with auto init disabled so terragrunt does not reach for S3 again.

Because of that interleaved bare `terraform init`, this uses explicit tool installs rather than `gruntwork-io/terragrunt-action`, which only takes a single `tg_command`. The versions still come from the same place.

The five `TF_VAR_*` values that both `terragrunt.hcl` files read via `get_env` are set to dummies at the workflow level. Validation never contacts AWS, so none of them need real values.

## What was verified

The workflow could not be executed locally, so it was first checked command by command and then confirmed by its own run on this PR. Since the workflow file sits in its own paths filter, opening this PR triggered it, and all three jobs passed: `Terraform Format`, `Validate prod-runtime`, `Validate prod-foundation`. On the runner, `terraform init` resolved `Finding hashicorp/aws versions matching "~> 6.8"` and installed 6.58.0 for both stacks, so the pin from the generate block is genuinely in effect in CI, and both stacks reported `Success! The configuration is valid.` with no credentials configured.

Checked beforehand using the pinned Terraform 1.12.0 and Terragrunt 0.62.1 binaries with AWS credentials stripped from the environment:

* The three command sequence exits 0 for both `prod-runtime` and `prod-foundation`. `terraform init` reports `Finding hashicorp/aws versions matching "~> 6.8"` and installs 6.58.0, which confirms the pin from the generate block is what is in effect.
* `terragrunt init -backend=false` fails with `Error finding AWS credentials`, which is what motivated the sequence above.
* Regression check: with the `prod-runtime` pin temporarily set back to `~> 5.50` and the current `max_message_size = 1048576` left in place, validate fails with

  ```
  Error: expected max_message_size to be in the range (1024 - 262144), got 1048576
    with aws_sqs_queue.runs_dlq,
    on runs_queue.tf line 9
  ```

  That is the 2026-08-08 failure, caught statically with no credentials. The pin was restored right after, and this PR changes no terraform files.
* `terraform fmt -check -recursive terraform/` passes on the committed files.
* `actionlint` 1.7.7 reports no problems on the workflow.

One thing still unproven: the failure path has only been demonstrated locally, not on the runner, since making CI fail on purpose would mean pushing a knowingly broken terraform change. The passing path is confirmed on both.
