### PR TITLE
fix: pin and report the RTMA sampler seed so runs are reproducible

### DIFF
--- a/apps/lambda-r-backend/r_scripts/api_v1.R
+++ b/apps/lambda-r-backend/r_scripts/api_v1.R
@@ -404,6 +404,33 @@ api_v1_winsorize_parameter <- function(params) {
   value
 }
 
+#' Validate the RTMA sampler seed (a positive integer), or NULL when absent
+#'
+#' Returns NULL rather than a default so the caller can leave the parameter out
+#' entirely and let run_rtma_model() apply RTMA_DEFAULT_SEED, keeping one
+#' definition of the default.
+api_v1_seed_parameter <- function(params) {
+  value <- params$seed
+  if (is.null(value)) {
+    return(NULL)
+  }
+  is_positive_integer <- is.numeric(value) &&
+    length(value) == 1 &&
+    !is.na(value) &&
+    value >= 1 &&
+    value <= .Machine$integer.max &&
+    abs(value - round(value)) < .Machine$double.eps^0.5
+  if (!is_positive_integer) {
+    api_v1_abort_validation(
+      sprintf(
+        "Invalid seed value: must be a positive integer no larger than %d.",
+        .Machine$integer.max
+      )
+    )
+  }
+  as.integer(round(value))
+}
+
 #' Validate a parameter that must lie strictly between 0 and 1
 api_v1_unit_interval_parameter <- function(params, name, default) {
   value <- params[[name]]
@@ -459,19 +486,31 @@ api_v1_default_maive_parameters <- function(parameters) {
 #' Apply RTMA parameter defaults per design D6
 #'
 #' The internal parallelize/timeoutSeconds knobs are deliberately not exposed;
-#' run_rtma_model falls back to its own safe defaults for them.
+#' run_rtma_model falls back to its own safe defaults for them. `seed` is not in
+#' that category: those two only affect how the fit is executed, while the seed
+#' determines the numbers that come back, so a caller who wants to re-run a
+#' response exactly, or to vary the seed and check that an interval is Monte
+#' Carlo stable, has to be able to set it. It is left out of the list when the
+#' caller omits it, so run_rtma_model()'s RTMA_DEFAULT_SEED stays the single
+#' definition of the default; the response echoes whichever seed was used.
 #'
 #' @param parameters The `parameters` field of the request body (may be NULL)
 #' @return Complete parameter list for run_rtma_model()
 api_v1_default_rtma_parameters <- function(parameters) {
   params <- api_v1_parameters_object(parameters)
 
-  list(
+  defaults <- list(
     favorPositive = api_v1_flag_parameter(params, "favorPositive", TRUE),
     alphaSelect = api_v1_unit_interval_parameter(params, "alphaSelect", 0.05),
     ciLevel = api_v1_unit_interval_parameter(params, "ciLevel", 0.95),
     winsorize = api_v1_winsorize_parameter(params)
   )
+
+  seed <- api_v1_seed_parameter(params)
+  if (!is.null(seed)) {
+    defaults$seed <- seed
+  }
+  defaults
 }
 
 #' Check whether ?include=plot was requested (design D7)

--- a/apps/lambda-r-backend/r_scripts/rtma_model.R
+++ b/apps/lambda-r-backend/r_scripts/rtma_model.R
@@ -7,6 +7,30 @@ library(phacking)
 
 RTMA_PLOT_RES <- 120
 
+# Default RNG seed for the RTMA sampler.
+#
+# phacking::phacking_meta() takes no seed argument, so RStan draws a fresh one on
+# every call. The mode comes from a deterministic mle_params() optimisation and
+# is stable, but the credible interval is a posterior quantile and moves between
+# runs on identical input, which reports Monte Carlo noise as statistical
+# uncertainty (#479). Seeding immediately before the fit makes the whole result
+# bit-identical across repeats.
+#
+# The value is arbitrary; what matters is that it is fixed, reported back in the
+# response, and overridable through params$seed so a caller can vary it
+# deliberately (e.g. to check that an interval is Monte Carlo stable).
+#
+# It is not entirely free of consequences, though. On a weakly identified dataset
+# the sampler's trajectory depends on where it starts, so some seeds send it into
+# a pathologically deep tree and the fit runs for minutes instead of seconds: on
+# the e2e "precise estimates" fixture that happens for 20250101 and 2026, and on
+# the near-degenerate /v1 fixture for 42 and 8454. Unseeded runs took that gamble
+# on every call, so this is not a new failure mode, but a fixed seed makes it
+# deterministic, so this value was timed against every RTMA fixture in the e2e
+# suite (all fits under 8 seconds). Any dataset can still be unlucky, which is
+# what the wall-clock limit below is for.
+RTMA_DEFAULT_SEED <- 2025L
+
 #' Render a z-score density plot and return it as a base64-encoded PNG data URI
 #'
 #' phacking::z_density() has no favor_positive argument: it always draws the
@@ -172,12 +196,22 @@ run_rtma_model <- function(data, parameters, include_plot = TRUE) {
   # Wall-clock budget kept below the Lambda function timeout so a degenerate
   # dataset returns a clear error instead of being hard-killed mid-request.
   timeout_sec <- if (!is.null(params$timeoutSeconds)) as.numeric(params$timeoutSeconds) else 480
+  # Sampler seed; see RTMA_DEFAULT_SEED above for why it must be pinned.
+  seed <- if (!is.null(params$seed)) {
+    suppressWarnings(as.integer(params$seed))
+  } else {
+    RTMA_DEFAULT_SEED
+  }
+  if (length(seed) != 1 || is.na(seed)) {
+    cli::cli_abort("The seed parameter must be a single integer.")
+  }
 
   cli::cli_h2("RTMA parameters:")
   cli::cli_bullets(c(
     "favor_positive: {favor_positive}",
     "alpha_select: {alpha_select}",
     "ci_level: {ci_level}",
+    "seed: {seed}",
     "parallelize: {parallelize}",
     "timeout_sec: {timeout_sec}"
   ))
@@ -198,14 +232,20 @@ run_rtma_model <- function(data, parameters, include_plot = TRUE) {
   setTimeLimit(elapsed = timeout_sec, transient = TRUE)
   rtma_res <- tryCatch(
     withCallingHandlers(
-      phacking::phacking_meta(
-        yi = yi,
-        vi = vi,
-        favor_positive = favor_positive,
-        alpha_select = alpha_select,
-        ci_level = ci_level,
-        parallelize = parallelize
-      ),
+      {
+        # Seeded here rather than at the top of the function: nothing between
+        # this line and phacking_meta() touches the RNG, so this is exactly the
+        # state the sampler starts from.
+        set.seed(seed)
+        phacking::phacking_meta(
+          yi = yi,
+          vi = vi,
+          favor_positive = favor_positive,
+          alpha_select = alpha_select,
+          ci_level = ci_level,
+          parallelize = parallelize
+        )
+      },
       warning = function(w) {
         rtma_warnings <<- c(rtma_warnings, conditionMessage(w))
         invokeRestart("muffleWarning")
@@ -331,6 +371,9 @@ run_rtma_model <- function(data, parameters, include_plot = TRUE) {
     # level (phacking does not compute HPD intervals); echoed back so displays
     # can state the level instead of implying 95%.
     ciLevel = ci_level,
+    # The RNG seed the sampler ran under, so the numbers above are traceable to
+    # the draw that produced them and can be reproduced exactly (#479).
+    seed = seed,
     k = k,
     affirmativeCount = k_affirmative,
     droppedRows = dropped_rows,

--- a/apps/lambda-r-backend/r_scripts/tests/e2e/run_e2e_tests.R
+++ b/apps/lambda-r-backend/r_scripts/tests/e2e/run_e2e_tests.R
@@ -39,6 +39,7 @@ source(file.path(script_dir, "scenarios/publication_bias_test.R"))
 source(file.path(script_dir, "scenarios/edge_cases_test.R"))
 source(file.path(script_dir, "scenarios/basic_rtma_test.R"))
 source(file.path(script_dir, "scenarios/rtma_direction_test.R"))
+source(file.path(script_dir, "scenarios/rtma_seed_test.R"))
 source(file.path(script_dir, "scenarios/api_v1_test.R"))
 
 # Define available test scenarios
@@ -109,6 +110,11 @@ AVAILABLE_SCENARIOS <- list(
     name = "RTMA Favored Direction Test",
     description = "Test that RTMA respects the favored direction and flags a wrong one",
     function_name = "test_rtma_direction"
+  ),
+  "rtma-seed" = list(
+    name = "RTMA Seed Reproducibility Test",
+    description = "Test that identical input and seed reproduce identical RTMA results",
+    function_name = "test_rtma_seed"
   ),
 
   # Public /v1 API scenarios
@@ -382,11 +388,22 @@ run_all_scenarios <- function(api_url = NULL, verbose = TRUE) {
   }
   test_count <- test_count + 1
 
-  # RTMA favored direction runs last: it fits three more RTMA models, and every
-  # extra fit in this long-lived process makes the rstan sampler more likely to
-  # wedge on a later one. Keeping it at the end leaves every other scenario with
-  # the same process state it had before this test existed.
-  cat("\n8. Running RTMA favored direction test...\n")
+  # The two scenarios below run last: between them they fit seven more RTMA
+  # models, and every extra fit in this long-lived process makes the rstan
+  # sampler more likely to wedge on a later one. Keeping them at the end leaves
+  # every other scenario with the same process state it had before they existed.
+  cat("\n8. Running RTMA seed reproducibility test...\n")
+  rtma_seed_result <- test_rtma_seed()
+  all_results$rtma_seed <- rtma_seed_result
+  if (rtma_seed_result$status == "PASS") {
+    passed_count <- passed_count + 1
+    cat("   ✓ RTMA seed reproducibility test passed\n")
+  } else {
+    cat("   ✗ RTMA seed reproducibility test failed:", rtma_seed_result$error, "\n")
+  }
+  test_count <- test_count + 1
+
+  cat("\n9. Running RTMA favored direction test...\n")
   rtma_direction_result <- test_rtma_direction()
   all_results$rtma_direction <- rtma_direction_result
   if (rtma_direction_result$status == "PASS") {

--- a/apps/lambda-r-backend/r_scripts/tests/e2e/scenarios/rtma_direction_test.R
+++ b/apps/lambda-r-backend/r_scripts/tests/e2e/scenarios/rtma_direction_test.R
@@ -124,9 +124,10 @@ test_rtma_direction <- function() {
         )
       )
 
-      # 2. The two fits mirror each other. Sampling is unseeded, so compare with
-      # a tolerance well above Monte Carlo noise but far below the sign error
-      # this guards against (which doubles the magnitude).
+      # 2. The two fits mirror each other. Both now run under the same pinned
+      # seed (#479), but they are still separate fits, so compare with a
+      # tolerance well above Monte Carlo noise but far below the sign error this
+      # guards against (which doubles the magnitude).
       mu_tolerance <- 0.25 * abs(positive_results$mu)
       # Interval bounds are posterior quantiles, so the long tail carries far
       # more Monte Carlo noise than the mode. Scale their tolerance to the

--- a/apps/lambda-r-backend/r_scripts/tests/e2e/scenarios/rtma_seed_test.R
+++ b/apps/lambda-r-backend/r_scripts/tests/e2e/scenarios/rtma_seed_test.R
@@ -1,0 +1,250 @@
+# RTMA Seed Reproducibility Test Scenario
+#
+# phacking::phacking_meta() takes no seed argument, so RStan used to draw a
+# fresh one on every call: identical input returned a different credible
+# interval each time, because the mode comes from a deterministic optimisation
+# but the interval is a posterior quantile (#479). run_rtma_model() now seeds
+# the sampler immediately before the fit and reports the seed it used.
+#
+# The check that matters is bit-identity, not "close enough": a tolerance would
+# pass just as happily with the seed removed again.
+
+# Keep in sync with RTMA_DEFAULT_SEED in rtma_model.R. Asserted end to end so a
+# request that sets no seed still runs pinned, rather than silently drifting
+# back to a per-call random draw.
+RTMA_EXPECTED_DEFAULT_SEED <- 2025
+
+# Arbitrary non-default seed, so a run that echoes it proves the request value
+# was honored rather than the default being reported back.
+RTMA_TEST_SEED <- 4242
+
+#' Fail with a message unless a condition holds
+expect_rtma_seed <- function(condition, message) {
+  if (!isTRUE(condition)) {
+    stop(message)
+  }
+}
+
+#' Build RTMA parameter JSON, optionally pinning the seed
+#' @param seed Seed to request, or NULL to leave it to the backend default
+#' @return JSON string of parameters
+rtma_seed_params <- function(seed = NULL) {
+  params <- list(
+    modelType = "RTMA",
+    favorPositive = TRUE,
+    alphaSelect = 0.05,
+    ciLevel = 0.95,
+    winsorize = 0
+  )
+  if (!is.null(seed)) {
+    params$seed <- seed
+  }
+  params_to_json(params)
+}
+
+#' Extract the numeric fields a seeded run must reproduce exactly
+#' @param results Parsed RTMA results object
+#' @return Named list of scalars and interval bounds
+rtma_seed_fingerprint <- function(results) {
+  list(
+    mu = results$mu,
+    muMedian = results$muMedian,
+    muCILower = results$muCI[[1]],
+    muCIUpper = results$muCI[[2]],
+    tau = results$tau,
+    tauMedian = results$tauMedian,
+    tauCILower = results$tauCI[[1]],
+    tauCIUpper = results$tauCI[[2]]
+  )
+}
+
+#' Report every field where two runs disagree, formatted for a failure message
+#' @param left Fingerprint of the first run
+#' @param right Fingerprint of the second run
+#' @return Character vector of differing fields, empty when the runs agree
+rtma_seed_differences <- function(left, right) {
+  differing <- vapply(names(left), function(field) {
+    !identical(left[[field]], right[[field]])
+  }, logical(1))
+
+  vapply(names(left)[differing], function(field) {
+    sprintf("%s: %.10f vs %.10f", field, left[[field]], right[[field]])
+  }, character(1))
+}
+
+#' Run /run-rtma once and return its parsed results
+#' @param df Data frame of estimates
+#' @param seed Seed to request, or NULL for the backend default
+#' @param label Label used in progress output and failure messages
+#' @return Parsed results object
+run_rtma_seed_case <- function(df, seed, label) {
+  cat(sprintf("  %s...\n", label))
+  response <- test_run_rtma(df_to_json(df), rtma_seed_params(seed))
+
+  expect_rtma_seed(
+    is.list(response) && !is.null(response$data),
+    sprintf("%s: response should contain a 'data' field", label)
+  )
+  results <- response$data
+
+  expect_rtma_seed(
+    !is.null(results$seed),
+    sprintf("%s: results should carry the seed the sampler ran under", label)
+  )
+  expect_rtma_seed(
+    is.numeric(results$seed) && length(results$seed) == 1,
+    sprintf("%s: seed should be a single number, got %s", label, class(results$seed))
+  )
+
+  results
+}
+
+#' Check that /v1/run-rtma honors, echoes, and validates the seed parameter
+#' @param df Data frame of estimates
+#' @param expected Fingerprint of the legacy-route run with the same seed
+#' @return TRUE invisibly
+check_rtma_seed_v1 <- function(df, expected) {
+  rows <- df_to_v1_rows(df)
+
+  cat("  /v1/run-rtma with an explicit seed...\n")
+  seeded_response <- v1_post_json(
+    "/v1/run-rtma",
+    list(data = rows, parameters = list(seed = RTMA_TEST_SEED)),
+    timeout = 300
+  )
+  expect_rtma_seed(
+    httr::status_code(seeded_response) == 200,
+    sprintf(
+      "/v1 seeded request failed with status %d",
+      httr::status_code(seeded_response)
+    )
+  )
+  seeded_body <- v1_parse_body(seeded_response)
+  expect_rtma_seed(
+    identical(as.numeric(seeded_body$seed), as.numeric(RTMA_TEST_SEED)),
+    sprintf(
+      "/v1 should echo the requested seed %s, got %s",
+      RTMA_TEST_SEED, seeded_body$seed
+    )
+  )
+
+  # Same data, same seed, different route: the fit must land on the same
+  # numbers, otherwise /v1 is dropping the seed somewhere on the way through.
+  differences <- rtma_seed_differences(expected, rtma_seed_fingerprint(seeded_body))
+  expect_rtma_seed(
+    length(differences) == 0,
+    paste(
+      "/v1 and the legacy route disagree for the same data and seed:",
+      paste(differences, collapse = " | ")
+    )
+  )
+
+  cat("  /v1/run-rtma with no seed (backend default)...\n")
+  default_response <- v1_post_json(
+    "/v1/run-rtma", list(data = rows),
+    timeout = 300
+  )
+  expect_rtma_seed(
+    httr::status_code(default_response) == 200,
+    sprintf(
+      "/v1 default request failed with status %d",
+      httr::status_code(default_response)
+    )
+  )
+  default_body <- v1_parse_body(default_response)
+  expect_rtma_seed(
+    identical(as.numeric(default_body$seed), as.numeric(RTMA_EXPECTED_DEFAULT_SEED)),
+    sprintf(
+      "A request with no seed should run under the default seed %s, got %s",
+      RTMA_EXPECTED_DEFAULT_SEED, default_body$seed
+    )
+  )
+
+  cat("  /v1/run-rtma rejects an invalid seed...\n")
+  invalid_response <- v1_post_json(
+    "/v1/run-rtma",
+    list(data = rows, parameters = list(seed = 1.5)),
+    timeout = 60
+  )
+  expect_rtma_seed(
+    httr::status_code(invalid_response) == 400,
+    sprintf(
+      "A non-integer seed should be rejected with 400, got %d",
+      httr::status_code(invalid_response)
+    )
+  )
+  invalid_body <- v1_parse_body(invalid_response)
+  expect_rtma_seed(
+    identical(invalid_body$error$code, "validation_error"),
+    "A non-integer seed should return a validation_error envelope"
+  )
+
+  invisible(TRUE)
+}
+
+#' Test that RTMA runs are reproducible under a pinned seed
+#' @return Test results
+test_rtma_seed <- function() {
+  test_name <- "RTMA Seed Reproducibility Test"
+
+  tryCatch(
+    {
+      cat("Running RTMA seed reproducibility test...\n")
+
+      # Rounded to 4 decimals because the two routes serialize the payload at
+      # different precision (the legacy helper uses jsonlite's default
+      # digits = 4, /v1 sends digits = NA). Pre-rounded input survives both
+      # unchanged, so the cross-route check below compares two fits of the same
+      # numbers rather than of two slightly different datasets.
+      test_data <- round(generate_rtma_test_data(), 4)
+
+      first <- run_rtma_seed_case(
+        test_data, RTMA_TEST_SEED, "first run with an explicit seed"
+      )
+      second <- run_rtma_seed_case(
+        test_data, RTMA_TEST_SEED, "second run with the same input and seed"
+      )
+
+      expect_rtma_seed(
+        identical(as.numeric(first$seed), as.numeric(RTMA_TEST_SEED)),
+        sprintf(
+          "The response should echo the requested seed %s, got %s",
+          RTMA_TEST_SEED, first$seed
+        )
+      )
+
+      differences <- rtma_seed_differences(
+        rtma_seed_fingerprint(first),
+        rtma_seed_fingerprint(second)
+      )
+      expect_rtma_seed(
+        length(differences) == 0,
+        paste(
+          "Two runs with the same input and seed must agree to every digit;",
+          "these differ in", paste(differences, collapse = " | ")
+        )
+      )
+
+      check_rtma_seed_v1(test_data, rtma_seed_fingerprint(first))
+
+      log_test_result(
+        test_name, "PASS",
+        "Identical input and seed reproduce identical RTMA results"
+      )
+
+      return(list(
+        status = "PASS",
+        test_name = test_name,
+        results = first
+      ))
+    },
+    error = function(e) {
+      log_test_result(test_name, "FAIL", e$message)
+      return(list(
+        status = "FAIL",
+        test_name = test_name,
+        error = e$message
+      ))
+    }
+  )
+}

--- a/apps/react-ui/client/src/components/ApiDocs/apiDocsContent.ts
+++ b/apps/react-ui/client/src/components/ApiDocs/apiDocsContent.ts
@@ -133,6 +133,11 @@ export const RTMA_PARAMETERS: ParameterRow[] = [
     values: "number (percent, 0 disables)",
     defaultValue: "0",
   },
+  {
+    name: "seed",
+    values: "integer (sampler seed, echoed in the response)",
+    defaultValue: "2025",
+  },
 ];
 
 export type CodeSample = {

--- a/apps/react-ui/client/src/components/Modals/RunInfoModal.tsx
+++ b/apps/react-ui/client/src/components/Modals/RunInfoModal.tsx
@@ -8,6 +8,7 @@ import TEXT from "@src/lib/text";
 import ResultsSummary from "@src/components/ResultsSummary";
 import RTMAResultsSummary from "@src/components/RTMAResultsSummary";
 import RunDetails from "@src/components/RunDetails";
+import type { DetailItem } from "@src/components/RunDetails";
 import SectionHeading from "@src/components/SectionHeading";
 import BaseModal from "./BaseModal";
 import { FaDownload } from "react-icons/fa";
@@ -45,6 +46,30 @@ export default function RunInfoModal({
   resultsText,
 }: RunInfoModalProps) {
   const isRtmaModel = parameters.modelType === CONST.MODEL_TYPES.RTMA;
+
+  // RTMA only: the credible intervals are posterior quantiles from a seeded
+  // sampler, so the seed is what makes the reported numbers traceable to the
+  // draw that produced them (#479). No other model reports one.
+  const seedText = TEXT.rtma.seed;
+  const rtmaSeed = rtmaResults?.seed;
+  const extraRunDetails: DetailItem[] = isRtmaModel
+    ? [
+        typeof rtmaSeed === "number"
+          ? {
+              label: seedText.label,
+              value: rtmaSeed,
+              show: true,
+              tooltip: seedText.tooltip,
+            }
+          : {
+              label: seedText.label,
+              value: seedText.unknownValue,
+              show: true,
+              tooltip: seedText.unknownTooltip,
+            },
+      ]
+    : [];
+
   const getParameterDisplayName = (key: keyof ModelParameters): string => {
     return TEXT.model[key].label;
   };
@@ -117,6 +142,7 @@ export default function RunInfoModal({
             runDuration={runDuration}
             runTimestamp={runTimestamp}
             dataInfo={dataInfo}
+            extraDetails={extraRunDetails}
           />
         </section>
 

--- a/apps/react-ui/client/src/components/RunDetails.tsx
+++ b/apps/react-ui/client/src/components/RunDetails.tsx
@@ -2,23 +2,26 @@
 
 import type { DataInfo } from "@src/types/data";
 
-type RunDetailsProps = {
-  runDuration?: number;
-  runTimestamp?: Date;
-  dataInfo?: DataInfo;
-};
-
-type DetailItem = {
+export type DetailItem = {
   label: string;
   value: string | number;
   show: boolean;
   tooltip?: string;
 };
 
+type RunDetailsProps = {
+  runDuration?: number;
+  runTimestamp?: Date;
+  dataInfo?: DataInfo;
+  /** Model-specific rows appended after the data details (e.g. the RTMA seed) */
+  extraDetails?: DetailItem[];
+};
+
 export default function RunDetails({
   runDuration,
   runTimestamp,
   dataInfo,
+  extraDetails = [],
 }: RunDetailsProps) {
   const formatDuration = (ms?: number): string => {
     if (!ms) {
@@ -106,7 +109,7 @@ export default function RunDetails({
       ]
     : [];
 
-  const allDetails = [...runDetails, ...dataDetails];
+  const allDetails = [...runDetails, ...dataDetails, ...extraDetails];
   const visibleDetails = allDetails.filter((detail) => detail.show);
 
   // Split details into two columns for better layout

--- a/apps/react-ui/client/src/lib/reproducibility/generators/readme.ts
+++ b/apps/react-ui/client/src/lib/reproducibility/generators/readme.ts
@@ -9,8 +9,13 @@ import type { VersionInfo } from "@src/types/reproducibility";
 
 /**
  * Converts model parameters to a readable markdown table
+ *
+ * @param rtmaSeed - Seed the RTMA sampler ran under, when the run recorded one
  */
-function generateParameterTable(parameters: ModelParameters): string {
+function generateParameterTable(
+  parameters: ModelParameters,
+  rtmaSeed?: number | null,
+): string {
   const rows =
     parameters.modelType === "RTMA"
       ? [
@@ -19,6 +24,12 @@ function generateParameterTable(parameters: ModelParameters): string {
           ["Alpha Select", "0.05"],
           ["CI Level", "0.95"],
           ["Winsorize Percentage", `${parameters.winsorize}%`],
+          [
+            "Sampler Seed",
+            rtmaSeed == null
+              ? "not recorded (run predates seeded RTMA sampling)"
+              : String(rtmaSeed),
+          ],
         ]
       : [
           ["Model Type", parameters.modelType],
@@ -64,6 +75,7 @@ export function generateReadme(
   versionInfo: VersionInfo,
   parameters: ModelParameters,
   numRows: number,
+  rtmaSeed?: number | null,
 ): string {
   const timestamp = new Date(versionInfo.timestamp).toLocaleString("en-US", {
     year: "numeric",
@@ -74,7 +86,7 @@ export function generateReadme(
     timeZoneName: "short",
   });
 
-  const parameterTable = generateParameterTable(parameters);
+  const parameterTable = generateParameterTable(parameters, rtmaSeed);
 
   const isRtma = parameters.modelType === "RTMA";
   const title = isRtma

--- a/apps/react-ui/client/src/lib/reproducibility/generators/wrapperScript.ts
+++ b/apps/react-ui/client/src/lib/reproducibility/generators/wrapperScript.ts
@@ -11,8 +11,33 @@
  */
 
 import CONST from "@src/CONST";
-import type { ModelParameters, ModelResults } from "@src/types/api";
+import type {
+  ModelParameters,
+  ModelResults,
+  RTMAResults,
+} from "@src/types/api";
 import type { VersionInfo, WinsorizeInfo } from "@src/types/reproducibility";
+
+/**
+ * Seed written into an RTMA script when the run itself carries none.
+ *
+ * Mirrors RTMA_DEFAULT_SEED in apps/lambda-r-backend/r_scripts/rtma_model.R.
+ * Only reached for runs stored before the backend pinned a seed (#479); those
+ * numbers cannot be reproduced by any seed, so the script says so rather than
+ * pretending this one recreates them.
+ */
+const RTMA_FALLBACK_SEED = 2025;
+
+/**
+ * Reads the seed the RTMA sampler actually ran under, if the run recorded one.
+ *
+ * RTMA results travel through the export path typed as ModelResults (the two
+ * shapes share the same slot), so the seed has to be read off the RTMA view.
+ */
+export function getRtmaSeed(results: ModelResults): number | null {
+  const seed = (results as unknown as RTMAResults).seed;
+  return typeof seed === "number" && Number.isFinite(seed) ? seed : null;
+}
 
 /**
  * Generates winsorization details section for the R script
@@ -45,8 +70,13 @@ function generateWinsorizeSection(
 
 /**
  * Generates the parameters configuration section
+ *
+ * @param rtmaSeed - Seed to pin the RTMA sampler to (RTMA runs only)
  */
-function generateParametersSection(parameters: ModelParameters): string {
+function generateParametersSection(
+  parameters: ModelParameters,
+  rtmaSeed?: number,
+): string {
   if (parameters.modelType === "RTMA") {
     return `
 # RTMA analysis parameters (exactly as configured in the web application)
@@ -55,7 +85,13 @@ parameters <- list(
   favorPositive = ${parameters.favorPositive ? "TRUE" : "FALSE"},
   alphaSelect = 0.05,
   ciLevel = 0.95,
-  winsorize = ${parameters.winsorize}
+  winsorize = ${parameters.winsorize},
+  # RNG seed the sampler runs under. phacking::phacking_meta() takes no seed
+  # argument, so run_rtma_model() calls set.seed() with this value immediately
+  # before fitting. The credible intervals are posterior quantiles and move
+  # between runs without it, so this is what makes the numbers below
+  # reproducible.
+  seed = ${rtmaSeed ?? RTMA_FALLBACK_SEED}
 )
 
 cat("\\nAnalysis Configuration:\\n")
@@ -64,6 +100,7 @@ cat("  Favor Positive:", ifelse(parameters$favorPositive, "Yes", "No"), "\\n")
 cat("  Alpha Select:", parameters$alphaSelect, "\\n")
 cat("  CI Level:", parameters$ciLevel, "\\n")
 cat("  Winsorize:", parameters$winsorize, "%\\n")
+cat("  Seed:", parameters$seed, "\\n")
 `;
   }
 
@@ -179,14 +216,24 @@ if (effect_match && se_match && egger_match) {
 
 /**
  * Generates RTMA-specific wrapper R script
+ *
+ * @param recordedSeed - Seed the original run reported, or null when the run
+ *   predates seeded RTMA sampling and cannot be reproduced exactly
  */
 function generateRtmaWrapperScript(
   versionInfo: VersionInfo,
   parameters: ModelParameters,
   numRows: number,
+  recordedSeed: number | null,
   winsorizeInfo?: WinsorizeInfo,
 ): string {
   const timestamp = new Date().toISOString();
+  const seed = recordedSeed ?? RTMA_FALLBACK_SEED;
+  const seedHeaderNote =
+    recordedSeed === null
+      ? `# Seed:            ${seed} (default; the original run recorded no seed,
+#                  so its credible intervals cannot be reproduced exactly)`
+      : `# Seed:            ${seed}`;
 
   return `#!/usr/bin/env Rscript
 #
@@ -199,6 +246,7 @@ function generateRtmaWrapperScript(
 # Method:          RTMA (Mathur, 2024)
 # Git Commit:      ${versionInfo.gitCommitHash}
 # R Version:       ${versionInfo.rVersion}
+${seedHeaderNote}
 #
 # This script reproduces the RTMA analysis performed in the
 # MAIVE web application (${CONST.LINKS.MAIVE.WEBSITE}).
@@ -295,7 +343,7 @@ ${generateWinsorizeSection(winsorizeInfo)}
 # ============================================================
 
 cat("\\nConfiguring analysis parameters...\\n")
-${generateParametersSection(parameters)}
+${generateParametersSection(parameters, seed)}
 
 # ============================================================
 # 5. RUN ANALYSIS
@@ -304,6 +352,13 @@ ${generateParametersSection(parameters)}
 cat("\\n========================================\\n")
 cat("Running RTMA analysis...\\n")
 cat("========================================\\n\\n")
+
+# Seed here as well as in parameters$seed above. rtma_model.R is bundled from
+# the backend commit this analysis ran on, and versions from before RTMA runs
+# were seeded ignore parameters$seed entirely. Nothing between this line and
+# phacking_meta() draws from the RNG, so the sampler starts from the same state
+# either way, and the section below reports which path took effect.
+set.seed(parameters$seed)
 
 # Run the analysis using the same function as the web backend
 # Note: run_rtma_model expects JSON strings (designed for Plumber backend)
@@ -337,6 +392,23 @@ cat("tau (mode):  ", sprintf("%.6f", results$tau), "\\n")
 cat("tau (median):", sprintf("%.6f", results$tauMedian), "\\n")
 cat("tau CI:      ", sprintf("[%.6f, %.6f]", results$tauCI[1], results$tauCI[2]),
     sprintf("(equal-tailed, level %.2f)", results$ciLevel), "\\n")
+
+cat("\\n=== REPRODUCIBILITY ===\\n")
+cat("Seed requested:  ", parameters$seed, "\\n")
+if (is.null(results$seed)) {
+  cat("\\u26a0 The bundled rtma_model.R reports no seed, so it predates seeded RTMA runs.\\n")
+  cat("  The set.seed() call above still pins this run, but repeat it to confirm.\\n")
+} else if (!isTRUE(all.equal(as.numeric(results$seed), as.numeric(parameters$seed)))) {
+  cat("\\u26a0 The fit ran under seed", results$seed, "instead of", parameters$seed, "\\n")
+} else {
+  cat("\\u2713 The fit ran under the requested seed\\n")
+}${
+    recordedSeed === null
+      ? `
+cat("\\u26a0 The original web-app run recorded no seed, so its credible intervals\\n")
+cat("  cannot be reproduced exactly. This run is pinned and repeatable from here on.\\n")`
+      : ""
+  }
 
 cat("\\n=== ESTIMATES ===\\n")
 cat("Used (k):        ", results$k, "\\n")
@@ -415,6 +487,7 @@ export function generateWrapperScript(
       versionInfo,
       parameters,
       numRows,
+      getRtmaSeed(results),
       winsorizeInfo,
     );
   }

--- a/apps/react-ui/client/src/lib/reproducibility/index.ts
+++ b/apps/react-ui/client/src/lib/reproducibility/index.ts
@@ -13,7 +13,7 @@ import type { VersionInfo, WinsorizeInfo } from "@src/types/reproducibility";
 import type { DataArray } from "@src/types";
 
 import { fetchRCodeBundle } from "./githubFetcher";
-import { generateWrapperScript } from "./generators/wrapperScript";
+import { generateWrapperScript, getRtmaSeed } from "./generators/wrapperScript";
 import { generateReadme, generateVersionManifest } from "./generators/readme";
 import { convertDataToCSV } from "./csvConverter";
 import { validateExportData, estimatePackageSize } from "./validator";
@@ -82,7 +82,12 @@ export async function generateReproducibilityPackage(
 
   // 4. Generate README
   console.log("Generating README...");
-  const readme = generateReadme(versionInfo, parameters, dataLength);
+  const readme = generateReadme(
+    versionInfo,
+    parameters,
+    dataLength,
+    parameters.modelType === "RTMA" ? getRtmaSeed(results) : null,
+  );
 
   // 5. Generate version manifest
   console.log("Generating version manifest...");

--- a/apps/react-ui/client/src/lib/text/index.ts
+++ b/apps/react-ui/client/src/lib/text/index.ts
@@ -448,6 +448,14 @@ const TEXT = {
   },
   rtma: {
     dropdownLabel: "RTMA",
+    seed: {
+      label: "Sampler Seed",
+      tooltip:
+        "Random seed the RTMA sampler ran under. The credible intervals are posterior quantiles, so they depend on it; the same data and seed reproduce the same numbers exactly.",
+      unknownValue: "Not recorded",
+      unknownTooltip:
+        "This run predates seeded RTMA sampling, so its credible intervals cannot be reproduced exactly. Rerun the model to get a seeded result.",
+    },
   },
   waive: {
     dropdownLabel: "WAIVE (Experimental)",

--- a/apps/react-ui/client/src/pages/results/index.tsx
+++ b/apps/react-ui/client/src/pages/results/index.tsx
@@ -419,6 +419,9 @@ export default function ResultsPage() {
         if (parsedRtmaResults.ciLevel != null) {
           optionalRows.push(["CI Level", String(parsedRtmaResults.ciLevel)]);
         }
+        if (parsedRtmaResults.seed != null) {
+          optionalRows.push(["Sampler Seed", String(parsedRtmaResults.seed)]);
+        }
         if (parsedRtmaResults.k != null) {
           optionalRows.push([
             "Estimates Used (k)",

--- a/apps/react-ui/client/src/tests/RunInfoModal.test.tsx
+++ b/apps/react-ui/client/src/tests/RunInfoModal.test.tsx
@@ -1,0 +1,113 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import RunInfoModal from "@components/Modals/RunInfoModal";
+import TEXT from "@src/lib/text";
+import type {
+  ModelParameters,
+  ModelResults,
+  RTMAResults,
+} from "@src/types/api";
+
+const maiveParameters: ModelParameters = {
+  modelType: "MAIVE",
+  includeStudyDummies: false,
+  includeStudyClustering: false,
+  standardErrorTreatment: "clustered_cr2",
+  computeAndersonRubin: false,
+  maiveMethod: "PET-PEESE",
+  weight: "equal_weights",
+  shouldUseInstrumenting: true,
+  useLogFirstStage: false,
+  winsorize: 0,
+  favorPositive: true,
+};
+
+const rtmaParameters: ModelParameters = {
+  ...maiveParameters,
+  modelType: "RTMA",
+};
+
+const modelResults: ModelResults = {
+  effectEstimate: 0.42,
+  standardError: 0.11,
+  isSignificant: true,
+  andersonRubinCI: "NA",
+  publicationBias: {
+    eggerCoef: 0.3,
+    eggerSE: 0.1,
+    isSignificant: true,
+    eggerBootCI: "NA",
+    eggerAndersonRubinCI: "NA",
+  },
+  firstStageFStatistic: 22.5,
+  hausmanTest: {
+    statistic: 1.2,
+    criticalValue: 3.84,
+    rejectsNull: false,
+  },
+  seInstrumented: [0.1, 0.2],
+  funnelPlot: "data:image/png;base64,xxx",
+  funnelPlotWidth: 600,
+  funnelPlotHeight: 400,
+  bootCI: "NA",
+  bootSE: "NA",
+};
+
+/** A run stored before the backend started pinning and reporting a seed */
+const withoutSeed = (results: RTMAResults): RTMAResults => {
+  const legacy = { ...results };
+  delete legacy.seed;
+  return legacy;
+};
+
+const rtmaResults: RTMAResults = {
+  mu: 0.12,
+  muCI: [0.07, 0.31],
+  tau: 0.03,
+  tauCI: [0.01, 0.16],
+  zScorePlot: "data:image/png;base64,xxx",
+  zScorePlotWidth: 600,
+  zScorePlotHeight: 400,
+  nonaffirmativeCount: 26,
+  nonaffirmativeProportion: 0.65,
+  warnings: [],
+  seed: 4242,
+};
+
+const renderModal = (
+  parameters: ModelParameters,
+  results?: RTMAResults | null,
+) =>
+  render(
+    <RunInfoModal
+      isOpen={true}
+      onClose={() => {}}
+      parameters={parameters}
+      results={modelResults}
+      rtmaResults={results}
+      onExportButtonClick={() => {}}
+      resultsText={TEXT.results}
+    />,
+  );
+
+describe("RunInfoModal", () => {
+  it("reports the seed an RTMA run was sampled under", () => {
+    renderModal(rtmaParameters, rtmaResults);
+
+    expect(screen.getByText("Sampler Seed:")).toBeInTheDocument();
+    expect(screen.getByText("4242")).toBeInTheDocument();
+  });
+
+  it("says so when an RTMA run predates seeded sampling", () => {
+    renderModal(rtmaParameters, withoutSeed(rtmaResults));
+
+    expect(screen.getByText("Sampler Seed:")).toBeInTheDocument();
+    expect(screen.getByText("Not recorded")).toBeInTheDocument();
+  });
+
+  it("shows no seed for models that do not sample", () => {
+    renderModal(maiveParameters, null);
+
+    expect(screen.queryByText("Sampler Seed:")).not.toBeInTheDocument();
+  });
+});

--- a/apps/react-ui/client/src/tests/reproducibilityWrapperScript.test.ts
+++ b/apps/react-ui/client/src/tests/reproducibilityWrapperScript.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from "vitest";
+import { generateWrapperScript } from "@src/lib/reproducibility/generators/wrapperScript";
+import type {
+  ModelParameters,
+  ModelResults,
+  RTMAResults,
+} from "@src/types/api";
+import type { VersionInfo } from "@src/types/reproducibility";
+
+const versionInfo: VersionInfo = {
+  uiVersion: "0.6.16-0",
+  maiveTag: "0.0.3.4",
+  gitCommitHash: "abc1234",
+  rVersion: "4.4.2",
+  timestamp: "2026-08-09T10:00:00.000Z",
+};
+
+const rtmaParameters: ModelParameters = {
+  modelType: "RTMA",
+  includeStudyDummies: false,
+  includeStudyClustering: false,
+  standardErrorTreatment: "clustered_cr2",
+  computeAndersonRubin: false,
+  maiveMethod: "PET-PEESE",
+  weight: "equal_weights",
+  shouldUseInstrumenting: false,
+  useLogFirstStage: false,
+  winsorize: 0,
+  favorPositive: true,
+};
+
+const rtmaResults: RTMAResults = {
+  mu: 0.12,
+  muCI: [0.07, 0.31],
+  tau: 0.03,
+  tauCI: [0.01, 0.16],
+  zScorePlot: "data:image/png;base64,xxx",
+  zScorePlotWidth: 600,
+  zScorePlotHeight: 400,
+  nonaffirmativeCount: 26,
+  nonaffirmativeProportion: 0.65,
+  warnings: [],
+  seed: 4242,
+};
+
+/** A run stored before the backend started pinning and reporting a seed */
+const withoutSeed = (results: RTMAResults): RTMAResults => {
+  const legacy = { ...results };
+  delete legacy.seed;
+  return legacy;
+};
+
+// RTMA results travel through the export path in the ModelResults slot.
+const asModelResults = (results: RTMAResults): ModelResults =>
+  results as unknown as ModelResults;
+
+const generate = (results: RTMAResults) =>
+  generateWrapperScript(
+    versionInfo,
+    rtmaParameters,
+    asModelResults(results),
+    40,
+  );
+
+describe("generateWrapperScript (RTMA)", () => {
+  it("passes the seed the run used into run_rtma_model", () => {
+    const script = generate(rtmaResults);
+
+    // The seed has to reach phacking_meta(), which run_rtma_model() reads out
+    // of the parameters list; a bare set.seed() elsewhere in the file would
+    // not survive a backend that re-seeds itself.
+    expect(script).toContain("seed = 4242");
+    expect(script).toMatch(/parameters <- list\([\s\S]*seed = 4242[\s\S]*\)/);
+    expect(script).toContain("set.seed(parameters$seed)");
+    // Still the JSON-string contract the Plumber-facing function expects.
+    expect(script).toContain("jsonlite::toJSON(parameters, auto_unbox = TRUE)");
+  });
+
+  it("verifies at runtime that the fit honored the requested seed", () => {
+    const script = generate(rtmaResults);
+
+    expect(script).toContain("Seed requested:");
+    expect(script).toContain("results$seed");
+  });
+
+  it("flags a run recorded before RTMA sampling was seeded", () => {
+    const script = generate(withoutSeed(rtmaResults));
+
+    expect(script).toContain("seed = 2025");
+    expect(script).toContain("recorded no seed");
+  });
+
+  it("leaves the MAIVE script alone", () => {
+    const maiveScript = generateWrapperScript(
+      versionInfo,
+      { ...rtmaParameters, modelType: "MAIVE", shouldUseInstrumenting: true },
+      asModelResults(rtmaResults),
+      40,
+    );
+
+    expect(maiveScript).toContain("run_maive_model(");
+    expect(maiveScript).not.toContain("set.seed(parameters$seed)");
+  });
+});

--- a/apps/react-ui/client/src/types/api.ts
+++ b/apps/react-ui/client/src/types/api.ts
@@ -122,6 +122,10 @@ type RTMAResults = {
   unadjustedMean?: number;
   // Level of the equal-tailed credible intervals in muCI and tauCI.
   ciLevel?: number;
+  // RNG seed the sampler ran under. The credible intervals are posterior
+  // quantiles, so they depend on it; runs stored before the backend pinned a
+  // seed (#479) have no value and are not exactly reproducible.
+  seed?: number;
   // Estimates analyzed after the se > 0 filter, the affirmative share of
   // them, and the uploaded rows removed by that filter.
   k?: number;

--- a/docs/PUBLIC_API_DESIGN.md
+++ b/docs/PUBLIC_API_DESIGN.md
@@ -231,10 +231,19 @@ plus `funnelPlot`/`funnelPlotWidth`/`funnelPlotHeight` only with
 ### 6.4 `POST /v1/run-rtma`: synchronous RTMA
 
 Same envelope; parameters (all optional): `favorPositive` (default `true`),
-`alphaSelect` (`0.05`), `ciLevel` (`0.95`), `winsorize` (`0`). The internal
-`parallelize` / `timeoutSeconds` knobs are **not** exposed. Response: `mu`,
-`muCI`, `tau`, `tauCI`, `nonaffirmativeCount`, `nonaffirmativeProportion`,
-`warnings` (+ `zScorePlot*` with `?include=plot`).
+`alphaSelect` (`0.05`), `ciLevel` (`0.95`), `winsorize` (`0`), `seed` (`2025`).
+The internal `parallelize` / `timeoutSeconds` knobs are **not**
+exposed. Response: `mu`, `muCI`, `tau`, `tauCI`, `seed`,
+`nonaffirmativeCount`, `nonaffirmativeProportion`, `warnings` (+ `zScorePlot*`
+with `?include=plot`).
+
+`seed` is exposed where `parallelize` / `timeoutSeconds` are not, because those
+two only change how the fit is executed while the seed changes the numbers that
+come back: `phacking_meta()` takes no seed, so an unseeded fit returns a
+different credible interval on every call for identical input (#479). The
+sampler is seeded immediately before the fit and the seed used is always echoed
+in the response, so a caller can reproduce a result exactly, or vary the seed
+deliberately to check that an interval is Monte Carlo stable.
 
 `mu` and `muCI` are reported on the sign convention of the submitted data:
 `phacking_meta()` fits on `-yi` when `favorPositive` is `false`, and

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -564,6 +564,15 @@ components:
           type: number
           description: Winsorization percentage applied to effect sizes and standard errors. 0 disables it.
           default: 0
+        seed:
+          type: integer
+          minimum: 1
+          default: 2025
+          description: >-
+            RNG seed for the sampler. The credible intervals are posterior
+            quantiles, so they depend on it: the same data and seed return the
+            same numbers, and varying it is how you check that an interval is
+            Monte Carlo stable. Always echoed back in the response.
 
     RunModelRequest:
       type: object
@@ -785,6 +794,7 @@ components:
         - tauCI
         - unadjustedMean
         - ciLevel
+        - seed
         - k
         - affirmativeCount
         - droppedRows
@@ -835,6 +845,12 @@ components:
         ciLevel:
           type: number
           description: Level of the credible intervals, echoed from the request.
+        seed:
+          type: integer
+          description: >-
+            RNG seed the sampler ran under, echoed from the request or the
+            default when none was sent. Re-running with the same data and seed
+            reproduces these numbers exactly.
         k:
           type: integer
           description: >-


### PR DESCRIPTION
Fixes #479.

## Problem

`phacking::phacking_meta()` takes no seed argument and the backend set none, so RStan drew a fresh one on every call. The mode is stable (it comes from a deterministic `mle_params()` optimisation), but the credible interval is a posterior quantile and moved between runs on identical input: the reporter measured the mu lower bound going -0.712, -0.759, -0.999 across three runs of the same request, with the tau interval moving by about a third. That is Monte Carlo noise reported as statistical uncertainty.

## What changed

- **`rtma_model.R`** seeds the sampler with `set.seed()` immediately before `phacking_meta()`. The seed is a parameter (`params$seed`) with a fixed default (`RTMA_DEFAULT_SEED`), read the same way as the existing `parallelize` / `timeoutSeconds` knobs.
- **The response carries `seed`**, so the numbers a user sees are traceable to the draw that produced them.
- **Run Info shows the seed for RTMA runs only**, and the RTMA results CSV export includes it. Runs stored before this change show "Not recorded" rather than a fake value.
- **The generated replication script pins it.** `run_analysis.R` now writes `seed = <n>` into the `parameters` list it passes to `run_rtma_model()`, so the seed actually reaches `phacking_meta()`, and prints a `REPRODUCIBILITY` block that checks the returned `results$seed` against the requested one. It also calls `set.seed(parameters$seed)` just before the run: the bundled `rtma_model.R` is fetched from the backend commit the analysis ran on, and pre-seed versions ignore `parameters$seed` entirely. Nothing between that call and `phacking_meta()` touches the RNG, so the sampler starts from the same state either way.

## Behaviour change to disclose (release notes)

**Every reported RTMA credible interval shifts once**, to whatever the pinned seed gives. Nothing about the estimator changed: the same posterior is being summarised, from one fixed draw instead of an arbitrary one. It is a one-time correction from "arbitrary and unreproducible" to "fixed and disclosed", not a regression, but published numbers from earlier app versions will not match a rerun to the last digits.

## Is the seed internal or user-facing?

`api_v1.R:461` notes that the internal `parallelize` / `timeoutSeconds` knobs are deliberately not exposed in `/v1`. The seed is **not** in that category and this PR exposes it as a public `/v1/run-rtma` parameter, because those two only change how the fit is executed while the seed changes the numbers that come back. A caller who wants to reproduce a response exactly, or to vary the seed deliberately and confirm an interval is Monte Carlo stable, needs to be able to set it, and the response reports it either way. It is validated as a positive integer (400 otherwise) and left out of the parameter list when omitted, so `RTMA_DEFAULT_SEED` stays the single definition of the default.

The UI does not send a seed; it takes the backend default.

## Choosing the default

The value is arbitrary, but not free of consequences. On a weakly identified dataset the sampler's trajectory depends on where it starts, so some seeds send it into a pathologically deep tree and a fit that normally takes seconds runs for minutes. Measured on the repo's own e2e fixtures:

| fixture | slow seeds | fast seeds |
|---|---|---|
| "precise estimates" (75 rows) | 20250101, 2026 (>90s) | 1, 7, 42, 12345 (1-3s) |
| near-degenerate `/v1` fixture (40 rows, 5 distinct effects) | 42, 8454 (>45s) | 1701, 2025, 7, 1, 12345, 99 (6-8s) |

Unseeded runs took that gamble on every call, so this is not a new failure mode, but pinning makes it deterministic. `RTMA_DEFAULT_SEED = 2025` was timed against every RTMA fixture in the e2e suite (all six under 8 seconds). Any dataset can still be unlucky, which is what the existing wall-clock limit is for.

## Relation to #489

#489 item 3 ("no seed") is the only part addressed here. Untouched: precision loss from `digits = 4` on re-serialization (1), unpinned `phacking` (2), `expected_results.json` bundled but never compared (4), `rtma_model.R` treated as an optional download (5), winsorization metadata always `undefined` (6), and the generic MAIVE-flavoured README sections (7).

Out of scope by design: Lambda memory, `mc.cores`, and `parallelize` (#483 section 2). This change is a prerequisite for that work, not part of it.

## Testing

- New e2e scenario `rtma-seed` (`npm run r:test-e2e -- --scenario rtma-seed`): two `/run-rtma` runs with the same input and seed must agree on mu, tau, both medians and both interval bounds to every digit; `/v1/run-rtma` must echo a requested seed, land on the same numbers as the legacy route, apply the documented default when no seed is sent, and reject a non-integer seed with a 400. Verified it has teeth: with the `set.seed()` line removed it fails, reporting exactly the drift from the issue.
- Full `npm run r:test-e2e` suite run locally against a fresh backend: 15/16 scenarios pass. The one failure, `parameter_combinations`, is unrelated and pre-existing: its EK case runs `standardErrorTreatment: "bootstrap"` through the legacy `/run-model` route and exceeds the suite's 30s client timeout. That path sources only `maive_model.R`, which this PR does not touch.
- `npm run ui:test`: new `RunInfoModal` and `wrapperScript` suites cover the seed row, the "Not recorded" fallback, that no seed row appears for non-RTMA models, and that the generated script puts the seed inside the `parameters` list rather than merely somewhere in the file.
- End-to-end check of the actual deliverable: generated a package, ran `Rscript run_analysis.R` twice, and confirmed byte-identical results and a `The fit ran under the requested seed` line.
- `npm run ui:lint` clean.
