### PR TITLE
feat: surface RTMA convergence diagnostics and warn on a bad fit

### DIFF
--- a/apps/lambda-r-backend/r_scripts/rtma_model.R
+++ b/apps/lambda-r-backend/r_scripts/rtma_model.R
@@ -272,7 +272,12 @@ run_rtma_model <- function(data, parameters, include_plot = TRUE) {
   cli::cli_code(capture.output(str(rtma_res, max.level = 2)))
 
   # Extract mu and tau from $stats tibble
-  # $stats has columns: param, mode, median, mean, se, ci_lower, ci_upper, ...
+  # $stats has columns: param, mode, median, mean, se, ci_lower, ci_upper,
+  # n_eff, r_hat. Note that `se` is phacking's rename of rstan's se_mean, the
+  # Monte Carlo error of the posterior mean, not the posterior SD: on the app's
+  # demo dataset it is 0.046 against a posterior SD of 1.248. It is deliberately
+  # not reported; the credible interval is the dispersion measure this response
+  # carries (#480).
   stats <- rtma_res$stats
   mu_row <- stats[stats$param == "mu", ]
   tau_row <- stats[stats$param == "tau", ]
@@ -295,6 +300,42 @@ run_rtma_model <- function(data, parameters, include_plot = TRUE) {
     mu_median <- -mu_median
     mu_ci <- c(-mu_ci[2], -mu_ci[1])
   }
+
+  # Convergence diagnostics (#480). phacking_meta() computes all of these and
+  # run_rtma_model() used to drop every one, so a failed fit and a clean fit
+  # returned responses that looked identical.
+  #
+  # Unknown is reported as a logical NA, which the unboxed-JSON serializer
+  # writes as null: a diagnostic that cannot be read should say so rather than
+  # take a valid analysis down with it, and null is distinguishable from a real
+  # value in a way that a substituted number would not be.
+  diagnostic_value <- function(row, column) {
+    if (!column %in% names(row)) {
+      return(NA)
+    }
+    value <- as.numeric(row[[column]])
+    if (length(value) != 1 || is.na(value)) NA else value
+  }
+
+  # The sharpest of the four: mu above is the mode from a separate mle_params()
+  # optimisation rather than a posterior summary, so an optimisation that failed
+  # leaves the headline point estimate meaningless while the credible interval,
+  # a posterior quantile, is untouched. Nothing else in this response tells the
+  # two cases apart.
+  optim_converged <- if (is.null(rtma_res$values$optim_converged)) {
+    NA
+  } else {
+    isTRUE(rtma_res$values$optim_converged)
+  }
+
+  # Divergent transitions come off the Stan fit rather than the $stats tibble.
+  # Any at all mean the sampler could not explore part of the posterior, so the
+  # intervals can be wrong even when r_hat looks healthy. Guarded because $fits
+  # is whatever phacking chose to hand metabias.
+  divergences <- tryCatch(
+    as.integer(rstan::get_num_divergent(rtma_res$fits)),
+    error = function(e) NA
+  )
 
   # Nonaffirmative (insignificant) estimates
   k <- rtma_res$values$k
@@ -343,7 +384,11 @@ run_rtma_model <- function(data, parameters, include_plot = TRUE) {
     "tau CI: [{round(tau_ci[1], 4)}, {round(tau_ci[2], 4)}]",
     "unadjusted FE mean: {round(unadjusted_mean, 4)}",
     "k_nonaffirmative: {k_nonaffirmative} / {k} ({round(nonaffirmative_proportion * 100, 1)}%)",
-    "dropped rows: {dropped_rows}"
+    "dropped rows: {dropped_rows}",
+    "optim converged: {optim_converged}",
+    "r_hat: mu {diagnostic_value(mu_row, 'r_hat')}, tau {diagnostic_value(tau_row, 'r_hat')}",
+    "n_eff: mu {diagnostic_value(mu_row, 'n_eff')}, tau {diagnostic_value(tau_row, 'n_eff')}",
+    "divergent transitions: {divergences}"
   ))
 
   # Generate z-score density plot, unless the caller has already said it will
