### PR TITLE
fix: make rtma reproducibility packages reproduce the numbers they report

### DIFF
--- a/apps/lambda-r-backend/Dockerfile.rlib
+++ b/apps/lambda-r-backend/Dockerfile.rlib
@@ -50,7 +50,9 @@ RUN if [ -n "${GITHUB_PAT:-}" ]; then \
 # Install pak (fast installer)
 RUN R -q -e "install.packages('pak', repos='https://cran.rstudio.com')"
 
-# Install CRAN packages from list
+# Install CRAN packages from list. Entries may carry a pak version ref
+# (pkg@version); phacking is pinned that way so a rebuilt image keeps shipping
+# the RTMA implementation the exported reproducibility packages name (#489).
 COPY r_scripts/r-packages.txt /tmp/r-packages.txt
 RUN R -q -e "pkgs <- readLines('/tmp/r-packages.txt'); pak::pkg_install(pkgs)"
 

--- a/apps/lambda-r-backend/r_scripts/r-packages.txt
+++ b/apps/lambda-r-backend/r_scripts/r-packages.txt
@@ -7,4 +7,4 @@ metafor
 ragg
 systemfonts
 textshaping
-phacking
+phacking@0.2.1

--- a/apps/react-ui/client/src/CONST.ts
+++ b/apps/react-ui/client/src/CONST.ts
@@ -55,6 +55,11 @@ const CONST = {
     DEFAULTS: {
       R_VERSION: "4.4.1",
       MAIVE_TAG: "0.0.3.4",
+      // Must equal the version pinned in
+      // apps/lambda-r-backend/r_scripts/r-packages.txt, which is what the
+      // backend image actually installs. phackingVersionPin.test.ts fails the
+      // build if the two drift apart.
+      PHACKING_VERSION: "0.2.1",
     },
   },
 

--- a/apps/react-ui/client/src/components/Footer.tsx
+++ b/apps/react-ui/client/src/components/Footer.tsx
@@ -97,6 +97,7 @@ function isVersionInfo(value: unknown): value is VersionInfo {
     typeof candidate.maiveTag === "string" &&
     typeof candidate.gitCommitHash === "string" &&
     typeof candidate.rVersion === "string" &&
+    typeof candidate.phackingVersion === "string" &&
     typeof candidate.timestamp === "string"
   );
 }

