### PR TITLE
New version release

### DIFF
--- a/apps/lambda-r-backend/Dockerfile.rlib
+++ b/apps/lambda-r-backend/Dockerfile.rlib
@@ -17,9 +17,10 @@ ENV MAKEFLAGS="-j2"
 ENV R_REMOTES_NO_ERRORS_FROM_WARNINGS=true
 ENV R_INSTALL_STAGED=false
 
-# Build deps (headers + toolchain) and ensure libcurl (not minimal)
+# Build deps (headers + toolchain) and ensure libcurl (not minimal).
+# cmake is required by RcppParallel 6.x, which configures TBB through it.
 RUN dnf -y update && dnf -y install \
-    gcc gcc-c++ gcc-gfortran make \
+    gcc gcc-c++ gcc-gfortran make cmake \
     tar gzip wget which \
     perl perl-core \
     zlib-devel bzip2 bzip2-devel xz xz-devel pcre2-devel \


### PR DESCRIPTION
## Summary

The 0.6.17-0 release (PR #510) failed in `buildRlib`, so `build`, `plan`, and `deploy` were all skipped and nothing reached production. This unblocks it.

`RcppParallel 6.2.0` fails to configure with:

```
error: RcppParallel requires cmake (>= 3.5); cmake was not found
```

RcppParallel 6.x configures TBB through cmake, and cmake was never in the rlib image's toolchain. The rlib image is built on `amazonlinux:2023` with R compiled from source, so every R package there is a source build and always has been. Nothing about the recent `phacking@0.2.1` pin changed that.

What the pin did change is the content hash of `r-packages.txt`, which is what keys the rlib image tag. That forced the first rlib rebuild in months and surfaced a break that arrived from upstream some time ago and had been sitting behind a cached image. Any change touching that file would have hit it.

Adds `cmake` to the `dnf install` toolchain list. AL2023 ships cmake 3.22, comfortably above the required 3.5.

## Test plan

- `buildRlib` completing is itself the test: it is the job that failed, and it exercises the full source build of the R library including RcppParallel and the rstan/phacking chain.
- Then `build`, `plan`, `deploy` proceed, and the live version and an RTMA double-run get checked against https://maive.eu.

No application code changes, so the R and UI suites are unaffected.
