### PR TITLE
refactor: remove dead MAIVE_TAG reproducibility default

### DIFF
--- a/apps/react-ui/client/src/CONST.ts
+++ b/apps/react-ui/client/src/CONST.ts
@@ -53,13 +53,19 @@ const CONST = {
 
   REPRODUCIBILITY: {
     DEFAULTS: {
+      // Nothing in the repo records the R version the image was built with, so
+      // get-version-info needs a literal to fall back to.
       R_VERSION: "4.4.1",
-      MAIVE_TAG: "0.0.3.4",
       // Must equal the version pinned in
       // apps/lambda-r-backend/r_scripts/r-packages.txt, which is what the
       // backend image actually installs. phackingVersionPin.test.ts fails the
       // build if the two drift apart.
       PHACKING_VERSION: "0.2.1",
+      // No MAIVE tag default here, deliberately. The tag is committed to
+      // package.json (`maiveTag`) by scripts/set-maive-tag.sh alongside
+      // release.yml, and get-version-info reads it from there. A third copy
+      // would be one more thing to keep in sync, and a stale one silently pins
+      // reproducibility packages to a MAIVE version the backend cannot run.
     },
   },
 

--- a/apps/react-ui/client/src/types/reproducibility.ts
+++ b/apps/react-ui/client/src/types/reproducibility.ts
@@ -8,7 +8,7 @@
 export type VersionInfo = {
   /** UI application version from package.json (e.g., "0.3.17-0") */
   uiVersion: string;
-  /** MAIVE R package tag/version (e.g., "0.0.3.4") */
+  /** MAIVE R package tag/version (e.g., "v0.2.2") */
   maiveTag: string;
   /** Git commit hash of the deployed code */
   gitCommitHash: string;


### PR DESCRIPTION
## Problem

`CONST.REPRODUCIBILITY.DEFAULTS.MAIVE_TAG` was `"0.0.3.4"`, but the tag the app actually builds and deploys is `v0.2.2` (`.github/workflows/release.yml` `env.MAIVE_TAG`, and `maiveTag` in `apps/react-ui/client/package.json`).

It was also dead. `pages/api/get-version-info.ts` resolves the tag as `process.env.MAIVE_TAG ?? packageJson.maiveTag ?? "unknown"` and never consults the constant, unlike its `DEFAULTS` siblings `R_VERSION` and `PHACKING_VERSION`, which are both read. A repo-wide grep finds no other reader.

That matters because MAIVE 0.0.3.4 predates the `get_funnel_plot` export that `apps/lambda-r-backend/r_scripts/funnel_plot.R` calls. Anything that did fall back to this value would generate a reproducibility package pinned to a MAIVE version the bundled backend code cannot run against (`'get_funnel_plot' is not an exported object from 'namespace:MAIVE'`).

## What this does

Deletes the constant, rather than wiring it up as a last fallback.

Three reasons:

1. **The fallback would never fire in practice.** `maiveTag` is committed to `package.json` and kept in sync by `scripts/set-maive-tag.sh`. The only path to a third fallback is `package.json` losing the field, which is not a state worth carrying a hardcoded version for.
2. **When it did fire, failing loudly beats pinning silently.** `"unknown"` produces `install_github("PetrCala/MAIVE@unknown")`, which errors immediately and visibly, and `Footer.tsx` already special-cases `"unknown"` by rendering plain text instead of a dead tag link. A hardcoded tag would instead hand the user a package that installs cleanly and then fails inside the analysis, or worse, runs against the wrong version.
3. **It removes a sync point instead of adding one.** Keeping it means a third copy of the tag for `set-maive-tag.sh` to update, and a stale third copy is exactly what produced this bug.

The two remaining `DEFAULTS` entries stay, because neither has a better home: nothing in the repo records the R version the image was built with, and `PHACKING_VERSION` mirrors the `r-packages.txt` pin under a drift-guard test. I left a comment recording why the MAIVE tag is deliberately absent, so it does not get added back.

Also updated the `VersionInfo.maiveTag` JSDoc example, which used the same stale `0.0.3.4` as its illustration.

No change to `scripts/set-maive-tag.sh`: with the constant gone it still covers every place the tag lives.

## Verification

- `npm test -- --run`: 29 files, 187 tests, all passing (includes `phackingVersionPin.test.ts` from the sibling commit this is rebased on).
- `npx eslint` on both changed files: clean.
- `npx tsc --noEmit`: one error, `src/tests/integration/results.test.tsx` `Property 'vitest' does not exist on type 'ImportMeta'`. Pre-existing and unrelated: that line is identical on `master` and this branch does not touch the file.