--- a/apps/react-ui/client/src/lib/reproducibility/generators/readme.ts
+++ b/apps/react-ui/client/src/lib/reproducibility/generators/readme.ts
@@ -386,6 +386,12 @@ export function generateVersionManifest(
   parameters: ModelParameters,
 ): string {
   const timestamp = versionInfo.timestamp;
+  // RTMA is fitted by phacking rather than by the MAIVE package, so its version
+  // is the one that has to be recorded for an RTMA run to be reproducible.
+  const isRtma = parameters.modelType === "RTMA";
+  const phackingLine = isRtma
+    ? `\nphacking R Package:      ${versionInfo.phackingVersion}`
+    : "";
 
   return `MAIVE Analysis Reproducibility Package - Version Manifest
 ============================================================
@@ -396,7 +402,7 @@ SOFTWARE VERSIONS
 -----------------
 MAIVE UI Version:        ${versionInfo.uiVersion}
 MAIVE R Package:         ${versionInfo.maiveTag}
-R Version:               ${versionInfo.rVersion}
+R Version:               ${versionInfo.rVersion}${phackingLine}
 Git Commit Hash:         ${versionInfo.gitCommitHash}
 
 GITHUB REFERENCES
@@ -426,7 +432,9 @@ Winsorize:               ${parameters.winsorize}%
 PACKAGE DEPENDENCIES
 --------------------
 Required R packages:
-  - MAIVE (${versionInfo.maiveTag})
+  - MAIVE (${versionInfo.maiveTag})${
+    isRtma ? `\n  - phacking (${versionInfo.phackingVersion})` : ""
+  }
   - jsonlite
   - base64enc
   - metafor
@@ -445,7 +453,11 @@ This package contains:
 
 To ensure perfect reproducibility:
   - Use R version ${versionInfo.rVersion} or compatible
-  - Install MAIVE package version ${versionInfo.maiveTag}
+  - Install MAIVE package version ${versionInfo.maiveTag}${
+    isRtma
+      ? `\n  - Install phacking package version ${versionInfo.phackingVersion} (run_analysis.R does this)`
+      : ""
+  }
   - Run from the same working directory as the extracted files
   - For bootstrap methods, results may vary slightly due to randomness
 

--- a/apps/react-ui/client/src/lib/reproducibility/generators/wrapperScript.test.ts
+++ b/apps/react-ui/client/src/lib/reproducibility/generators/wrapperScript.test.ts
@@ -8,6 +8,7 @@ const versionInfo: VersionInfo = {
   maiveTag: "0.2.5",
   gitCommitHash: "abc1234",
   rVersion: "4.4.1",
+  phackingVersion: "0.2.1",
   timestamp: "2026-01-01T00:00:00.000Z",
 };
 
@@ -77,5 +78,22 @@ describe("generateWrapperScript", () => {
     expect(script).not.toContain(
       "abs(results$effectEstimate - expected$effectEstimate) < tolerance",
     );
+  });
+
+  it("feeds the model full-precision input on the local re-run", () => {
+    // The rounding above is a property of the API *response*. The input must
+    // not be rounded on the way back in: jsonlite::toJSON() writes 4 decimal
+    // places by default, which alters small standard errors before the refit
+    // and defeats the point of an app that detects spurious precision (#489).
+    // The backend serializes its own input with digits = NA (api_v1.R).
+    const script = generateWrapperScript(versionInfo, parameters, results, 60);
+
+    expect(script).toContain(
+      'jsonlite::toJSON(data, dataframe = "rows", digits = NA)',
+    );
+    expect(script).toContain(
+      "jsonlite::toJSON(parameters, auto_unbox = TRUE, digits = NA)",
+    );
+    expect(script).not.toContain('jsonlite::toJSON(data, dataframe = "rows")');
   });
 });

--- a/apps/react-ui/client/src/lib/reproducibility/generators/wrapperScript.ts
+++ b/apps/react-ui/client/src/lib/reproducibility/generators/wrapperScript.ts
@@ -134,6 +134,184 @@ cat("  Winsorize:", parameters$winsorize, "%\\n")
 }
 
 /**
+ * A single number the generated script checks against expected_results.json
+ */
+type VerificationField = {
+  /** R variable that receives the outcome of the comparison */
+  variable: string;
+  /** Label printed in the PASS/FAIL list; " Match:" is appended */
+  label: string;
+  /** R expression for the value the local re-run produced */
+  actual: string;
+  /** R expression for the recorded value, rooted at `expected` */
+  expected: string;
+};
+
+/**
+ * Generates the block that compares a local re-run against the numbers the web
+ * application reported.
+ *
+ * Shared by the MAIVE and RTMA scripts because the comparison itself is the
+ * same everywhere: round to the precision the API response carries, skip
+ * fields the stored run predates, print PASS/FAIL. Only the field list and the
+ * plausible causes of a mismatch differ, so those are the arguments. RTMA
+ * previously shipped expected_results.json without ever reading it (#489).
+ *
+ * @param fields - Values to compare, in the order they should be printed
+ * @param mismatchCauses - Explanations listed when a comparison fails
+ */
+function generateVerificationSection(
+  fields: VerificationField[],
+  mismatchCauses: string[],
+): string {
+  const labelWidth = Math.max(
+    ...fields.map((field) => `${field.label} Match:`.length),
+  );
+
+  const comparisons = fields
+    .map(
+      (field) =>
+        `${field.variable} <- if (recorded(${field.expected})) abs(round(${field.actual}, 4) - ${field.expected}) < tolerance else NA`,
+    )
+    .join("\n");
+
+  const report = fields
+    .map(
+      (field) =>
+        `cat("${`${field.label} Match:`.padEnd(labelWidth)}", verdict(${field.variable}), "\\n")`,
+    )
+    .join("\n");
+
+  const causes = mismatchCauses
+    .map((cause) => `  cat("  - ${cause}\\n")`)
+    .join("\n");
+
+  return `
+# Compare with expected results
+cat("\\n=== VERIFICATION ===\\n")
+cat("Comparing with expected results from web application...\\n")
+
+expected <- jsonlite::fromJSON("expected_results.json")
+tolerance <- 1e-8
+
+# expected_results.json was captured from the web app's JSON API response,
+# which rounds every numeric field to 4 decimal places before it reaches the
+# browser (jsonlite::toJSON default digits = 4). This script's local re-run
+# is not rounded, so round to that same precision before comparing.
+#
+# Fields the original run predates are absent from the file; those are reported
+# as unrecorded instead of counting as a mismatch.
+recorded <- function(value) !is.null(value) && length(value) == 1 && is.finite(value)
+verdict <- function(match) {
+  if (is.na(match)) "- not recorded" else if (match) "\\u2713 PASS" else "\\u2717 FAIL"
+}
+
+${comparisons}
+
+${report}
+
+checks <- c(${fields.map((field) => field.variable).join(", ")})
+if (all(is.na(checks))) {
+  cat("\\n\\u26a0 expected_results.json records none of these fields; nothing to verify.\\n")
+} else if (all(checks[!is.na(checks)])) {
+  cat("\\n\\u2713 All key results match! Reproducibility confirmed.\\n")
+  if (any(is.na(checks))) {
+    cat("  (fields shown as not recorded were absent from expected_results.json)\\n")
+  }
+} else {
+  cat("\\n\\u26a0 Some results differ. This may be due to:\\n")
+${causes}
+}
+`;
+}
+
+/**
+ * Generates the RTMA verification block
+ *
+ * Compares the fields the RTMA response carries. The credible interval bounds
+ * are checked individually because they are what the sampler seed moves, so a
+ * matching mode with a drifting interval has to be visible.
+ */
+function generateRtmaVerificationSection(phackingVersion: string): string {
+  return generateVerificationSection(
+    [
+      {
+        variable: "mu_match",
+        label: "mu (mode)",
+        actual: "results$mu",
+        expected: "expected$mu",
+      },
+      {
+        variable: "mu_median_match",
+        label: "mu (median)",
+        actual: "results$muMedian",
+        expected: "expected$muMedian",
+      },
+      {
+        variable: "mu_ci_lower_match",
+        label: "mu CI lower",
+        actual: "results$muCI[1]",
+        expected: "expected$muCI[1]",
+      },
+      {
+        variable: "mu_ci_upper_match",
+        label: "mu CI upper",
+        actual: "results$muCI[2]",
+        expected: "expected$muCI[2]",
+      },
+      {
+        variable: "tau_match",
+        label: "tau (mode)",
+        actual: "results$tau",
+        expected: "expected$tau",
+      },
+      {
+        variable: "tau_median_match",
+        label: "tau (median)",
+        actual: "results$tauMedian",
+        expected: "expected$tauMedian",
+      },
+      {
+        variable: "tau_ci_lower_match",
+        label: "tau CI lower",
+        actual: "results$tauCI[1]",
+        expected: "expected$tauCI[1]",
+      },
+      {
+        variable: "tau_ci_upper_match",
+        label: "tau CI upper",
+        actual: "results$tauCI[2]",
+        expected: "expected$tauCI[2]",
+      },
+      {
+        variable: "unadjusted_mean_match",
+        label: "Unadjusted FE mean",
+        actual: "results$unadjustedMean",
+        expected: "expected$unadjustedMean",
+      },
+      {
+        variable: "k_match",
+        label: "Estimates used (k)",
+        actual: "results$k",
+        expected: "expected$k",
+      },
+      {
+        variable: "affirmative_match",
+        label: "Affirmative count",
+        actual: "results$affirmativeCount",
+        expected: "expected$affirmativeCount",
+      },
+    ],
+    [
+      `A different phacking version (this run: ${phackingVersion})`,
+      "A different sampler seed, reported above",
+      "A different R version or Stan toolchain",
+      "Floating-point arithmetic differences",
+    ],
+  );
+}
+
+/**
  * Generates the results display section
  */
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -182,34 +360,94 @@ if (!identical(results$firstStageFStatistic, "NA") && !is.null(results$firstStag
 cat("Hausman Statistic: ", sprintf("%.6f", results$hausmanTest$statistic), "\\n")
 cat("Chi-Squared CV:    ", sprintf("%.6f", results$hausmanTest$criticalValue), "\\n")
 cat("Rejects Null:      ", results$hausmanTest$rejectsNull, "\\n")
+${generateVerificationSection(
+  [
+    {
+      variable: "effect_match",
+      label: "Effect Estimate",
+      actual: "results$effectEstimate",
+      expected: "expected$effectEstimate",
+    },
+    {
+      variable: "se_match",
+      label: "Standard Error",
+      actual: "results$standardError",
+      expected: "expected$standardError",
+    },
+    {
+      variable: "egger_match",
+      label: "Egger Coefficient",
+      actual: "results$publicationBias$eggerCoef",
+      expected: "expected$publicationBias$eggerCoef",
+    },
+  ],
+  [
+    "Different R version",
+    "Different MAIVE package version",
+    "Different random seed (for bootstrap methods)",
+    "Floating-point arithmetic differences",
+  ],
+)}`;
+}
 