@@ -381,7 +426,24 @@ run_rtma_model <- function(data, parameters, include_plot = TRUE) {
     nonaffirmativeProportion = nonaffirmative_proportion,
     # I() so the unboxed-JSON serializer keeps this an array even when a single
     # warning was raised; callers can always treat it as a list of strings.
-    warnings = I(rtma_warnings)
+    warnings = I(rtma_warnings),
+    # Whether the numbers above can be trusted at all (#480). Appended rather
+    # than grouped with the estimates they qualify so the field order every
+    # existing caller reads stays exactly as it was. r_hat and n_eff are
+    # per-parameter because the sampler can mix well for one and badly for the
+    # other, and a single worst-case number would hide which.
+    diagnostics = list(
+      optimConverged = optim_converged,
+      rHat = list(
+        mu = diagnostic_value(mu_row, "r_hat"),
+        tau = diagnostic_value(tau_row, "r_hat")
+      ),
+      nEff = list(
+        mu = diagnostic_value(mu_row, "n_eff"),
+        tau = diagnostic_value(tau_row, "n_eff")
+      ),
+      divergences = divergences
+    )
   )
 
   if (include_plot) {

--- a/apps/lambda-r-backend/r_scripts/tests/e2e/scenarios/basic_rtma_test.R
+++ b/apps/lambda-r-backend/r_scripts/tests/e2e/scenarios/basic_rtma_test.R
@@ -145,6 +145,78 @@ check_rtma_include_plot_gating <- function() {
   invisible(TRUE)
 }
 
+#' Check the convergence diagnostics block (#480)
+#'
+#' phacking_meta() computes all of these and run_rtma_model() used to discard
+#' them, which left a failed fit and a clean fit looking identical in the
+#' response.
+#'
+#' The bounds below check that each field is the quantity it claims to be, not
+#' that this particular fit is a good one. r_hat and n_eff sit in disjoint
+#' ranges, so a check phrased this way still fails loudly if the two are ever
+#' swapped or read off the wrong tibble column, while leaving the suite free to
+#' use a fixture whose chains mix imperfectly. This fixture is one: its mu
+#' r_hat is around 1.03, which is exactly the kind of run that used to be
+#' reported as a clean number.
+#'
+#' @param results Parsed RTMA results object
+#' @return TRUE invisibly
+check_rtma_diagnostics <- function(results) {
+  cat("Checking RTMA convergence diagnostics...\n")
+
+  diagnostics <- results$diagnostics
+  if (!is.list(diagnostics)) {
+    stop("diagnostics should be an object")
+  }
+
+  missing <- setdiff(
+    c("optimConverged", "rHat", "nEff", "divergences"),
+    names(diagnostics)
+  )
+  if (length(missing) > 0) {
+    stop(paste(
+      "Missing RTMA diagnostics fields:",
+      paste(missing, collapse = ", ")
+    ))
+  }
+
+  # The mode this response reports comes out of that optimisation, so a FALSE
+  # here would mean the fixture's headline estimate is unusable.
+  if (!isTRUE(diagnostics$optimConverged)) {
+    stop(paste(
+      "optimConverged should be TRUE on this fixture; the reported mode comes",
+      "from that optimisation, so anything else means either the mode is",
+      "unusable or the flag is being read from the wrong place"
+    ))
+  }
+
+  # Per-parameter, because the sampler can mix well for one and badly for the
+  # other and a single number would hide which.
+  for (param in c("mu", "tau")) {
+    r_hat <- diagnostics$rHat[[param]]
+    if (!is.numeric(r_hat) || length(r_hat) != 1 || r_hat < 1 || r_hat > 2) {
+      stop(sprintf(
+        "rHat$%s should be a single number in [1, 2], got %s",
+        param, paste(r_hat, collapse = ", ")
+      ))
+    }
+
+    n_eff <- diagnostics$nEff[[param]]
+    if (!is.numeric(n_eff) || length(n_eff) != 1 || n_eff <= 10) {
+      stop(sprintf(
+        "nEff$%s should be a single number above 10, got %s",
+        param, paste(n_eff, collapse = ", ")
+      ))
+    }
+  }
+
+  if (!is.numeric(diagnostics$divergences) || diagnostics$divergences < 0) {
+    stop("divergences should be a non-negative count")
+  }
+
+  invisible(TRUE)
+}
+
 #' Test basic RTMA functionality
 #' @return Test results
 test_basic_rtma <- function() {
@@ -194,7 +266,8 @@ test_basic_rtma <- function() {
         "zScorePlotHeight",
         "nonaffirmativeCount",
         "nonaffirmativeProportion",
-        "warnings"
+        "warnings",
+        "diagnostics"
       )
 
       missing <- setdiff(
@@ -276,6 +349,9 @@ test_basic_rtma <- function() {
       ) {
         stop("tauMedian should lie inside tauCI")
       }
+
+      # #480: the diagnostics that say whether any of the above is trustworthy
+      check_rtma_diagnostics(results)
 
       # #486: plot must stay in sync with the favored direction
       check_rtma_plot_direction()

--- a/apps/react-ui/client/src/CONST.ts
+++ b/apps/react-ui/client/src/CONST.ts
@@ -132,6 +132,21 @@ const CONST = {
       TEXT: "Bootstrap",
     },
   },
+  // Thresholds the results page uses to decide when an RTMA fit is worth
+  // warning about (#480). See getRtmaDiagnosticWarnings in
+  // src/utils/rtmaDiagnostics.ts for how each one is applied.
+  RTMA_DIAGNOSTICS: {
+    // Above this, the chains have not converged on the same distribution.
+    // 1.01 is the current Stan recommendation (Vehtari et al., 2021).
+    MAX_R_HAT: 1.01,
+    // phacking runs 4 chains, and the usual guidance is at least 100
+    // effectively independent draws per chain.
+    MIN_N_EFF: 400,
+    // RTMA is fitted only to the not-affirmative estimates, so this, not k, is
+    // the sample size the model actually has. Below this the posterior is
+    // driven mostly by the prior.
+    MIN_NONAFFIRMATIVE_COUNT: 10,
+  },
   LARGE_DATASET_ROW_THRESHOLD: 500,
   MOCK_DATA_ROWS_MIN: 9, // At least 3 studies with 3 observations each
   MOCK_DATA_ROWS_MAX: 200,

--- a/apps/react-ui/client/src/components/ApiDocs/apiDocsContent.ts
+++ b/apps/react-ui/client/src/components/ApiDocs/apiDocsContent.ts
@@ -140,6 +140,46 @@ export const RTMA_PARAMETERS: ParameterRow[] = [
   },
 ];
 
+export type ResponseFieldRow = {
+  field: string;
+  type: string;
+  notes: string;
+};
+
+/**
+ * The `diagnostics` block on an RTMA response.
+ *
+ * Documented as its own table because these are the fields that decide whether
+ * the rest of the response means anything, and a caller reading only `mu` has
+ * no way to tell a converged fit from a failed one.
+ */
+export const RTMA_DIAGNOSTIC_FIELDS: ResponseFieldRow[] = [
+  {
+    field: "diagnostics.optimConverged",
+    type: "boolean | null",
+    notes:
+      "Whether the optimisation that produces the reported modes converged. It runs separately from the sampler, so false means mu and tau are meaningless while muCI and tauCI, being posterior quantiles, stay valid.",
+  },
+  {
+    field: "diagnostics.rHat",
+    type: "{ mu, tau }: number | null",
+    notes:
+      "Gelman-Rubin statistic per parameter. Above 1.01 the chains have not converged on the same distribution.",
+  },
+  {
+    field: "diagnostics.nEff",
+    type: "{ mu, tau }: number | null",
+    notes:
+      "Effective posterior sample size per parameter. The sampler runs four chains, so below roughly 400 the summaries rest on few independent draws.",
+  },
+  {
+    field: "diagnostics.divergences",
+    type: "integer | null",
+    notes:
+      "Divergent transitions. Any at all mean part of the posterior went unexplored, so the intervals can be biased even at a healthy rHat.",
+  },
+];
+
 export type CodeSample = {
   language: string;
   label: string;

--- a/apps/react-ui/client/src/components/Modals/RunInfoModal.tsx
+++ b/apps/react-ui/client/src/components/Modals/RunInfoModal.tsx
@@ -10,6 +10,12 @@ import RTMAResultsSummary from "@src/components/RTMAResultsSummary";
 import RunDetails from "@src/components/RunDetails";
 import type { DetailItem } from "@src/components/RunDetails";
 import SectionHeading from "@src/components/SectionHeading";
+import {
+  formatDivergences,
+  formatNEff,
+  formatOptimConverged,
+  formatRHat,
+} from "@utils/rtmaDiagnostics";
 import BaseModal from "./BaseModal";
 import { FaDownload } from "react-icons/fa";
 
@@ -52,22 +58,66 @@ export default function RunInfoModal({
   // draw that produced them (#479). No other model reports one.
   const seedText = TEXT.rtma.seed;
   const rtmaSeed = rtmaResults?.seed;
-  const extraRunDetails: DetailItem[] = isRtmaModel
+  const seedDetail: DetailItem =
+    typeof rtmaSeed === "number"
+      ? {
+          label: seedText.label,
+          value: rtmaSeed,
+          show: true,
+          tooltip: seedText.tooltip,
+        }
+      : {
+          label: seedText.label,
+          value: seedText.unknownValue,
+          show: true,
+          tooltip: seedText.unknownTooltip,
+        };
+
+  // RTMA only: the raw convergence diagnostics behind the results (#480). The
+  // results summary turns the bad values into warnings; these rows are the
+  // numbers themselves, for a reader who wants to judge a borderline fit.
+  const diagnosticsText = TEXT.rtma.diagnostics;
+  const diagnostics = rtmaResults?.diagnostics;
+  const diagnosticDetails: DetailItem[] = diagnostics
     ? [
-        typeof rtmaSeed === "number"
-          ? {
-              label: seedText.label,
-              value: rtmaSeed,
-              show: true,
-              tooltip: seedText.tooltip,
-            }
-          : {
-              label: seedText.label,
-              value: seedText.unknownValue,
-              show: true,
-              tooltip: seedText.unknownTooltip,
-            },
+        {
+          label: diagnosticsText.optimConverged.label,
+          value: formatOptimConverged(diagnostics.optimConverged),
+          show: true,
+          tooltip: diagnosticsText.optimConverged.tooltip,
+        },
+        {
+          label: diagnosticsText.rHat.label,
+          value: `${formatRHat(diagnostics.rHat.mu)} / ${formatRHat(diagnostics.rHat.tau)}`,
+          show: true,
+          tooltip: diagnosticsText.rHat.tooltip,
+        },
+        {
+          label: diagnosticsText.nEff.label,
+          value: `${formatNEff(diagnostics.nEff.mu)} / ${formatNEff(diagnostics.nEff.tau)}`,
+          show: true,
+          tooltip: diagnosticsText.nEff.tooltip,
+        },
+        {
+          label: diagnosticsText.divergences.label,
+          value: formatDivergences(diagnostics.divergences),
+          show: true,
+          tooltip: diagnosticsText.divergences.tooltip,
+        },
       ]
+    : [
+        // Absence is reported explicitly: a run with no diagnostics block is
+        // not a run that converged, it is a run that never said.
+        {
+          label: diagnosticsText.unavailableLabel,
+          value: diagnosticsText.unavailableValue,
+          show: true,
+          tooltip: diagnosticsText.unavailableTooltip,
+        },
+      ];
+
+  const extraRunDetails: DetailItem[] = isRtmaModel
+    ? [seedDetail, ...diagnosticDetails]
     : [];
 
   const getParameterDisplayName = (key: keyof ModelParameters): string => {

--- a/apps/react-ui/client/src/components/RTMAResultsSummary.tsx
+++ b/apps/react-ui/client/src/components/RTMAResultsSummary.tsx
@@ -5,6 +5,10 @@ import Alert from "@components/Alert";
 import Tooltip from "@components/Tooltip";
 import CONFIG from "@src/CONFIG";
 import CONST from "@src/CONST";
+import {
+  getRtmaDiagnosticWarnings,
+  isRtmaModeUnreliable,
+} from "@utils/rtmaDiagnostics";
 
 type RTMAResultsSummaryProps = {
   results: RTMAResults;
@@ -36,15 +40,31 @@ export default function RTMAResultsSummary({
   const ciPercent = Math.round((results.ciLevel ?? 0.95) * 100);
   const intervalNote = `The interval is the equal-tailed ${ciPercent}% credible interval (posterior quantiles; phacking does not compute HPD intervals).`;
 
+  // Both modes below come from an mle_params() optimisation that runs
+  // separately from the sampler. When it fails, those two numbers are the only
+  // part of the result it damaged, so they are withheld rather than shown next
+  // to intervals that are still sound (#480).
+  const modeUnreliable = isRtmaModeUnreliable(results);
+  const withheldModeNote = (mode: number, median?: number): string =>
+    `mode ${formatNumber(mode)} withheld: its optimisation did not converge${
+      median != null ? `; posterior median ${formatNumber(median)}` : ""
+    }`;
+  const withheldModeTooltip = `The optimisation that produces the mode did not converge for this run, so only the interval is shown. ${intervalNote}`;
+
   const metrics: Metric[] = [
     {
       label: "Corrected Effect (μ)",
-      value: `${formatNumber(results.mu)} ${formatCI(results.muCI)}`,
-      subValue:
-        results.muMedian != null
+      value: modeUnreliable
+        ? formatCI(results.muCI)
+        : `${formatNumber(results.mu)} ${formatCI(results.muCI)}`,
+      subValue: modeUnreliable
+        ? withheldModeNote(results.mu, results.muMedian)
+        : results.muMedian != null
           ? `median ${formatNumber(results.muMedian)}`
           : undefined,
-      tooltip: `Posterior mode of the bias-corrected mean effect from the right-truncated meta-analysis. ${intervalNote} The posterior can be skewed, so the median is shown alongside the mode.`,
+      tooltip: modeUnreliable
+        ? withheldModeTooltip
+        : `Posterior mode of the bias-corrected mean effect from the right-truncated meta-analysis. ${intervalNote} The posterior can be skewed, so the median is shown alongside the mode.`,
     },
     ...(results.unadjustedMean != null
       ? [
@@ -58,12 +78,17 @@ export default function RTMAResultsSummary({
       : []),
     {
       label: "Heterogeneity (τ)",
-      value: `${formatNumber(results.tau)} ${formatCI(results.tauCI)}`,
-      subValue:
-        results.tauMedian != null
+      value: modeUnreliable
+        ? formatCI(results.tauCI)
+        : `${formatNumber(results.tau)} ${formatCI(results.tauCI)}`,
+      subValue: modeUnreliable
+        ? withheldModeNote(results.tau, results.tauMedian)
+        : results.tauMedian != null
           ? `median ${formatNumber(results.tauMedian)}`
           : undefined,
-      tooltip: `Posterior mode of the between-study standard deviation (heterogeneity). ${intervalNote}`,
+      tooltip: modeUnreliable
+        ? withheldModeTooltip
+        : `Posterior mode of the between-study standard deviation (heterogeneity). ${intervalNote}`,
     },
     {
       label: "Not Affirmative Estimates",
@@ -87,7 +112,14 @@ export default function RTMAResultsSummary({
       : []),
   ];
 
-  const warnings = results.warnings ?? [];
+  // Conditions the backend raised while fitting, followed by the ones derived
+  // from the diagnostics it reported. Diagnostic warnings come second because
+  // a wrong favored direction (the usual backend warning) invalidates the run
+  // outright, whereas these qualify numbers that are otherwise meaningful.
+  const warnings = [
+    ...(results.warnings ?? []),
+    ...getRtmaDiagnosticWarnings(results),
+  ];
   const droppedRows = results.droppedRows ?? 0;
 
   return (

--- a/apps/react-ui/client/src/lib/text/index.ts
+++ b/apps/react-ui/client/src/lib/text/index.ts
@@ -456,6 +456,32 @@ const TEXT = {
       unknownTooltip:
         "This run predates seeded RTMA sampling, so its credible intervals cannot be reproduced exactly. Rerun the model to get a seeded result.",
     },
+    diagnostics: {
+      optimConverged: {
+        label: "Mode Optimisation",
+        tooltip:
+          "Whether the optimisation that produces the reported modes converged. It runs separately from the sampler, so a failure leaves the modes meaningless while the credible intervals, which are posterior quantiles, stay sound.",
+      },
+      rHat: {
+        label: "R-hat (μ / τ)",
+        tooltip:
+          "Gelman-Rubin convergence statistic for each parameter. Above 1.01 the chains have not converged on the same distribution and no summary of them can be trusted.",
+      },
+      nEff: {
+        label: "Effective Draws (μ / τ)",
+        tooltip:
+          "Number of effectively independent posterior draws behind each parameter's summaries. The sampler runs four chains, so anything below roughly 400 means the estimates and intervals rest on very little.",
+      },
+      divergences: {
+        label: "Divergent Transitions",
+        tooltip:
+          "Iterations where the sampler could not follow the geometry of the posterior. Any at all mean part of the posterior went unexplored, so the intervals can be biased even when everything else looks healthy.",
+      },
+      unavailableLabel: "Convergence Diagnostics",
+      unavailableValue: "Not recorded",
+      unavailableTooltip:
+        "This run predates RTMA convergence diagnostics, so there is no way to tell whether its fit converged. Rerun the model to get them.",
+    },
   },
   waive: {
     dropdownLabel: "WAIVE (Experimental)",

--- a/apps/react-ui/client/src/pages/api-docs.tsx
+++ b/apps/react-ui/client/src/pages/api-docs.tsx
@@ -15,6 +15,7 @@ import {
   ERROR_ENVELOPE_EXAMPLE,
   MINIMAL_REQUEST_EXAMPLE,
   MODEL_PARAMETERS,
+  RTMA_DIAGNOSTIC_FIELDS,
   RTMA_PARAMETERS,
   SYNC_EXAMPLES,
 } from "@components/ApiDocs";
@@ -291,6 +292,70 @@ export default function ApiDocsPage() {
                 base64 PNG of roughly 50KB that most callers do not need. Add{" "}
                 <code className={CODE_CLASSES}>?include=plot</code> to any run
                 or poll request to embed them.
+              </p>
+            </section>
+
+            <section className="space-y-4">
+              <SectionHeading
+                level="h2"
+                text="RTMA convergence diagnostics"
+                description="Whether an RTMA result means anything at all."
+              />
+              <p className="text-secondary text-sm leading-relaxed">
+                Every RTMA response carries a{" "}
+                <code className={CODE_CLASSES}>diagnostics</code> object. Check
+                it before using the numbers beside it:{" "}
+                <code className={CODE_CLASSES}>mu</code> and{" "}
+                <code className={CODE_CLASSES}>tau</code> are modes from an
+                optimisation that runs separately from the sampler, so they can
+                fail on their own while the credible intervals stay sound. A{" "}
+                <code className={CODE_CLASSES}>null</code> means the value could
+                not be read off the fit, which is not the same as the fit being
+                healthy.
+              </p>
+              <div className="overflow-x-auto rounded-lg border border-gray-200 dark:border-gray-700">
+                <table className="w-full border-collapse">
+                  <caption className="sr-only">
+                    RTMA response diagnostics fields
+                  </caption>
+                  <thead className="bg-gray-50 dark:bg-gray-800/60">
+                    <tr>
+                      <th scope="col" className={TABLE_HEAD_CELL_CLASSES}>
+                        Field
+                      </th>
+                      <th scope="col" className={TABLE_HEAD_CELL_CLASSES}>
+                        Type
+                      </th>
+                      <th scope="col" className={TABLE_HEAD_CELL_CLASSES}>
+                        Notes
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {RTMA_DIAGNOSTIC_FIELDS.map((row) => (
+                      <tr
+                        key={row.field}
+                        className="border-t border-gray-200 dark:border-gray-700"
+                      >
+                        <td className={TABLE_CELL_CLASSES}>
+                          <code className={CODE_CLASSES}>{row.field}</code>
+                        </td>
+                        <td className={TABLE_CELL_CLASSES}>{row.type}</td>
+                        <td className={TABLE_CELL_CLASSES}>{row.notes}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+              <p className="text-secondary text-sm leading-relaxed">
+                The response has no standard error for{" "}
+                <code className={CODE_CLASSES}>mu</code> on purpose. The{" "}
+                <code className={CODE_CLASSES}>se</code> column that{" "}
+                <code className={CODE_CLASSES}>phacking</code> reports
+                internally is the Monte Carlo error of the posterior mean, not
+                the posterior standard deviation, and the two differ by more
+                than an order of magnitude on ordinary data. Use{" "}
+                <code className={CODE_CLASSES}>muCI</code> for uncertainty.
               </p>
             </section>
 

--- a/apps/react-ui/client/src/pages/results/index.tsx
+++ b/apps/react-ui/client/src/pages/results/index.tsx
@@ -14,6 +14,7 @@ import InterpretationButton from "@components/InterpretationButton";
 import TEXT, { getResultsText } from "@src/lib/text";
 import { useDataStore, dataCache } from "@store/dataStore";
 import {
+  buildRtmaResultsCsvRows,
   exportComprehensiveResults,
   downloadImageAsJpg,
 } from "@utils/dataUtils";
@@ -394,70 +395,8 @@ export default function ResultsPage() {
       }
 
       if (isRtmaModel && parsedRtmaResults) {
-        // RTMA-specific export: simple CSV with results summary. The optional
-        // rows cover fields the backend only returns since #481; older stored
-        // runs simply omit them.
-        const optionalRows: string[][] = [];
-        if (parsedRtmaResults.muMedian != null) {
-          optionalRows.push([
-            "mu Posterior Median",
-            String(parsedRtmaResults.muMedian),
-          ]);
-        }
-        if (parsedRtmaResults.tauMedian != null) {
-          optionalRows.push([
-            "tau Posterior Median",
-            String(parsedRtmaResults.tauMedian),
-          ]);
-        }
-        if (parsedRtmaResults.unadjustedMean != null) {
-          optionalRows.push([
-            "Unadjusted Mean (Fixed Effect)",
-            String(parsedRtmaResults.unadjustedMean),
-          ]);
-        }
-        if (parsedRtmaResults.ciLevel != null) {
-          optionalRows.push(["CI Level", String(parsedRtmaResults.ciLevel)]);
-        }
-        if (parsedRtmaResults.seed != null) {
-          optionalRows.push(["Sampler Seed", String(parsedRtmaResults.seed)]);
-        }
-        if (parsedRtmaResults.k != null) {
-          optionalRows.push([
-            "Estimates Used (k)",
-            String(parsedRtmaResults.k),
-          ]);
-        }
-        if (parsedRtmaResults.affirmativeCount != null) {
-          optionalRows.push([
-            "Affirmative Count",
-            String(parsedRtmaResults.affirmativeCount),
-          ]);
-        }
-        if (parsedRtmaResults.droppedRows != null) {
-          optionalRows.push([
-            "Dropped Rows",
-            String(parsedRtmaResults.droppedRows),
-          ]);
-        }
-        const rows = [
-          ["Metric", "Value"],
-          ["Corrected Effect (mu)", String(parsedRtmaResults.mu)],
-          ["mu CI Lower", String(parsedRtmaResults.muCI[0])],
-          ["mu CI Upper", String(parsedRtmaResults.muCI[1])],
-          ["Heterogeneity (tau)", String(parsedRtmaResults.tau)],
-          ["tau CI Lower", String(parsedRtmaResults.tauCI[0])],
-          ["tau CI Upper", String(parsedRtmaResults.tauCI[1])],
-          [
-            "Nonaffirmative Count",
-            String(parsedRtmaResults.nonaffirmativeCount),
-          ],
-          [
-            "Nonaffirmative Proportion",
-            String(parsedRtmaResults.nonaffirmativeProportion),
-          ],
-          ...optionalRows,
-        ];
+        // RTMA-specific export: simple CSV with results summary.
+        const rows = buildRtmaResultsCsvRows(parsedRtmaResults);
         const csv = rows.map((r) => r.join(",")).join("\n");
         const blob = new Blob([csv], { type: "text/csv;charset=utf-8" });
         const url = URL.createObjectURL(blob);

--- a/apps/react-ui/client/src/tests/RTMAResultsSummary.test.tsx
+++ b/apps/react-ui/client/src/tests/RTMAResultsSummary.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { render, screen } from "@testing-library/react";
 import RTMAResultsSummary from "@components/RTMAResultsSummary";
-import type { RTMAResults } from "@src/types/api";
+import type { RTMADiagnostics, RTMAResults } from "@src/types/api";
 
 const baseResults: RTMAResults = {
   mu: 5.171,
@@ -16,6 +16,14 @@ const baseResults: RTMAResults = {
   warnings: [],
 };
 
+/** A fit with nothing wrong with it */
+const healthyDiagnostics: RTMADiagnostics = {
+  optimConverged: true,
+  rHat: { mu: 1.001, tau: 1.002 },
+  nEff: { mu: 1420, tau: 1548 },
+  divergences: 0,
+};
+
 const fullResults: RTMAResults = {
   ...baseResults,
   muMedian: 5.233,
@@ -25,6 +33,27 @@ const fullResults: RTMAResults = {
   k: 74,
   affirmativeCount: 7,
   droppedRows: 2,
+  diagnostics: healthyDiagnostics,
+};
+
+const withDiagnostics = (overrides: Partial<RTMADiagnostics>): RTMAResults => ({
+  ...fullResults,
+  diagnostics: { ...healthyDiagnostics, ...overrides },
+});
+
+/**
+ * Alert copy is split across emphasis spans, so a single getByText cannot see
+ * a whole message. Match against each alert's joined text instead.
+ */
+const alertTexts = (): string[] =>
+  screen.queryAllByRole("alert").map((alert) => alert.textContent ?? "");
+
+const expectAlertMatching = (pattern: RegExp): void => {
+  expect(alertTexts().filter((text) => pattern.test(text))).not.toHaveLength(0);
+};
+
+const expectNoAlertMatching = (pattern: RegExp): void => {
+  expect(alertTexts().filter((text) => pattern.test(text))).toHaveLength(0);
 };
 
 describe("RTMAResultsSummary", () => {
@@ -85,5 +114,113 @@ describe("RTMAResultsSummary", () => {
     );
 
     expect(screen.getByText("Favored direction check")).toBeInTheDocument();
+  });
+
+  it("stays quiet when every diagnostic is healthy", () => {
+    render(<RTMAResultsSummary results={fullResults} />);
+
+    expectNoAlertMatching(/converge|divergent|R-hat|effective sample size/i);
+    expect(screen.getByText("5.171 [4.500, 5.900]")).toBeInTheDocument();
+  });
+
+  it("warns and withholds the mode when its optimisation did not converge", () => {
+    render(
+      <RTMAResultsSummary
+        results={withDiagnostics({ optimConverged: false })}
+      />,
+    );
+
+    expectAlertMatching(
+      /optimisation behind the reported mode did not converge/i,
+    );
+    // The mode is the only number the failed optimisation produced, so it must
+    // not still be sitting there as the headline estimate.
+    expect(screen.queryByText("5.171 [4.500, 5.900]")).not.toBeInTheDocument();
+    expect(screen.getByText("[4.500, 5.900]")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        /mode 5\.171 withheld: its optimisation did not converge/,
+      ),
+    ).toBeInTheDocument();
+    // tau's mode comes from the same optimisation and goes the same way.
+    expect(screen.getByText("[0.900, 1.600]")).toBeInTheDocument();
+  });
+
+  it("warns when r_hat is above 1.01", () => {
+    render(
+      <RTMAResultsSummary
+        results={withDiagnostics({ rHat: { mu: 1.043, tau: 1.002 } })}
+      />,
+    );
+
+    expectAlertMatching(/R-hat is 1\.043 for μ, above the 1\.01/);
+    // tau is inside the threshold, so it must not be named as an offender.
+    expectNoAlertMatching(/1\.002 for τ/);
+  });
+
+  it("names both parameters when both r_hats are above the threshold", () => {
+    render(
+      <RTMAResultsSummary
+        results={withDiagnostics({ rHat: { mu: 1.043, tau: 1.021 } })}
+      />,
+    );
+
+    expectAlertMatching(/R-hat is 1\.043 for μ and 1\.021 for τ/);
+  });
+
+  it("warns on divergent transitions", () => {
+    render(
+      <RTMAResultsSummary results={withDiagnostics({ divergences: 12 })} />,
+    );
+
+    expectAlertMatching(/12 divergent transitions/);
+  });
+
+  it("warns when the effective sample size is low", () => {
+    render(
+      <RTMAResultsSummary
+        results={withDiagnostics({ nEff: { mu: 312, tau: 1548 } })}
+      />,
+    );
+
+    expectAlertMatching(/effective sample size is 312 for μ, below the 400/);
+  });
+
+  it("warns when RTMA had very few not-affirmative estimates to fit", () => {
+    render(
+      <RTMAResultsSummary
+        results={{
+          ...fullResults,
+          nonaffirmativeCount: 4,
+          nonaffirmativeProportion: 0.05,
+        }}
+      />,
+    );
+
+    expectAlertMatching(/fitted to only 4 not-affirmative estimates/);
+  });
+
+  it("treats an unreadable diagnostic as unknown rather than healthy", () => {
+    render(
+      <RTMAResultsSummary
+        results={withDiagnostics({
+          optimConverged: null,
+          rHat: { mu: null, tau: null },
+          nEff: { mu: null, tau: null },
+          divergences: null,
+        })}
+      />,
+    );
+
+    // Nothing is known to be wrong, so nothing is claimed to be wrong; the
+    // mode is still shown because no failed optimisation was reported.
+    expectNoAlertMatching(/converge|divergent|R-hat|effective sample size/i);
+    expect(screen.getByText("5.171 [4.500, 5.900]")).toBeInTheDocument();
+  });
+
+  it("raises no diagnostic warnings for a run stored before diagnostics existed", () => {
+    render(<RTMAResultsSummary results={baseResults} />);
+
+    expectNoAlertMatching(/converge|divergent|R-hat|effective sample size/i);
   });
 });

--- a/apps/react-ui/client/src/tests/RunInfoModal.test.tsx
+++ b/apps/react-ui/client/src/tests/RunInfoModal.test.tsx
@@ -5,6 +5,7 @@ import TEXT from "@src/lib/text";
 import type {
   ModelParameters,
   ModelResults,
+  RTMADiagnostics,
   RTMAResults,
 } from "@src/types/api";
 
@@ -60,6 +61,20 @@ const withoutSeed = (results: RTMAResults): RTMAResults => {
   return legacy;
 };
 
+/** A run stored before the backend started reporting convergence diagnostics */
+const withoutDiagnostics = (results: RTMAResults): RTMAResults => {
+  const legacy = { ...results };
+  delete legacy.diagnostics;
+  return legacy;
+};
+
+const healthyDiagnostics: RTMADiagnostics = {
+  optimConverged: true,
+  rHat: { mu: 1.0028, tau: 1.0012 },
+  nEff: { mu: 1419.93, tau: 1548.37 },
+  divergences: 0,
+};
+
 const rtmaResults: RTMAResults = {
   mu: 0.12,
   muCI: [0.07, 0.31],
@@ -72,7 +87,20 @@ const rtmaResults: RTMAResults = {
   nonaffirmativeProportion: 0.65,
   warnings: [],
   seed: 4242,
+  diagnostics: healthyDiagnostics,
 };
+
+/**
+ * Read the value shown next to a run-detail label.
+ *
+ * Values like "Yes" also appear in the Run Settings grid below, so a bare
+ * getByText would be ambiguous; this pins the assertion to the labelled row.
+ */
+const detailValue = (label: string): string =>
+  screen
+    .getByText(`${label}:`)
+    .parentElement?.textContent?.replace(`${label}:`, "")
+    .trim() ?? "";
 
 const renderModal = (
   parameters: ModelParameters,
@@ -109,5 +137,40 @@ describe("RunInfoModal", () => {
     renderModal(maiveParameters, null);
 
     expect(screen.queryByText("Sampler Seed:")).not.toBeInTheDocument();
+  });
+
+  it("reports the convergence diagnostics behind an RTMA fit", () => {
+    renderModal(rtmaParameters, rtmaResults);
+
+    expect(detailValue("Mode Optimisation")).toBe("Yes");
+    expect(detailValue("R-hat (μ / τ)")).toBe("1.003 / 1.001");
+    expect(detailValue("Effective Draws (μ / τ)")).toBe("1,420 / 1,548");
+    expect(detailValue("Divergent Transitions")).toBe("0");
+  });
+
+  it("says a failed optimisation failed rather than hiding it", () => {
+    renderModal(rtmaParameters, {
+      ...rtmaResults,
+      diagnostics: { ...healthyDiagnostics, optimConverged: false },
+    });
+
+    expect(detailValue("Mode Optimisation")).toBe("No");
+  });
+
+  it("says so when an RTMA run predates convergence diagnostics", () => {
+    renderModal(rtmaParameters, withoutDiagnostics(rtmaResults));
+
+    // Absence must not read as "converged fine".
+    expect(detailValue("Convergence Diagnostics")).toBe("Not recorded");
+    expect(screen.queryByText("Mode Optimisation:")).not.toBeInTheDocument();
+  });
+
+  it("shows no diagnostics for models that do not sample", () => {
+    renderModal(maiveParameters, null);
+
+    expect(screen.queryByText("Mode Optimisation:")).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("Convergence Diagnostics:"),
+    ).not.toBeInTheDocument();
   });
 });

--- a/apps/react-ui/client/src/tests/dataUtils.test.ts
+++ b/apps/react-ui/client/src/tests/dataUtils.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
-import { hasNObsColumn } from "@src/utils/dataUtils";
+import { buildRtmaResultsCsvRows, hasNObsColumn } from "@src/utils/dataUtils";
+import type { RTMAResults } from "@src/types/api";
 
 describe("hasNObsColumn", () => {
   it("detects a canonical n_obs column", () => {
@@ -19,5 +20,74 @@ describe("hasNObsColumn", () => {
     expect(hasNObsColumn([{ effect: 0.1, se: 0.2, study_id: "a" }])).toBe(
       false,
     );
+  });
+});
+
+describe("buildRtmaResultsCsvRows", () => {
+  const rtmaResults: RTMAResults = {
+    mu: 0.12,
+    muCI: [0.07, 0.31],
+    tau: 0.03,
+    tauCI: [0.01, 0.16],
+    zScorePlot: "data:image/png;base64,xxx",
+    zScorePlotWidth: 600,
+    zScorePlotHeight: 400,
+    nonaffirmativeCount: 26,
+    nonaffirmativeProportion: 0.65,
+    warnings: [],
+    diagnostics: {
+      optimConverged: false,
+      rHat: { mu: 1.043, tau: 1.002 },
+      nEff: { mu: 312, tau: 1548 },
+      divergences: 12,
+    },
+  };
+
+  const valueOf = (rows: Array<[string, string]>, metric: string) =>
+    rows.find(([label]) => label === metric)?.[1];
+
+  it("exports the diagnostics alongside the estimates they qualify", () => {
+    const rows = buildRtmaResultsCsvRows(rtmaResults);
+
+    expect(valueOf(rows, "Mode Optimisation Converged")).toBe("false");
+    expect(valueOf(rows, "R-hat (mu)")).toBe("1.043");
+    expect(valueOf(rows, "R-hat (tau)")).toBe("1.002");
+    expect(valueOf(rows, "Effective Draws (mu)")).toBe("312");
+    expect(valueOf(rows, "Effective Draws (tau)")).toBe("1548");
+    expect(valueOf(rows, "Divergent Transitions")).toBe("12");
+  });
+
+  it("exports zero divergences rather than dropping the row", () => {
+    const rows = buildRtmaResultsCsvRows({
+      ...rtmaResults,
+      diagnostics: {
+        optimConverged: true,
+        rHat: { mu: 1.001, tau: 1.002 },
+        nEff: { mu: 1420, tau: 1548 },
+        divergences: 0,
+      },
+    });
+
+    expect(valueOf(rows, "Divergent Transitions")).toBe("0");
+    expect(valueOf(rows, "Mode Optimisation Converged")).toBe("true");
+  });
+
+  it("omits diagnostics rows for a run stored before they existed", () => {
+    const legacy = { ...rtmaResults };
+    delete legacy.diagnostics;
+
+    const rows = buildRtmaResultsCsvRows(legacy);
+
+    expect(valueOf(rows, "Mode Optimisation Converged")).toBeUndefined();
+    expect(valueOf(rows, "Divergent Transitions")).toBeUndefined();
+    expect(valueOf(rows, "Corrected Effect (mu)")).toBe("0.12");
+  });
+
+  it("never reports phacking's se_mean as a standard error", () => {
+    const rows = buildRtmaResultsCsvRows(rtmaResults);
+
+    expect(
+      rows.filter(([label]) => /standard error/i.test(label)),
+    ).toHaveLength(0);
   });
 });

--- a/apps/react-ui/client/src/types/api.ts
+++ b/apps/react-ui/client/src/types/api.ts
@@ -98,6 +98,33 @@ type RTMAParameters = {
   winsorize: number;
 };
 
+// Per-parameter sampler diagnostics. The sampler can mix well for mu and
+// badly for tau, so these are reported separately rather than collapsed into
+// a single worst case.
+type RTMAParameterDiagnostic = {
+  mu: number | null;
+  tau: number | null;
+};
+
+// Whether an RTMA fit can be trusted at all. `null` on any field means the
+// backend could not read that diagnostic off the fit, which is not the same as
+// the diagnostic being fine.
+type RTMADiagnostics = {
+  // Whether the mle_params() optimisation converged. This is the optimisation
+  // that produces the reported mode (mu and tau), so a false here means those
+  // point estimates are meaningless while the credible intervals, which are
+  // posterior quantiles, are unaffected.
+  optimConverged: boolean | null;
+  // Gelman-Rubin convergence statistic; above 1.01 the chains disagree.
+  rHat: RTMAParameterDiagnostic;
+  // Effective sample size: how many independent draws the posterior summaries
+  // are effectively based on.
+  nEff: RTMAParameterDiagnostic;
+  // Divergent transitions. Any at all mean the sampler could not explore part
+  // of the posterior, so the intervals can be biased even at a healthy r_hat.
+  divergences: number | null;
+};
+
 type RTMAResults = {
   mu: number;
   muCI: [number, number];
@@ -131,6 +158,10 @@ type RTMAResults = {
   k?: number;
   affirmativeCount?: number;
   droppedRows?: number;
+  // Convergence diagnostics for the fit (#480). Optional for the same
+  // stored-run reason: runs from before the backend returned them cannot say
+  // whether they converged, so their absence must not read as "all clear".
+  diagnostics?: RTMADiagnostics;
 };
 
 type PingResponse = {
@@ -186,6 +217,8 @@ export type {
   ModelResults,
   RTMAParameters,
   RTMAResults,
+  RTMADiagnostics,
+  RTMAParameterDiagnostic,
   PingResponse,
   ApiConfig,
   ApiResponse,

--- a/apps/react-ui/client/src/utils/dataUtils.ts
+++ b/apps/react-ui/client/src/utils/dataUtils.ts
@@ -1,5 +1,6 @@
 import TEXT, { getResultsText } from "@src/lib/text";
 import type { DataArray, ModelResults, ModelParameters } from "@src/types";
+import type { RTMAResults } from "@src/types/api";
 import CONST from "@src/CONST";
 import type { DataInfo } from "@src/types/data";
 import {
@@ -518,6 +519,65 @@ export const exportComprehensiveResults = (
   const newFilename = `${baseName}_${modelSlug}_results${salt}.xlsx`;
 
   XLSX.writeFile(workbook, newFilename);
+};
+
+/**
+ * Build the rows of the RTMA results CSV export
+ *
+ * Optional rows cover fields the backend only started returning later, so an
+ * older stored run exports what it has instead of a column of "undefined".
+ * The diagnostics rows are the point of the exercise (#480): a mode exported
+ * without its `optimConverged` flag looks exactly like a mode that converged.
+ *
+ * `stats$se` from phacking is deliberately absent. It is `se_mean`, the Monte
+ * Carlo error of the posterior mean rather than the posterior SD, and on the
+ * demo dataset the two differ by a factor of 27. The credible interval bounds
+ * below are the dispersion this export reports.
+ *
+ * @param results - The RTMA results to export
+ * @returns Rows of [metric, value], header first
+ */
+export const buildRtmaResultsCsvRows = (
+  results: RTMAResults,
+): Array<[string, string]> => {
+  const optionalRows: Array<[string, string]> = [];
+  const addOptional = (label: string, value: unknown): void => {
+    if (value != null) {
+      optionalRows.push([label, String(value)]);
+    }
+  };
+
+  addOptional("mu Posterior Median", results.muMedian);
+  addOptional("tau Posterior Median", results.tauMedian);
+  addOptional("Unadjusted Mean (Fixed Effect)", results.unadjustedMean);
+  addOptional("CI Level", results.ciLevel);
+  addOptional("Sampler Seed", results.seed);
+  addOptional("Estimates Used (k)", results.k);
+  addOptional("Affirmative Count", results.affirmativeCount);
+  addOptional("Dropped Rows", results.droppedRows);
+
+  const diagnostics = results.diagnostics;
+  if (diagnostics) {
+    addOptional("Mode Optimisation Converged", diagnostics.optimConverged);
+    addOptional("R-hat (mu)", diagnostics.rHat.mu);
+    addOptional("R-hat (tau)", diagnostics.rHat.tau);
+    addOptional("Effective Draws (mu)", diagnostics.nEff.mu);
+    addOptional("Effective Draws (tau)", diagnostics.nEff.tau);
+    addOptional("Divergent Transitions", diagnostics.divergences);
+  }
+
+  return [
+    ["Metric", "Value"],
+    ["Corrected Effect (mu)", String(results.mu)],
+    ["mu CI Lower", String(results.muCI[0])],
+    ["mu CI Upper", String(results.muCI[1])],
+    ["Heterogeneity (tau)", String(results.tau)],
+    ["tau CI Lower", String(results.tauCI[0])],
+    ["tau CI Upper", String(results.tauCI[1])],
+    ["Nonaffirmative Count", String(results.nonaffirmativeCount)],
+    ["Nonaffirmative Proportion", String(results.nonaffirmativeProportion)],
+    ...optionalRows,
+  ];
 };
 
 /**

--- a/apps/react-ui/client/src/utils/rtmaDiagnostics.ts
+++ b/apps/react-ui/client/src/utils/rtmaDiagnostics.ts
@@ -1,0 +1,158 @@
+import CONST from "@src/CONST";
+import type {
+  RTMADiagnostics,
+  RTMAParameterDiagnostic,
+  RTMAResults,
+} from "@src/types/api";
+
+const THRESHOLDS = CONST.RTMA_DIAGNOSTICS;
+
+/** Label for each diagnostic parameter, matching the results summary metrics */
+const PARAMETER_LABELS = {
+  mu: "μ",
+  tau: "τ",
+} as const;
+
+type DiagnosticParameter = keyof typeof PARAMETER_LABELS;
+
+const PARAMETERS: DiagnosticParameter[] = ["mu", "tau"];
+
+/**
+ * Whether a diagnostic the backend reports as `null` is present at all.
+ *
+ * `null` means the backend could not read that number off the fit, which is
+ * not the same as the fit being healthy, so every check below has to treat it
+ * as "no evidence" rather than "no problem".
+ */
+const isReported = (value: number | null | undefined): value is number =>
+  typeof value === "number" && Number.isFinite(value);
+
+/** Format an R-hat for display; 3 decimals is enough to see the 1.01 line */
+export const formatRHat = (value: number | null | undefined): string =>
+  isReported(value) ? value.toFixed(3) : "Not reported";
+
+/** Format an effective sample size for display; the fraction is never useful */
+export const formatNEff = (value: number | null | undefined): string =>
+  isReported(value) ? Math.round(value).toLocaleString() : "Not reported";
+
+/** Format a divergent-transition count for display */
+export const formatDivergences = (value: number | null | undefined): string =>
+  isReported(value) ? String(Math.round(value)) : "Not reported";
+
+/** Format the optimiser convergence flag for display */
+export const formatOptimConverged = (
+  value: boolean | null | undefined,
+): string => {
+  if (value === true) {
+    return "Yes";
+  }
+  if (value === false) {
+    return "No";
+  }
+  return "Not reported";
+};
+
+/**
+ * Whether the reported mode should be treated as a usable point estimate.
+ *
+ * The mode comes from a separate `mle_params()` optimisation rather than from
+ * the sampler, so when that optimisation fails the mode is meaningless even
+ * though the credible interval next to it is perfectly sound.
+ */
+export const isRtmaModeUnreliable = (results: RTMAResults): boolean =>
+  results.diagnostics?.optimConverged === false;
+
+/** Whether a run carries a diagnostics block at all (runs before #480 do not) */
+export const hasRtmaDiagnostics = (
+  results: RTMAResults,
+): results is RTMAResults & { diagnostics: RTMADiagnostics } =>
+  results.diagnostics != null;
+
+/**
+ * List the parameters whose diagnostic value fails a threshold, formatted for
+ * a sentence: "**1.043** for μ and **1.021** for τ".
+ */
+const describeOffenders = (
+  diagnostic: RTMAParameterDiagnostic,
+  fails: (value: number) => boolean,
+  format: (value: number) => string,
+): string | null => {
+  const offenders = PARAMETERS.flatMap((parameter) => {
+    const value = diagnostic[parameter];
+    if (!isReported(value) || !fails(value)) {
+      return [];
+    }
+    return [`**${format(value)}** for ${PARAMETER_LABELS[parameter]}`];
+  });
+
+  if (offenders.length === 0) {
+    return null;
+  }
+  return offenders.join(" and ");
+};
+
+/**
+ * Build the warnings the results page shows for an RTMA fit.
+ *
+ * These are generated in the UI rather than appended to the backend's own
+ * `warnings` array so that the API keeps reporting only conditions raised
+ * while fitting, and so the thresholds stay adjustable without a redeploy of
+ * the R backend.
+ *
+ * @param results - RTMA results, with or without a diagnostics block
+ * @returns Warning messages, most consequential first
+ */
+export const getRtmaDiagnosticWarnings = (results: RTMAResults): string[] => {
+  const warnings: string[] = [];
+  const diagnostics = results.diagnostics;
+
+  if (diagnostics?.optimConverged === false) {
+    warnings.push(
+      "**The optimisation behind the reported mode did not converge.** The mode is what RTMA normally reports as the corrected effect, so that point estimate is not usable for this run. The credible intervals are posterior quantiles and are unaffected, so read those instead, and rerun with a different seed to see whether the optimisation settles.",
+    );
+  }
+
+  const divergences = diagnostics?.divergences;
+  if (isReported(divergences) && divergences > 0) {
+    const count = Math.round(divergences);
+    warnings.push(
+      `The sampler reported **${count} divergent ${count === 1 ? "transition" : "transitions"}**, so it could not explore part of the posterior. The credible intervals can be biased even though the numbers themselves look ordinary.`,
+    );
+  }
+
+  if (diagnostics) {
+    const rHatOffenders = describeOffenders(
+      diagnostics.rHat,
+      (value) => value > THRESHOLDS.MAX_R_HAT,
+      (value) => value.toFixed(3),
+    );
+    if (rHatOffenders) {
+      warnings.push(
+        `R-hat is ${rHatOffenders}, above the ${THRESHOLDS.MAX_R_HAT} convergence threshold. The chains did not settle on the same distribution, so neither the estimates nor the intervals are trustworthy yet.`,
+      );
+    }
+
+    const nEffOffenders = describeOffenders(
+      diagnostics.nEff,
+      (value) => value < THRESHOLDS.MIN_N_EFF,
+      (value) => Math.round(value).toLocaleString(),
+    );
+    if (nEffOffenders) {
+      warnings.push(
+        `The effective sample size is ${nEffOffenders}, below the ${THRESHOLDS.MIN_N_EFF.toLocaleString()} draws this fit should reach. The posterior summaries rest on few effectively independent draws and may be unreliable.`,
+      );
+    }
+  }
+
+  if (
+    typeof results.nonaffirmativeCount === "number" &&
+    results.nonaffirmativeCount > 0 &&
+    results.nonaffirmativeCount < THRESHOLDS.MIN_NONAFFIRMATIVE_COUNT
+  ) {
+    warnings.push(
+      `RTMA was fitted to only **${results.nonaffirmativeCount} not-affirmative ${results.nonaffirmativeCount === 1 ? "estimate" : "estimates"}**. That is the entire sample the correction has to work from, so treat the corrected effect as indicative at best.`,
+    );
+  }
+
+  return warnings;
+};

--- a/docs/PUBLIC_API.md
+++ b/docs/PUBLIC_API.md
@@ -68,6 +68,26 @@ Plots (`funnelPlot`, `zScorePlot`, and their width/height companions) are
 programmatic callers. Add `?include=plot` to any run or poll request to embed
 them.
 
+## RTMA convergence diagnostics
+
+Every RTMA response carries a `diagnostics` object. Check it before using the
+numbers beside it: `mu` and `tau` are modes from an optimisation that runs
+separately from the sampler, so they can fail on their own while the credible
+intervals stay sound. A `null` means the value could not be read off the fit,
+which is not the same as the fit being healthy.
+
+| Field | Type | Notes |
+|---|---|---|
+| `diagnostics.optimConverged` | boolean \| null | Whether the optimisation behind the reported modes converged. `false` means `mu` and `tau` are meaningless while `muCI` and `tauCI`, being posterior quantiles, stay valid |
+| `diagnostics.rHat` | `{mu, tau}`: number \| null | Gelman-Rubin statistic per parameter; above 1.01 the chains have not converged on the same distribution |
+| `diagnostics.nEff` | `{mu, tau}`: number \| null | Effective posterior sample size per parameter; the sampler runs four chains, so below roughly 400 the summaries rest on few independent draws |
+| `diagnostics.divergences` | integer \| null | Divergent transitions; any at all mean part of the posterior went unexplored, so the intervals can be biased even at a healthy `rHat` |
+
+There is no standard error for `mu`, on purpose. The `se` column `phacking`
+reports internally is the Monte Carlo error of the posterior mean, not the
+posterior standard deviation, and the two differ by more than an order of
+magnitude on ordinary data. Use `muCI` for uncertainty.
+
 ## Examples: synchronous run
 
 ### curl

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -801,6 +801,7 @@ components:
         - nonaffirmativeCount
         - nonaffirmativeProportion
         - warnings
+        - diagnostics
       properties:
         mu:
           type: number
@@ -877,6 +878,8 @@ components:
             most important one reports a favored direction opposite the pooled
             estimate, which means nothing was truncated and `mu` is not actually
             corrected for p-hacking.
+        diagnostics:
+          $ref: "#/components/schemas/RTMADiagnostics"
         zScorePlot:
           type: string
           description: 'Base64-encoded PNG data URI. Only present with `?include=plot`.'
@@ -886,6 +889,61 @@ components:
         zScorePlotHeight:
           type: number
           description: Only present with `?include=plot`.
+
+    RTMAParameterDiagnostic:
+      type: object
+      description: >-
+        A sampler diagnostic reported separately for each parameter, because
+        the chains can mix well for one and badly for the other. `null` means
+        the backend could not read the value off the fit, which is not the same
+        as the diagnostic being healthy.
+      required: [mu, tau]
+      properties:
+        mu:
+          type: number
+          nullable: true
+        tau:
+          type: number
+          nullable: true
+
+    RTMADiagnostics:
+      type: object
+      description: >-
+        Convergence diagnostics for the fit that produced the results above.
+        Without them a failed fit and a clean fit are indistinguishable in this
+        response.
+      required: [optimConverged, rHat, nEff, divergences]
+      properties:
+        optimConverged:
+          type: boolean
+          nullable: true
+          description: >-
+            Whether the `mle_params()` optimisation converged. That
+            optimisation runs separately from the sampler and is what produces
+            the reported modes `mu` and `tau`, so `false` means those two point
+            estimates are meaningless while `muCI` and `tauCI`, which are
+            posterior quantiles, remain valid. `null` means the value could not
+            be read.
+        rHat:
+          allOf:
+            - $ref: "#/components/schemas/RTMAParameterDiagnostic"
+          description: >-
+            Gelman-Rubin convergence statistic per parameter. Above 1.01 the
+            chains have not converged on the same distribution.
+        nEff:
+          allOf:
+            - $ref: "#/components/schemas/RTMAParameterDiagnostic"
+          description: >-
+            Effective posterior sample size per parameter. The sampler runs
+            four chains, so values below roughly 400 mean the summaries rest on
+            few effectively independent draws.
+        divergences:
+          type: integer
+          nullable: true
+          description: >-
+            Divergent transitions in the sampler. Any at all mean part of the
+            posterior went unexplored, so the credible intervals can be biased
+            even at a healthy `rHat`. `null` means the value could not be read.
 
     RunStatus:
       type: string


### PR DESCRIPTION
Closes #480.

`phacking_meta()` computes convergence diagnostics and `rtma_model.R` discarded all of them, so a failed fit and a clean fit produced identical responses. This adds a `diagnostics` block and warns on it.

The sharpest case: the headline `mu` is the mode from a separate `mle_params()` optimisation, not a posterior summary. If that optimisation fails, the point estimate is meaningless while the credible interval is untouched. That is now visible, and the mode is withheld rather than displayed as an estimate.

## What ships

**R backend** (`rtma_model.R`). `diagnostics` is appended to the response after `warnings`, so no existing field moves and the `include_plot` splice keeps working:

```json
"diagnostics": {
  "optimConverged": true,
  "rHat":  {"mu": 1.0028, "tau": 1.0012},
  "nEff":  {"mu": 1419.9, "tau": 1548.4},
  "divergences": 0
}
```

`rHat` and `nEff` are per-parameter because the sampler can mix well for one and badly for the other. A diagnostic that cannot be read is reported as `null`, not as a substituted number, so absence never reads as "all clear". Divergences come from `rstan::get_num_divergent()` on the Stan fit, guarded so a diagnostics failure cannot take a valid analysis down.

**Types.** `RTMADiagnostics` and `RTMAParameterDiagnostic` in `types/api.ts`; `diagnostics` is optional on `RTMAResults` because runs stored before this change have no value for it.

**Results page.** Warnings are generated in `utils/rtmaDiagnostics.ts` and rendered through the existing `Alert` pattern in `RTMAResultsSummary`, so they appear on both the results page and the Run Info modal. Covered: a failed mode optimisation, divergent transitions, r-hat above 1.01, effective sample size below 400, and fewer than 10 not-affirmative estimates. Thresholds live in `CONST.RTMA_DIAGNOSTICS`.

When the optimisation failed, the mu and tau metrics show the credible interval alone, with the mode named in a subline as withheld and the posterior median alongside it where available. The tooltip changes to match.

**Run Info.** Four new detail rows with the raw numbers. A run with no diagnostics block shows "Convergence Diagnostics: Not recorded" rather than nothing, since silence would read as a healthy fit.

**CSV export.** The RTMA row builder moved out of `pages/results/index.tsx` into `dataUtils.buildRtmaResultsCsvRows` so the new rows are unit-testable; behaviour for existing rows is unchanged.

**Docs.** `openapi.yaml` gets `RTMADiagnostics` and `RTMAParameterDiagnostic` schemas matching exactly what ships, plus `diagnostics` on `RTMAResults`. A matching section was added to the API docs page and `docs/PUBLIC_API.md`.

## Not reported: `stats$se`

`phacking` sets `se = se_mean`, the Monte Carlo error of the posterior mean, not the posterior SD. It is deliberately absent from the response, the CSV, and the UI, and there is now a comment at the extraction site plus a test asserting no export column is labelled a standard error. The credible interval is the dispersion this response carries.

## Testing

- `npm test -- --run`: 29 files, 204 tests, all green. New coverage goes past field presence: `optimConverged: false` must produce a visible warning and withhold the mode, r-hat above 1.01 must warn and must not name the parameter that is inside the threshold, and all-`null` diagnostics must warn about nothing while still showing the mode.
- `npm run ui:lint`: clean apart from the repo's usual CRLF noise.
- Full R e2e suite against a local plumber server: 16/16 green, including `parameter_combinations`, which is the scenario that is flaky on a 30s client timeout locally.

Worth knowing: the `basic-rtma` fixture reports `r_hat = 1.0304` for mu. That is a real result, not a bug in this change, and it is exactly the kind of run the app used to display as a clean number. The e2e assertion therefore checks that each diagnostic is the quantity it claims to be (disjoint ranges for r-hat and n_eff, so a swap still fails loudly) rather than that this fixture converges well.

## Scope

Everything #480 asks for is covered. `k` and `kAffirmative` were already in the response and were not re-added. The default seed 2025 is untouched, as are Lambda memory, `mc.cores`, `parallelize`, and `r-packages.txt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)