-# Compare with expected results
-cat("\\n=== VERIFICATION ===\\n")
-cat("Comparing with expected results from web application...\\n")
+/**
+ * Generates the phacking installation block for the RTMA script
+ *
+ * phacking is the RTMA implementation, so installing "whatever CRAN has today"
+ * means a package regenerated later can silently refit under a different
+ * method (#489). Install the recorded version instead, and say so when the
+ * loaded one differs.
+ *
+ * @param phackingVersion - Version the backend image ran under
+ */
+function generatePhackingInstallSection(phackingVersion: string): string {
+  // A backend that never reported its phacking version (or reported something
+  // that is not a version) leaves nothing to pin to. Falling back to the
+  // unpinned install is still better than failing the script, as long as it
+  // says out loud that the RTMA implementation is not the recorded one.
+  if (!/^\d+(\.\d+)*$/.test(phackingVersion)) {
+    return `
+# Install phacking package (RTMA)
+cat("\\n\\u26a0 This package does not record the phacking version the analysis ran\\n")
+cat("  under, so the current CRAN release is installed instead. The RTMA\\n")
+cat("  implementation may differ from the one the web application used.\\n")
+if (!requireNamespace("phacking", quietly = TRUE)) {
+  install.packages("phacking", repos = "https://cloud.r-project.org/")
+}
+library(phacking)
+`;
+  }
 
-expected <- jsonlite::fromJSON("expected_results.json")
-tolerance <- 1e-8
+  return `
+# Install phacking package (RTMA), pinned to the version the web application
+# ran under. phacking is the RTMA implementation itself, so an unpinned install
+# would quietly change the method once CRAN moves on.
+phacking_version <- "${phackingVersion}"
+phacking_ready <- requireNamespace("phacking", quietly = TRUE) &&
+  identical(as.character(utils::packageVersion("phacking")), phacking_version)
 
-# expected_results.json was captured from the web app's JSON API response,
-# which rounds every numeric field to 4 decimal places before it reaches the
-# browser (jsonlite::toJSON default digits = 4). This script's local re-run
-# is not rounded, so round to that same precision before comparing.
-effect_match <- abs(round(results$effectEstimate, 4) - expected$effectEstimate) < tolerance
-se_match <- abs(round(results$standardError, 4) - expected$standardError) < tolerance
-egger_match <- abs(round(results$publicationBias$eggerCoef, 4) - expected$publicationBias$eggerCoef) < tolerance
+if (!phacking_ready) {
+  cat("\\nInstalling phacking", phacking_version, "...\\n")
+  if (!requireNamespace("remotes", quietly = TRUE)) {
+    install.packages("remotes", repos = "https://cloud.r-project.org/")
+  }
+  # install_version() falls back to the CRAN archive once this version is no
+  # longer the current release.
+  remotes::install_version(
+    "phacking",
+    version = phacking_version,
+    repos = "https://cloud.r-project.org/",
+    upgrade = "never"
+  )
+}
+library(phacking)
 
-cat("Effect Estimate Match:  ", ifelse(effect_match, "✓ PASS", "✗ FAIL"), "\\n")
-cat("Standard Error Match:   ", ifelse(se_match, "✓ PASS", "✗ FAIL"), "\\n")
-cat("Egger Coefficient Match:", ifelse(egger_match, "✓ PASS", "✗ FAIL"), "\\n")
-
-if (effect_match && se_match && egger_match) {
-  cat("\\n✓ All key results match! Reproducibility confirmed.\\n")
+phacking_loaded <- as.character(utils::packageVersion("phacking"))
+if (identical(phacking_loaded, phacking_version)) {
+  cat("\\u2713 phacking", phacking_version, "loaded\\n")
 } else {
-  cat("\\n⚠ Some results differ. This may be due to:\\n")
-  cat("  - Different R version\\n")
-  cat("  - Different MAIVE package version\\n")
-  cat("  - Different random seed (for bootstrap methods)\\n")
-  cat("  - Floating-point arithmetic differences\\n")
+  cat("\\u26a0 phacking", phacking_loaded, "is loaded, but this analysis ran under",
+      phacking_version, "- results may differ\\n")
 }
 `;
 }
@@ -246,6 +484,7 @@ function generateRtmaWrapperScript(
 # Method:          RTMA (Mathur, 2024)
 # Git Commit:      ${versionInfo.gitCommitHash}
 # R Version:       ${versionInfo.rVersion}
+# phacking:        ${versionInfo.phackingVersion} (the RTMA implementation)
 ${seedHeaderNote}
 #
 # This script reproduces the RTMA analysis performed in the
@@ -259,6 +498,7 @@ cat("RTMA Analysis Reproducibility Script\\n")
 cat("============================================================\\n")
 cat("UI Version:    ${versionInfo.uiVersion}\\n")
 cat("R Version:     ${versionInfo.rVersion}\\n")
+cat("phacking:      ${versionInfo.phackingVersion}\\n")
 cat("Git Commit:    ${versionInfo.gitCommitHash}\\n")
 cat("============================================================\\n\\n")
 
@@ -288,14 +528,7 @@ if (length(missing_packages) > 0) {
 for (pkg in required_packages) {
   suppressPackageStartupMessages(library(pkg, character.only = TRUE))
 }
-
-# Install phacking package (RTMA)
-cat("\\nInstalling phacking package...\\n")
-if (!requireNamespace("phacking", quietly = TRUE)) {
-  install.packages("phacking", repos = "https://cloud.r-project.org/")
-}
-library(phacking)
-
+${generatePhackingInstallSection(versionInfo.phackingVersion)}
 cat("\\u2713 Environment setup complete\\n")
 
 # ============================================================
@@ -362,9 +595,14 @@ set.seed(parameters$seed)
 
 # Run the analysis using the same function as the web backend
 # Note: run_rtma_model expects JSON strings (designed for Plumber backend)
+#
+# digits = NA keeps every value at full double precision. jsonlite::toJSON()
+# otherwise writes 4 decimal places, which would round the standard errors
+# before the model ever sees them and refit on different data than the web
+# application did (#489). The backend serializes its own input the same way.
 results <- run_rtma_model(
-  jsonlite::toJSON(data, dataframe = "rows"),
-  jsonlite::toJSON(parameters, auto_unbox = TRUE)
+  jsonlite::toJSON(data, dataframe = "rows", digits = NA),
+  jsonlite::toJSON(parameters, auto_unbox = TRUE, digits = NA)
 )
 
 cat("\\u2713 Analysis complete\\n")
@@ -416,7 +654,7 @@ cat("Affirmative:     ", results$affirmativeCount, "\\n")
 cat("Not affirmative: ", results$nonaffirmativeCount,
     sprintf("(%.1f%%)", results$nonaffirmativeProportion * 100), "\\n")
 cat("Dropped rows:    ", results$droppedRows, "\\n")
-
+${generateRtmaVerificationSection(versionInfo.phackingVersion)}
 cat("\\n=== Z-SCORE DENSITY PLOT ===\\n")
 if (!is.null(results$zScorePlot) && results$zScorePlot != "") {
   # Decode base64 image
@@ -623,9 +861,14 @@ cat("========================================\\n\\n")
 
 # Run the analysis using the same function as the web backend
 # Note: run_maive_model expects JSON strings (designed for Lambda/Plumber backend)
+#
+# digits = NA keeps every value at full double precision. jsonlite::toJSON()
+# otherwise writes 4 decimal places, which would round the standard errors
+# before the model ever sees them and refit on different data than the web
+# application did (#489). The backend serializes its own input the same way.
 results <- run_maive_model(
-  jsonlite::toJSON(data, dataframe = "rows"),
-  jsonlite::toJSON(parameters, auto_unbox = TRUE)
+  jsonlite::toJSON(data, dataframe = "rows", digits = NA),
+  jsonlite::toJSON(parameters, auto_unbox = TRUE, digits = NA)
 )
 
 cat("✓ Analysis complete\\n")

--- a/apps/react-ui/client/src/pages/api/get-version-info.ts
+++ b/apps/react-ui/client/src/pages/api/get-version-info.ts
@@ -12,6 +12,7 @@ import type { VersionInfo } from "@src/types/reproducibility";
  * - MAIVE R package tag
  * - Git commit hash
  * - R version
+ * - phacking version (the RTMA implementation)
  * - Current timestamp
  */
 
@@ -55,11 +56,19 @@ function getVersionInfo(): VersionInfo {
   const rVersion =
     process.env.R_VERSION ?? CONST.REPRODUCIBILITY.DEFAULTS.R_VERSION;
 
+  // phacking version, pinned at image build time in r-packages.txt. The default
+  // mirrors that pin (a test fails if the two drift), so an RTMA package always
+  // names the implementation it ran under and can reinstall exactly that one.
+  const phackingVersion =
+    process.env.PHACKING_VERSION ??
+    CONST.REPRODUCIBILITY.DEFAULTS.PHACKING_VERSION;
+
   cachedVersionInfo = {
     uiVersion,
     maiveTag,
     gitCommitHash,
     rVersion,
+    phackingVersion,
     timestamp: new Date().toISOString(),
   };
 

--- a/apps/react-ui/client/src/tests/phackingVersionPin.test.ts
+++ b/apps/react-ui/client/src/tests/phackingVersionPin.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "fs";
+import { join } from "path";
+import CONST from "@src/CONST";
+
+/**
+ * An RTMA reproducibility package names the phacking version it ran under and
+ * reinstalls exactly that one (#489). That promise only holds if the version
+ * the UI reports is the version the backend image actually installs, so read
+ * the pin out of r-packages.txt instead of trusting the constant on its own.
+ *
+ * process.cwd() is apps/react-ui/client when the suite runs.
+ */
+const R_PACKAGES_PATH = join(
+  process.cwd(),
+  "../../..",
+  "apps/lambda-r-backend/r_scripts/r-packages.txt",
+);
+
+function readPackageEntries(): string[] {
+  return readFileSync(R_PACKAGES_PATH, "utf-8")
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+}
+
+describe("phacking version pin", () => {
+  it("pins phacking to an exact version in the backend package list", () => {
+    const entry = readPackageEntries().find((line) =>
+      line.startsWith("phacking"),
+    );
+
+    expect(entry).toBeDefined();
+    // pak reads this file verbatim; "phacking" alone installs whatever CRAN
+    // ships on the day the image is rebuilt.
+    expect(entry).toMatch(/^phacking@\d+(\.\d+)*$/);
+  });
+
+  it("reports the pinned version to the reproducibility package", () => {
+    const entry = readPackageEntries().find((line) =>
+      line.startsWith("phacking@"),
+    );
+    const pinnedVersion = entry?.split("@")[1];
+
+    expect(CONST.REPRODUCIBILITY.DEFAULTS.PHACKING_VERSION).toBe(pinnedVersion);
+  });
+});

--- a/apps/react-ui/client/src/tests/reproducibilityWrapperScript.test.ts
+++ b/apps/react-ui/client/src/tests/reproducibilityWrapperScript.test.ts
@@ -12,6 +12,7 @@ const versionInfo: VersionInfo = {
   maiveTag: "0.0.3.4",
   gitCommitHash: "abc1234",
   rVersion: "4.4.2",
+  phackingVersion: "0.2.1",
   timestamp: "2026-08-09T10:00:00.000Z",
 };
 
@@ -73,7 +74,93 @@ describe("generateWrapperScript (RTMA)", () => {
     expect(script).toMatch(/parameters <- list\([\s\S]*seed = 4242[\s\S]*\)/);
     expect(script).toContain("set.seed(parameters$seed)");
     // Still the JSON-string contract the Plumber-facing function expects.
-    expect(script).toContain("jsonlite::toJSON(parameters, auto_unbox = TRUE)");
+    expect(script).toContain(
+      "jsonlite::toJSON(parameters, auto_unbox = TRUE, digits = NA)",
+    );
+  });
+
+  it("feeds the model full-precision input on the local re-run", () => {
+    // jsonlite::toJSON() writes 4 decimal places by default, which rounds small
+    // standard errors before phacking ever sees them and refits on different
+    // data than the web application used (#489). The backend serializes its own
+    // input with digits = NA (api_v1.R).
+    const script = generate(rtmaResults);
+
+    expect(script).toContain(
+      'jsonlite::toJSON(data, dataframe = "rows", digits = NA)',
+    );
+    expect(script).not.toContain('jsonlite::toJSON(data, dataframe = "rows")');
+  });
+
+  it("verifies the fresh fit against expected_results.json", () => {
+    // RTMA packages shipped the expectations file and never read it (#489).
+    const script = generate(rtmaResults);
+
+    expect(script).toContain("=== VERIFICATION ===");
+    expect(script).toContain(
+      'expected <- jsonlite::fromJSON("expected_results.json")',
+    );
+
+    // RTMA fields, not MAIVE's effect/SE/Egger ones.
+    expect(script).toContain(
+      "mu_match <- if (recorded(expected$mu)) abs(round(results$mu, 4) - expected$mu) < tolerance else NA",
+    );
+    expect(script).toContain(
+      "tau_match <- if (recorded(expected$tau)) abs(round(results$tau, 4) - expected$tau) < tolerance else NA",
+    );
+    // The credible intervals are what the sampler seed moves, so both bounds
+    // are checked rather than the point estimates alone.
+    expect(script).toContain(
+      "abs(round(results$muCI[1], 4) - expected$muCI[1])",
+    );
+    expect(script).toContain(
+      "abs(round(results$muCI[2], 4) - expected$muCI[2])",
+    );
+    expect(script).toContain(
+      "abs(round(results$tauCI[1], 4) - expected$tauCI[1])",
+    );
+    expect(script).toContain(
+      "abs(round(results$tauCI[2], 4) - expected$tauCI[2])",
+    );
+    expect(script).toContain(
+      "abs(round(results$unadjustedMean, 4) - expected$unadjustedMean)",
+    );
+
+    expect(script).toContain("\\u2713 PASS");
+    expect(script).toContain("\\u2717 FAIL");
+    expect(script).toContain(
+      "\\u2713 All key results match! Reproducibility confirmed.",
+    );
+
+    expect(script).not.toContain("expected$effectEstimate");
+  });
+
+  it("installs the phacking version the analysis ran under", () => {
+    // An unpinned install refits RTMA with whatever CRAN ships that day (#489).
+    const script = generate(rtmaResults);
+
+    expect(script).toContain('phacking_version <- "0.2.1"');
+    expect(script).toContain('remotes::install_version(\n    "phacking",');
+    expect(script).toContain("version = phacking_version,");
+    expect(script).toContain("# phacking:        0.2.1");
+    expect(script).not.toContain(
+      'install.packages("phacking", repos = "https://cloud.r-project.org/")',
+    );
+  });
+
+  it("falls back to an unpinned install when no phacking version was recorded", () => {
+    const script = generateWrapperScript(
+      { ...versionInfo, phackingVersion: "unknown" },
+      rtmaParameters,
+      asModelResults(rtmaResults),
+      40,
+    );
+
+    expect(script).toContain(
+      'install.packages("phacking", repos = "https://cloud.r-project.org/")',
+    );
+    expect(script).toContain("does not record the phacking version");
+    expect(script).not.toContain("remotes::install_version(");
   });
 
   it("verifies at runtime that the fit honored the requested seed", () => {

--- a/apps/react-ui/client/src/types/reproducibility.ts
+++ b/apps/react-ui/client/src/types/reproducibility.ts
@@ -14,6 +14,15 @@ export type VersionInfo = {
   gitCommitHash: string;
   /** R version used in backend (e.g., "4.4.1") */
   rVersion: string;
+  /**
+   * phacking CRAN version the backend image installs (e.g., "0.2.1").
+   *
+   * RTMA is fitted by phacking, so a package that does not name the version it
+   * ran under cannot be re-run against the same implementation (#489). Pinned
+   * in apps/lambda-r-backend/r_scripts/r-packages.txt; see the drift guard in
+   * phackingVersionPin.test.ts.
+   */
+  phackingVersion: string;
   /** Timestamp when version info was generated */
   timestamp: string;
 };


### PR DESCRIPTION
Closes items **1, 2, and 4** of #489. Item 3 (the sampler seed) landed in #507. Items **5, 6, and 7 stay open**: `rtma_model.R` is still treated as an optional download, winsorization metadata is still always `undefined`, and the README still promises MAIVE installation and funnel-plot output for RTMA packages.

## Item 1: the input data was rounded to 4 decimals before the refit

`jsonlite::toJSON()` defaults to `digits = 4`, so the generated wrapper handed the model a rounded copy of the user's data. The app exists to detect spurious precision in standard errors, and the export was destroying that precision on the way back in. Both call sites now pass `digits = NA`, matching what the backend does with its own input (`api_v1.R:585`).

Measured on a real 40-estimate RTMA package (details below), this is the difference between:

```
mu (mode) Match:          ✓ PASS        mu (mode) Match:          ✗ FAIL
mu CI lower Match:        ✓ PASS        mu CI lower Match:        ✗ FAIL
tau (mode) Match:         ✓ PASS        tau (mode) Match:         ✗ FAIL
   (digits = NA)                           (default digits = 4)
```

Every posterior quantity moves. The response-side rounding at the comparison step is untouched: `expected_results.json` really is the 4-digit API response, so rounding the fresh local result to match is correct there.

## Item 4: the RTMA script never read `expected_results.json`

Every package shipped the expectations file and the README promised automatic verification; only the MAIVE script delivered it.

I generalized the block instead of writing an RTMA counterpart. The comparison logic is identical for both models (round to the precision the API response carries, tolerate fields a stored run predates, print aligned PASS/FAIL, list plausible causes on failure), so a copy would mean fixing the next rounding or formatting bug twice. `generateVerificationSection(fields, mismatchCauses)` takes the field list and the failure explanations; MAIVE and RTMA each supply their own. The MAIVE comparison expressions are emitted unchanged, so the existing regression test still pins them.

RTMA compares mu and tau (mode and median), all four credible interval bounds, the unadjusted FE mean, k, and the affirmative count. The interval bounds get their own lines because they are what the sampler seed moves, so a matching mode with a drifting interval has to be visible rather than averaged away. Fields absent from a stored run report `- not recorded` instead of failing.

## Item 2: `phacking` was unpinned

`phacking` is the RTMA implementation, so "install whatever CRAN has today" means a package regenerated next year can silently fit a different method.

**Design decision: pinned at build time, not queried at runtime.** The pin lives in `r-packages.txt` (`phacking@0.2.1`), which is what the image actually installs, so the deployed backend becomes reproducible too, not just the export. `VersionInfo.phackingVersion` reports the same value, resolved as `process.env.PHACKING_VERSION ?? CONST.REPRODUCIBILITY.DEFAULTS.PHACKING_VERSION`, the same shape `rVersion` already uses. `phackingVersionPin.test.ts` reads `r-packages.txt` and fails if the constant and the pin ever disagree, so the reported version cannot drift from the shipped one.

The alternative was having the R backend report `packageVersion("phacking")` alongside `rVersion`. It reports the true installed version, but it leaves the image itself unpinned (half of what the issue asks), turns `/api/get-version-info` from a cached local read into a cross-service call, and gives package export a new failure mode when the R Lambda is cold or unreachable.

0.2.1 is not invented: it is the current CRAN release (published 2023-07-17) and the version installed in the dev environment, so the pin does not change what today's image ships. The generated script installs it with `remotes::install_version()`, which falls back to the CRAN archive once it stops being current, and prints a warning if a different version ends up loaded. A `VersionInfo` without a usable version falls back to the old unpinned install and says so out loud.

The version is also recorded in the manifest (software versions, dependencies, and the reproducibility notes) and in the script's header block, for RTMA runs only.

## Testing

- `npm run ui:test`: 187 passed, 29 files.
- `npm run ui:lint`: clean (the repo-wide `Delete ␍` noise is a local CRLF artifact, not from this branch). `npx tsc --noEmit` reports only the pre-existing `import.meta.vitest` error in `results.test.tsx`.
- New Vitest coverage: `digits = NA` reaches both serialization sites in both scripts, the RTMA script carries a verification block referencing the RTMA fields, the phacking install is pinned, the unpinned fallback works, and the pin matches `r-packages.txt`.
- **Real end-to-end run.** Built an actual RTMA package (40 estimates, full-precision `data.csv`, `expected_results.json` captured from the live local Plumber backend the way the browser captures it), extracted it, ran `Rscript run_analysis.R`, and got all 11 checks PASS plus `✓ All key results match! Reproducibility confirmed.` Re-ran the same package with `digits = NA` stripped out and 8 of 11 checks flipped to FAIL, which is the table above. Repeated the exercise for a MAIVE package to confirm the refactored block still passes there.
- `npm run r:test-e2e`: 15 passed, 1 failed. The failure is `parameter_combinations`, which is red at baseline on this machine (the EK combination exceeds the suite's 30s client timeout) and is unrelated to this branch. Nothing here changes R runtime behavior: the backend edits are a version suffix in `r-packages.txt` and a comment in `Dockerfile.rlib`.

## Note for the deploy

`r-packages.txt` is hashed into the rlib image tag, so this changes the tag and forces one R library rebuild.
