### PR TITLE
style: remove em and en dashes across docs, config, and UI copy

### DIFF
--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -10,7 +10,7 @@ Run the MAIVE release flow. Follow these steps exactly.
   `terraform/stacks/prod-runtime` apply.
 - `master` has branch protection; release PRs are merged with admin: `gh pr merge <PR> --rebase --admin`.
 - **Foundation infra** (`terraform/stacks/prod-foundation`) is applied **manually with elevated creds**, never by CI.
-- Live site: https://maive.eu — version check: `curl -s https://maive.eu/api/get-version-info`.
+- Live site: https://maive.eu; version check: `curl -s https://maive.eu/api/get-version-info`.
 
 ## Steps
 1. **Keep master clean.** Work must be on a feature branch off the latest `master` (never commit to master directly).
@@ -21,9 +21,9 @@ Run the MAIVE release flow. Follow these steps exactly.
 4. **Label it:** `gh pr edit <PR> --add-label release`. Optionally add a version-bump label
    (`v-patch` / `v-minor` / `v-major`); a plain `release` defaults to a build bump.
 5. **Wait for CI:** `gh pr checks <PR> --watch`. Never merge on red.
-6. **Merge:** `gh pr merge <PR> --rebase --admin` (omit `--delete-branch` — it fails inside a worktree).
+6. **Merge:** `gh pr merge <PR> --rebase --admin` (omit `--delete-branch`, which fails inside a worktree).
 7. **Monitor the release:** `gh run list --workflow=release.yml --limit 3`, then `gh run watch <id> --exit-status`.
-   `--exit-status` returning 0 is **not** sufficient — confirm every job (especially `deploy`) with
+   `--exit-status` returning 0 is **not** sufficient; confirm every job (especially `deploy`) with
    `gh run view <id> --json conclusion,jobs`.
 8. **Confirm live:** `curl -s https://maive.eu/api/get-version-info` shows the new version.
 
@@ -35,5 +35,5 @@ Run the MAIVE release flow. Follow these steps exactly.
   `bun.lock` too (`cd apps/react-ui/client && bun install --lockfile-only`) or CI fails.
 - **Partial deploy:** Lambda images update *before* the IAM step in the apply, so a failed IAM step can leave the site on
   the new version with a degraded new endpoint. Re-running the failed deploy completes it.
-- **Config-only changes** (docs, `.gitignore`, `.claude/`) don't need a deploy — merge without the `release` label to
+- **Config-only changes** (docs, `.gitignore`, `.claude/`) don't need a deploy: merge without the `release` label to
   avoid an unnecessary prod redeploy.

--- a/.gitignore
+++ b/.gitignore
@@ -107,7 +107,7 @@ notes/
 !docs/screenshots/*.png
 **/*.bak
 
-# Claude Code — local & ephemeral (never commit). Shared config such as
+# Claude Code: local & ephemeral (never commit). Shared config such as
 # .claude/settings.json and .claude/commands/ is intentionally NOT ignored.
 .claude/settings.local.json
 .claude/projects/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@ The interface lives in `apps/react-ui/client`, a Next 14 + TypeScript app using 
 
 ## Build, Test, and Development Commands
 
-For UI work rely on `npm run ui:dev` (Next dev server with hot reload), `npm run ui:test` (Vitest + Testing Library), and `npm run ui:lint` (ESLint + Prettier). Analytics changes can be verified with `npm run lambda:test` or the focused R suite `npm run r:test-e2e`. When TypeScript or lint rules are updated, run `npm run ui:lint -- --fix` to keep the tree consistent. Infrastructure scripts exist but deployment, container orchestration, and registry management are handled separately—coordinate with the maintainer before invoking them.
+For UI work rely on `npm run ui:dev` (Next dev server with hot reload), `npm run ui:test` (Vitest + Testing Library), and `npm run ui:lint` (ESLint + Prettier). Analytics changes can be verified with `npm run lambda:test` or the focused R suite `npm run r:test-e2e`. When TypeScript or lint rules are updated, run `npm run ui:lint -- --fix` to keep the tree consistent. Infrastructure scripts exist but deployment, container orchestration, and registry management are handled separately. Coordinate with the maintainer before invoking them.
 
 ## Coding Style & Naming Conventions
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ MAIVE (Meta-Analysis Instrumental Variable Estimator) is a tool for detecting sp
 
 - **React UI** (Next.js 14): Interactive frontend for data upload, analysis, and visualization
 - **R Backend** (Plumber): Statistical analysis service running MAIVE algorithms
-- **AWS Infrastructure**: Fully serverless — both the UI and the R backend run as AWS Lambda functions exposed via Lambda Function URLs, fronted by Cloudflare (CDN/TLS/WAF)
+- **AWS Infrastructure**: Fully serverless. Both the UI and the R backend run as AWS Lambda functions exposed via Lambda Function URLs, fronted by Cloudflare (CDN/TLS/WAF)
 
 ## Citation
 
@@ -99,7 +99,7 @@ Browser ──► Cloudflare ──► UI Lambda Function URL (Next.js)
 - The Next.js UI runs on AWS Lambda via a container image using the [AWS Lambda Web Adapter](https://github.com/awslabs/aws-lambda-web-adapter), exposed through a Lambda Function URL.
 - Cloudflare fronts the UI for CDN/TLS/WAF. A Cloudflare Worker rewrites the `Host`/SNI to the `.on.aws` origin, because Lambda Function URLs reject a foreign `Host` header.
 - The R backend is a separate public Lambda Function URL (authorization `NONE`, CORS `*`).
-- The heavy `/run-model` analysis call goes **directly from the browser to the R Lambda Function URL** — it does not pass through the Next.js server. The browser obtains the R URL from the `/api/runtime-config` route (exposed as `window.RUNTIME_CONFIG`), served at request time.
+- The heavy `/run-model` analysis call goes **directly from the browser to the R Lambda Function URL**; it does not pass through the Next.js server. The browser obtains the R URL from the `/api/runtime-config` route (exposed as `window.RUNTIME_CONFIG`), served at request time.
 - Lightweight Next.js API routes (e.g. `/api/runtime-config`, `/api/ping`, `/api/get-version-info`) still run server-side inside the UI Lambda.
 - There is no longer an ALB, ECS/Fargate cluster, or VPC public/private-subnet serving path.
 
@@ -147,7 +147,7 @@ The heavy analysis request goes directly from the browser to the R Lambda; light
 3. **R processing**: The R Lambda executes the MAIVE analysis.
 4. **Response**: Results return directly to the browser.
 
-**Lightweight routes (server-side, inside the UI Lambda):** `/api/runtime-config`, `/api/ping`, `/api/get-version-info`, etc. These run in the Next.js server context. The same `modelService`/`pingService` code is isomorphic — see `getRApiUrl()` for how the R URL is resolved on the client vs. the server.
+**Lightweight routes (server-side, inside the UI Lambda):** `/api/runtime-config`, `/api/ping`, `/api/get-version-info`, etc. These run in the Next.js server context. The same `modelService`/`pingService` code is isomorphic: see `getRApiUrl()` for how the R URL is resolved on the client vs. the server.
 
 ### State Management
 
@@ -426,7 +426,7 @@ R_PORT=8787
 ### Production
 
 ```bash
-# React UI (UI Lambda) — the public R Lambda Function URL.
+# React UI (UI Lambda): the public R Lambda Function URL.
 # The /api/runtime-config route reads this and exposes it to the browser
 # (window.RUNTIME_CONFIG), since the browser calls /run-model directly.
 R_API_URL=https://<r-lambda-id>.lambda-url.<region>.on.aws

--- a/README-dev.md
+++ b/README-dev.md
@@ -111,8 +111,8 @@ bun run cloud:lambda-url
 
 After running `bun run cloud:status`, you'll see:
 
-- **Frontend (React UI)**: the UI Lambda Function URL (`ui_lambda_url`) — fronted by Cloudflare in production
-- **Backend (AWS Lambda)**: the R backend Function URL (`lambda_r_backend_url`) — public access
+- **Frontend (React UI)**: the UI Lambda Function URL (`ui_lambda_url`), fronted by Cloudflare in production
+- **Backend (AWS Lambda)**: the R backend Function URL (`lambda_r_backend_url`), public access
 
 ### Example Output
 
@@ -297,7 +297,7 @@ When merging a release PR:
 
 - **Security**: Cloudflare WAF in front of the UI Lambda; R backend is a public Function URL (auth `NONE`, CORS `*`)
 - **Architecture**: Internet → Cloudflare (CDN/TLS/WAF) → UI Lambda Function URL; browser → R Lambda Function URL (direct, for analysis)
-- **Best for**: Production — serverless, scales to zero when idle
+- **Best for**: Production (serverless, scales to zero when idle)
 
 # Commit message formatting
 

--- a/apps/lambda-r-backend/Dockerfile
+++ b/apps/lambda-r-backend/Dockerfile
@@ -1,5 +1,5 @@
 # ─────────────────────────────────────────────────────────
-# APP IMAGE — tiny, reusing pre-baked R library base
+# APP IMAGE: tiny, reusing pre-baked R library base
 # ─────────────────────────────────────────────────────────
 
 ARG PROJECT_NAME

--- a/apps/lambda-r-backend/Dockerfile.rlib
+++ b/apps/lambda-r-backend/Dockerfile.rlib
@@ -1,5 +1,5 @@
 # ─────────────────────────────────────────────────────────
-# R LIBRARY BASE (Amazon Linux 2023)  — pre-baked libs
+# R LIBRARY BASE (Amazon Linux 2023): pre-baked libs
 # Produces: rlib:al2023-r4.4.1-maive-<hash>
 # ─────────────────────────────────────────────────────────
 

--- a/apps/react-ui/client/docs/API_ARCHITECTURE.md
+++ b/apps/react-ui/client/docs/API_ARCHITECTURE.md
@@ -20,7 +20,7 @@ Browser ──► Cloudflare (CDN/TLS/WAF) ──► UI Lambda Function URL (Nex
   `.on.aws` origin because Lambda Function URLs reject a foreign `Host` header.
 - **R backend** is a public Lambda Function URL (authorization `NONE`, CORS `*`).
 - The **`/run-model`** analysis request goes straight from the browser to the R
-  Lambda — it no longer proxies through a Next.js API route.
+  Lambda; it no longer proxies through a Next.js API route.
 
 ## How It Works
 
@@ -54,24 +54,24 @@ return await httpPost<ModelResponse>(`${getRApiUrl()}/run-model`, requestData, {
 
 ### Isomorphic Services (`/src/api/services/`)
 
-- **`modelService.ts`** — POSTs analysis requests to the R backend. In the
+- **`modelService.ts`**: POSTs analysis requests to the R backend. In the
   browser this hits the R Lambda Function URL directly.
-- **`pingService.ts`** — connectivity check against the R backend.
+- **`pingService.ts`**: connectivity check against the R backend.
 
 ### Next.js API Routes (`/src/pages/api/`)
 
 Lightweight routes that run server-side inside the UI Lambda:
 
-- **`/api/runtime-config`** — exposes the R backend URL to the browser
-- **`/api/ping`** — connectivity testing
-- **`/api/get-version-info`**, **`/api/system-status`** — metadata
+- **`/api/runtime-config`**: exposes the R backend URL to the browser
+- **`/api/ping`**: connectivity testing
+- **`/api/get-version-info`**, **`/api/system-status`**: metadata
 
 > The previous **`/api/run-model`** proxy route has been removed.
 
 ## Environment Configuration
 
 ```bash
-# Production (UI Lambda) — public R Lambda Function URL exposed to the browser
+# Production (UI Lambda): public R Lambda Function URL exposed to the browser
 R_API_URL=https://<r-lambda-id>.lambda-url.<region>.on.aws
 # NEXT_PUBLIC_R_API_URL is also honored (takes precedence if set)
 

--- a/apps/react-ui/client/src/api/server/runsService.ts
+++ b/apps/react-ui/client/src/api/server/runsService.ts
@@ -132,7 +132,7 @@ export const batchGetRunStatuses = async (
       RequestItems: {
         [tableName]: {
           Keys: ids.map((id) => ({ jobId: id })),
-          // Status-only projection (no heavy `result`) — the list/watcher
+          // Status-only projection (no heavy `result`): the list/watcher
           // only needs status; the full result is fetched per-run elsewhere.
           ProjectionExpression:
             "jobId, #status, modelType, errorMessage, runDurationMs, submittedAt",
@@ -227,7 +227,7 @@ export const submitRun = async (
     parameters: params.parameters,
   });
 
-  // Too large to queue via SQS — caller falls back to the synchronous path.
+  // Too large to queue via SQS; caller falls back to the synchronous path.
   if (Buffer.byteLength(messageBody, "utf8") > MAX_QUEUE_BODY_BYTES) {
     return { outcome: "too_large" };
   }

--- a/apps/react-ui/client/src/api/services/modelService.ts
+++ b/apps/react-ui/client/src/api/services/modelService.ts
@@ -129,7 +129,7 @@ export class ModelService {
    * Submit a model run to the async queue (non-blocking).
    * Calls the same-origin UI Lambda route, which persists a queued job and
    * enqueues it for the orchestrator, returning a jobId. Returns
-   * `{ tooLarge: true }` when the dataset is too large to queue — the caller
+   * `{ tooLarge: true }` when the dataset is too large to queue; the caller
    * should then fall back to the synchronous runModel/runRTMA path.
    * @param data - The data to process
    * @param parameters - Model or RTMA parameters

--- a/apps/react-ui/client/src/components/RunLoading.tsx
+++ b/apps/react-ui/client/src/components/RunLoading.tsx
@@ -17,12 +17,12 @@ type RunLoadingProps = {
 const COPY: Record<RunLoadingPhase, { title: string; subtitle: string }> = {
   submitting: {
     title: "Queueing your analysis…",
-    subtitle: "One moment — we're setting things up.",
+    subtitle: "One moment, we're setting things up.",
   },
   running: {
     title: "Your analysis is running…",
     subtitle:
-      "You're free to leave this page — it keeps running in the background and will appear under My Runs.",
+      "You're free to leave this page. It keeps running in the background and will appear under My Runs.",
   },
   blocking: {
     title: "Running your analysis…",
@@ -46,7 +46,7 @@ export default function RunLoading({
   const { title } = COPY[phase];
   const subtitle =
     phase === "blocking" && showWarmupHint
-      ? "Still working — the first run can take a little longer while the analysis engine warms up."
+      ? "Still working. The first run can take a little longer while the analysis engine warms up."
       : COPY[phase].subtitle;
 
   return (

--- a/apps/react-ui/client/src/components/RunsWatcher.tsx
+++ b/apps/react-ui/client/src/components/RunsWatcher.tsx
@@ -27,7 +27,7 @@ const isTerminal = (status: RunStatus) => TERMINAL_STATUSES.includes(status);
  * App-level watcher (renders nothing). While the per-browser runs list has any
  * non-terminal run, it polls their status via the batch endpoint, updates the
  * store (so the My Runs list reflects live status from anywhere in the app),
- * and fires a browser notification when a run transitions to terminal — with an
+ * and fires a browser notification when a run transitions to terminal, with an
  * in-app alert fallback. Inert when CONFIG.ASYNC_RUNS_ENABLED is false.
  */
 export default function RunsWatcher() {
@@ -36,7 +36,7 @@ export default function RunsWatcher() {
   const updateRunStatus = useRunsStore((state) => state.updateRunStatus);
   const { showAlert } = useGlobalAlert();
 
-  // Stable key of the runs still in flight — drives the polling effect.
+  // Stable key of the runs still in flight; drives the polling effect.
   const pendingIdsKey = runsList
     .filter((run) => !isTerminal(run.status))
     .map((run) => run.jobId)
@@ -98,7 +98,7 @@ export default function RunsWatcher() {
         // terminal "expired" status. Done in a separate pass (not driven by the
         // response) so it never fires a "run finished" notification. The age
         // guard means a run only transiently absent from a throttled batch
-        // response is not falsely expired — a younger missing run keeps polling
+        // response is not falsely expired: a younger missing run keeps polling
         // until its record reappears or it genuinely ages out.
         const returnedIds = new Set(runs.map((run) => run.jobId));
         const now = Date.now();
@@ -111,7 +111,7 @@ export default function RunsWatcher() {
           }
         });
       } catch {
-        // transient (network/throttle) — keep polling
+        // transient (network/throttle); keep polling
       }
 
       if (!cancelled) {

--- a/apps/react-ui/client/src/hooks/useRunStatus.ts
+++ b/apps/react-ui/client/src/hooks/useRunStatus.ts
@@ -90,7 +90,7 @@ export function useRunStatus(jobId: string | null): UseRunStatusResult {
         if (cancelled) {
           return;
         }
-        // Transient errors (network blip, brief 404 right after submit) — keep
+        // Transient errors (network blip, brief 404 right after submit): keep
         // polling; a persistent failure is caught by the MAX_POLL_MS guard.
         setErrorMessage(
           error instanceof Error
@@ -126,10 +126,10 @@ export function useRunStatus(jobId: string | null): UseRunStatusResult {
         setIsPolling(false);
         return;
       }
-      // No durable result and the run is past the 48h server TTL — its record is
-      // gone, so polling would only spin until MAX_POLL_MS. Mark it expired and
-      // stop. (The cache check above still wins, so an immutable cached result
-      // always renders regardless of age.)
+      // No durable result and the run is past the 48h server TTL, so its record
+      // is gone and polling would only spin until MAX_POLL_MS. Mark it expired
+      // and stop. (The cache check above still wins, so an immutable cached
+      // result always renders regardless of age.)
       const entry = useRunsStore
         .getState()
         .runsList.find((run) => run.jobId === jobId);

--- a/apps/react-ui/client/src/lib/text/index.ts
+++ b/apps/react-ui/client/src/lib/text/index.ts
@@ -239,7 +239,7 @@ const TEXT = {
       requiredColumns:
         "Please include columns for **effect estimates** and **standard errors**. **Sample sizes** are required for every model except RTMA (study IDs are optional).",
       numberFormats:
-        "Effect estimates and standard errors can include decimal points or commas—MAIVE will interpret both.",
+        "Effect estimates and standard errors can include decimal points or commas; MAIVE will interpret both.",
       extraColumns:
         "Extra columns are welcome! You'll be able to ignore them during column mapping.",
     },
@@ -255,7 +255,7 @@ const TEXT = {
       studyId: "Study ID (optional)",
     },
     helperText:
-      "Each column can only be mapped once. The Sample size field is required for every model except RTMA; without it, only RTMA will be available. The Study ID field is optional — leave it blank if you don't have study-level clustering.",
+      "Each column can only be mapped once. The Sample size field is required for every model except RTMA; without it, only RTMA will be available. The Study ID field is optional: leave it blank if you don't have study-level clustering.",
     continueButton: "Continue to validation",
     autoMappingNotice:
       "We've pre-selected columns where the headers looked familiar. Feel free to adjust before continuing.",
@@ -363,7 +363,7 @@ const TEXT = {
     computeAndersonRubin: {
       label: "Compute Anderson-Rubin Confidence Interval",
       tooltip:
-        "The Anderson–Rubin confidence interval is robust to weak instruments (when sample size poorly predicts precision). It should be reported when the first-stage F-statistic is below 10.",
+        "The Anderson-Rubin confidence interval is robust to weak instruments (when sample size poorly predicts precision). It should be reported when the first-stage F-statistic is below 10.",
       warning:
         "May increase processing time. For the corrected mean (intercept), intervals can be wide because the instrument identifies the slope, not the intercept. In some cases (e.g. high heterogeneity in standard errors), AR intervals may return NA.",
     },
@@ -417,7 +417,7 @@ const TEXT = {
     winsorize: {
       label: "Winsorization (%)",
       tooltip:
-        "Reduces the influence of extreme outliers by replacing values beyond symmetric percentile bounds with the corresponding boundary values. Select the winsorization percentage (0–5%) to apply to effect sizes and standard errors.",
+        "Reduces the influence of extreme outliers by replacing values beyond symmetric percentile bounds with the corresponding boundary values. Select the winsorization percentage (0 to 5%) to apply to effect sizes and standard errors.",
       selectedLabel: "Selected winsorization",
     },
     shouldUseInstrumenting: {
@@ -511,7 +511,7 @@ const TEXT = {
       "Adjust your meta-analysis for publication bias, p-hacking, and spurious precision using MAIVE. Explore the methodology and access the resources that power the estimator.",
     overview: {
       title: "Overview",
-      text: `MAIVE (Meta-Analysis Instrumental Variable Estimator) adjusts for publication bias and p-hacking while correcting for “spurious precision” — over-optimistic standard errors that arise when researchers choose methods or models that under-report true uncertainty.
+      text: `MAIVE (Meta-Analysis Instrumental Variable Estimator) adjusts for publication bias and p-hacking while correcting for “spurious precision”: over-optimistic standard errors that arise when researchers choose methods or models that under-report true uncertainty.
       By using an instrumental-variable based on the inverse sample size, MAIVE **reduces biases due to p-hacking** while leaving publication-bias corrections (e.g. PET-PEESE) intact.
       It is most useful for observational research, where standard errors are easiest to game and inverse-variance weights can back-fire. For experimental research, it presents a useful robustness check.`,
     },
@@ -556,7 +556,7 @@ const TEXT = {
       text: [
         {
           head: "Observational Evidence",
-          text: "Economics, psychology, education, medical research — any field where research design can drive reported precision.",
+          text: "Economics, psychology, education, medical research: any field where research design can drive reported precision.",
         },
         {
           head: "Policy Analysis",

--- a/apps/react-ui/client/src/pages/api/runs.ts
+++ b/apps/react-ui/client/src/pages/api/runs.ts
@@ -31,7 +31,7 @@ const handler = async (
     return res.status(503).json({ error: "Async runs are not configured." });
   }
 
-  // GET /api/runs?ids=a,b,c — batch status lookup for the My Runs list / watcher.
+  // GET /api/runs?ids=a,b,c: batch status lookup for the My Runs list / watcher.
   if (req.method === "GET") {
     const ids = parseIdsParam(req.query.ids, MAX_BATCH_IDS);
     if (ids.length === 0) {

--- a/apps/react-ui/client/src/pages/index.tsx
+++ b/apps/react-ui/client/src/pages/index.tsx
@@ -162,7 +162,7 @@ export default function Home() {
                     <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-blue-400 opacity-75" />
                     <span className="relative inline-flex h-2 w-2 rounded-full bg-blue-500" />
                   </span>
-                  {`${activeRunCount} run${activeRunCount === 1 ? "" : "s"} in progress — view My Runs`}
+                  {`${activeRunCount} run${activeRunCount === 1 ? "" : "s"} in progress: view My Runs`}
                 </>
               ) : (
                 `View My Runs (${runsList.length})`

--- a/apps/react-ui/client/src/pages/model/index.tsx
+++ b/apps/react-ui/client/src/pages/model/index.tsx
@@ -150,7 +150,7 @@ export default function ModelPage() {
 
       // Durable fallback: the in-memory cache is lost on a page reload (the
       // persisted store keeps only the dataId), so recover from IndexedDB
-      // before giving up — otherwise the run would submit with empty data.
+      // before giving up. Otherwise the run would submit with empty data.
       if (!data && dataId) {
         const cached = await getCachedUploadedData(dataId);
         if (cached) {
@@ -195,7 +195,7 @@ export default function ModelPage() {
       console.error("Error loading data:", error);
       if (isMountedRef.current) {
         showAlert(
-          "We couldn't find your data — it isn't kept after a page reload. Please upload it again or re-run the demo.",
+          "We couldn't find your data. It isn't kept after a page reload, so please upload it again or re-run the demo.",
           "error",
         );
         router.push("/upload");
@@ -729,11 +729,11 @@ export default function ModelPage() {
 
   const handleRunModel = useCallback(() => {
     void (async () => {
-      // Never submit an empty-data run — without this the backend fails with a
+      // Never submit an empty-data run; without this the backend fails with a
       // confusing "Data must have exactly 3 or 4 columns. Found 0 columns."
       if (!uploadedData || uploadedData.data.length === 0) {
         showAlert(
-          "Your data isn't loaded — please upload it again or re-run the demo.",
+          "Your data isn't loaded. Please upload it again or re-run the demo.",
           "error",
         );
         return;
@@ -769,8 +769,8 @@ export default function ModelPage() {
               : parameters;
 
           // Best-effort: if the async submit fails (e.g. the queue/table isn't
-          // configured — 503 locally — or a transient error), degrade to the
-          // synchronous path below rather than failing the whole run. A user
+          // configured, giving a 503 locally, or a transient error), degrade to
+          // the synchronous path below rather than failing the whole run. A user
           // abort is re-thrown so the outer handler can report it.
           let submission: SubmitRunResponse | null = null;
           try {

--- a/apps/react-ui/client/src/pages/results/index.tsx
+++ b/apps/react-ui/client/src/pages/results/index.tsx
@@ -265,7 +265,7 @@ export default function ResultsPage() {
     }
   }, [exportErrorMessage]);
 
-  // Lateral nav back to the run history — only meaningful when this page was
+  // Lateral nav back to the run history, only meaningful when this page was
   // opened for a specific async run (jobId present, i.e. from My Runs).
   const allRunsLink = jobId ? (
     <Link
@@ -276,7 +276,7 @@ export default function ResultsPage() {
     </Link>
   ) : null;
 
-  // Async run still in flight (or terminal-but-unavailable) — show a loading /
+  // Async run still in flight (or terminal-but-unavailable): show a loading /
   // error state while polling, instead of the "no results" view.
   if (jobId && !results) {
     const runExpired = runStatus.status === "expired";

--- a/apps/react-ui/client/src/store/runsStore.ts
+++ b/apps/react-ui/client/src/store/runsStore.ts
@@ -4,7 +4,7 @@ import { persist } from "zustand/middleware";
 
 /**
  * A lightweight record of a submitted async run, tracked per-browser.
- * The heavy result payload is NOT stored here — it lives in DynamoDB (48h TTL)
+ * The heavy result payload is NOT stored here; it lives in DynamoDB (48h TTL)
  * and is fetched by jobId when a run is opened. (Durable client-side result
  * caching via IndexedDB is a Phase 2 enhancement.)
  */

--- a/apps/react-ui/client/src/tests/RunsWatcher.test.tsx
+++ b/apps/react-ui/client/src/tests/RunsWatcher.test.tsx
@@ -68,7 +68,7 @@ describe("RunsWatcher", () => {
 
   it("flips a run gone from the backend and past the TTL to expired", async () => {
     // Submitted beyond the 48h TTL and absent from the batch response (its
-    // record has expired) — the watcher marks it expired, without notifying.
+    // record has expired), the watcher marks it expired, without notifying.
     useRunsStore.getState().addRun({
       jobId: "old-1",
       modelType: "RTMA",

--- a/apps/react-ui/client/src/tests/apiRunsLegacy.test.ts
+++ b/apps/react-ui/client/src/tests/apiRunsLegacy.test.ts
@@ -124,12 +124,12 @@ describe("legacy /api/runs (unchanged behavior)", () => {
     });
   });
 
-  it("queues a valid submission and returns 200 { jobId } — no dataset shape enforced", async () => {
+  it("queues a valid submission and returns 200 { jobId } with no dataset shape enforced", async () => {
     setConfigured();
     ddbSendMock.mockResolvedValue({});
     sqsSendMock.mockResolvedValue({});
     const { default: handler } = await import("@src/pages/api/runs");
-    // Only 1 row / missing n_obs — the legacy route never validated shape.
+    // Only 1 row / missing n_obs; the legacy route never validated shape.
     const req = createMockReq({
       method: "POST",
       body: {

--- a/apps/react-ui/client/src/utils/interpretationTextGenerator.ts
+++ b/apps/react-ui/client/src/utils/interpretationTextGenerator.ts
@@ -161,7 +161,7 @@ export function generateTestsInterpretation(
       strength === "weak" ? "required" : "optional but recommended";
 
     sentences.push(
-      `The instrument is ${strengthText} (first-stage F-statistic = ${formatNumber(firstStageFStatistic)}), implying that the Anderson–Rubin confidence interval is ${ciRequirement}.`,
+      `The instrument is ${strengthText} (first-stage F-statistic = ${formatNumber(firstStageFStatistic)}), implying that the Anderson-Rubin confidence interval is ${ciRequirement}.`,
     );
   }
 
@@ -174,7 +174,7 @@ export function generateTestsInterpretation(
     const hausmanNA = isHausmanTestNA(hausmanTest);
     if (hausmanNA) {
       sentences.push(
-        "The Hausman test is undefined because IV variance < OLS variance — estimators are nearly identical, so this test is not informative.",
+        "The Hausman test is undefined because IV variance < OLS variance; estimators are nearly identical, so this test is not informative.",
       );
     } else {
       const { rejectsNull } = hausmanTest;

--- a/apps/react-ui/client/src/utils/notifications.ts
+++ b/apps/react-ui/client/src/utils/notifications.ts
@@ -12,7 +12,7 @@ export const requestNotificationPermission = (): void => {
     return;
   }
   void Notification.requestPermission().catch(() => {
-    // ignore — we fall back to in-app alerts
+    // ignore; we fall back to in-app alerts
   });
 };
 
@@ -35,8 +35,8 @@ export const notifyRunComplete = ({
   if (!isSupported() || Notification.permission !== "granted") {
     return false;
   }
-  // "expired" is assigned locally to stale runs, not a completion event — never
-  // surface it as a notification.
+  // "expired" is assigned locally to stale runs, not a completion event, so
+  // never surface it as a notification.
   if (status === "expired") {
     return false;
   }
@@ -45,7 +45,7 @@ export const notifyRunComplete = ({
     ? `${modelType} run finished`
     : `${modelType} run ${status === "timedout" ? "timed out" : "failed"}`;
   const body = succeeded
-    ? "Your analysis is ready — open it from My Runs."
+    ? "Your analysis is ready. Open it from My Runs."
     : "Open My Runs for details.";
   try {
     const notification = new Notification(title, { body, tag: jobId });

--- a/docs/ASYNC_RUNS_DESIGN.md
+++ b/docs/ASYNC_RUNS_DESIGN.md
@@ -1,4 +1,4 @@
-# Async Model Runs — Design & Implementation Plan
+# Async Model Runs: Design & Implementation Plan
 
 **Status:** Proposed (scope locked, pre-implementation)
 **Date:** 2026-06-04
@@ -55,7 +55,7 @@ This aligns with the direction agreed in #441 ("async/background runs now").
   triggered in `apps/react-ui/client/src/pages/model/index.tsx`.
 - **Results are passed entirely via URL query params**
   (`apps/react-ui/client/src/pages/results/index.tsx` reads `?results=&parameters=`),
-  including the ~50 KB base64 plot — producing enormous, fragile URLs. **No run is
+  including the ~50 KB base64 plot, producing enormous, fragile URLs. **No run is
   persisted server-side.**
 - **No async/queue infra exists** (no SQS, no app DynamoDB, no S3 results bucket). The
   only DynamoDB is the Terraform state-lock table. **No user accounts.**
@@ -71,7 +71,7 @@ This aligns with the direction agreed in #441 ("async/background runs now").
 | D2 | **Result storage: DynamoDB-only, full result (~50 KB) stored inline; 48 h TTL.** No S3. | Result fits well under DynamoDB's 400 KB item limit. One store, minimal footprint. S3 reserved only if a payload ever exceeds ~400 KB. |
 | D3 | **Durable history is client-side** (IndexedDB for result payloads, localStorage for the lightweight job list). The DynamoDB item is only a **48 h pickup buffer**. | Matches "persist it in the client's session"; minimizes server persistence. |
 | D4 | **No auto-retry for runs that executed** (`maxReceiveCount=1` → DLQ; user re-runs explicitly). **Amended 2026-07-17:** HTTP 429 from the R backend *is* retried in-process with bounded backoff. | MCMC is nondeterministic (a retry yields a different result) and pathological datasets just re-time-out, doubling cost, but both rationales only apply to runs that actually ran. A 429 means the reserved-concurrency cap (see PUBLIC_API_DESIGN.md D2) refused the invocation and no analysis happened, so retrying is deterministic-safe and free. Without the carve-out, a burst of synchronous traffic saturating the cap marks queued runs permanently `failed` instead of letting them wait for a slot. |
-| D5 | **Keep the synchronous path as a flagged fallback** — and as the route for datasets too large to queue. | Instant rollback lever; avoids needing S3 input plumbing in Phase 1 (large datasets bypass the queue). |
+| D5 | **Keep the synchronous path as a flagged fallback**, and as the route for datasets too large to queue. | Instant rollback lever; avoids needing S3 input plumbing in Phase 1 (large datasets bypass the queue). |
 | D6 | **Runs list is per-browser** (no accounts). `jobId` is an opaque bearer token; results readable by anyone holding the id. | No identity system exists; same sharing model as today's shareable results URL. |
 | D7 | **Status delivery via short polling** (status-only reads; full result fetched once when terminal). No SSE/WebSocket. | Simple; fast handlers; avoids Lambda/Cloudflare long-connection issues. |
 | D8 | **Dark launch behind `CONFIG.ASYNC_RUNS_ENABLED`** (off by default, like `RTMA_ENABLED`). | Ship without exposure; flip on after verification; flip off to roll back. |
@@ -91,10 +91,10 @@ This aligns with the direction agreed in #441 ("async/background runs now").
 ```
 
 **Why the orchestrator (D1), rejected alternatives:**
-- *SQS event source directly on the R Lambda* — would require replacing the Lambda Web
+- *SQS event source directly on the R Lambda*: would require replacing the Lambda Web
   Adapter with a native R runtime loop and re-plumbing request parsing in the rstan
   image. Too invasive/risky.
-- *Submit endpoint async-`Invoke`s the R Lambda* — same HTTP-handler-vs-raw-event
+- *Submit endpoint async-`Invoke`s the R Lambda*: same HTTP-handler-vs-raw-event
   mismatch, and no clean place to persist terminal status; loses SQS visibility/DLQ.
 
 ## 6. Data model
@@ -118,30 +118,30 @@ This aligns with the direction agreed in #441 ("async/background runs now").
 (`succeeded` / `failed` / `timedout`). The R 480 s-guard error maps to `timedout`.
 
 **Client stores:**
-- `localStorage` — `runsStore` (Zustand `persist`): list of `{jobId, modelType, dataId, submittedAt}`.
-- `IndexedDB` — cache of fetched result payloads (durable history; localStorage is too small for ~50 KB plots).
+- `localStorage`: `runsStore` (Zustand `persist`), list of `{jobId, modelType, dataId, submittedAt}`.
+- `IndexedDB`: cache of fetched result payloads (durable history; localStorage is too small for ~50 KB plots).
 
 ## 7. API surface (Next.js routes in the UI Lambda)
 
 All handlers are fast (DDB/SQS calls), so the UI Lambda's 30 s cap is irrelevant.
 
-- `POST /api/runs` — body `{ data, parameters, dataId, modelType }`. Generate `jobId`,
+- `POST /api/runs`: body `{ data, parameters, dataId, modelType }`. Generate `jobId`,
   write DDB `queued`, send SQS message, return `{ jobId }`. If `data` exceeds the SQS
   body budget (~200 KB), return a signal to use the **synchronous fallback** (D5).
-- `GET /api/runs/{jobId}` — DDB GetItem with a **status-only projection** for polling;
+- `GET /api/runs/{jobId}`: DDB GetItem with a **status-only projection** for polling;
   returns the full `result` once `status` is terminal.
-- *(Phase 2)* `GET /api/runs?ids=...` — DDB BatchGetItem of statuses for the history list.
+- *(Phase 2)* `GET /api/runs?ids=...`: DDB BatchGetItem of statuses for the history list.
 
-## 8. Phase 1 — MVP "fire-and-poll" (scope)
+## 8. Phase 1: MVP "fire-and-poll" (scope)
 
-**Terraform — `prod-runtime`** (suggested new files `runs_store.tf`, `runs_queue.tf`, `orchestrator_lambda.tf`):
-- [ ] `aws_dynamodb_table.runs` — PK `jobId`, `PAY_PER_REQUEST`, TTL on `ttl`.
+**Terraform, `prod-runtime`** (suggested new files `runs_store.tf`, `runs_queue.tf`, `orchestrator_lambda.tf`):
+- [ ] `aws_dynamodb_table.runs`: PK `jobId`, `PAY_PER_REQUEST`, TTL on `ttl`.
 - [ ] `aws_sqs_queue.runs` (visibility ~660 s) + `aws_sqs_queue.runs_dlq` (redrive `maxReceiveCount=1`).
 - [ ] `aws_lambda_function.orchestrator` (Node 20, zip) + IAM role/policy (SQS consume, DDB update/get) + `aws_lambda_event_source_mapping` (SQS, `maximum_concurrency` capped) + log group + DLQ-depth alarm.
 - [ ] Set `lambda_r_backend_reserved_concurrency` to a real cap (start ~5).
 - [ ] Extend `ui_lambda.tf`: env (`RUNS_TABLE_NAME`, `RUNS_QUEUE_URL`) + IAM (DDB get/put/batchGet/query, SQS send).
 
-**Terraform — `prod-foundation`** (manual apply, must precede the runtime apply):
+**Terraform, `prod-foundation`** (manual apply, must precede the runtime apply):
 - [ ] Extend `gha_terraform_policy` (`iam.tf`): add `sqs:*`; broaden DynamoDB to include `Query`, `UpdateItem`, `BatchGetItem`, `BatchWriteItem`, `Scan`.
 
 **Orchestrator Lambda (Node 20, zip):**
@@ -158,7 +158,7 @@ All handlers are fast (DDB/SQS calls), so the UI Lambda's 30 s cap is irrelevant
 
 **Outcome:** submit → don't block → return to *this* run; mega-URL problem fixed.
 
-## 9. Phase 2 — runs queue/history, compare, notifications (later)
+## 9. Phase 2: runs queue/history, compare, notifications (later)
 
 - [ ] **Runs/History page**: list the browser's runs with live status (batch endpoint), filter, re-open.
 - [ ] **Compare view**: select 2+ succeeded runs, render side-by-side (reuse `ResultsSummary` / `RTMAResultsSummary`).
@@ -182,41 +182,41 @@ All handlers are fast (DDB/SQS calls), so the UI Lambda's 30 s cap is irrelevant
 - **New:** results persist server-side for up to **48 h** (today nothing persists).
   Mitigations: DynamoDB item is private (reachable only via the UI Lambda routes),
   random opaque `jobId`, 48 h TTL auto-delete.
-- The **input dataset is not persisted at rest** — it travels only in the transient
+- The **input dataset is not persisted at rest**; it travels only in the transient
   (encrypted, auto-deleted on consume) SQS message.
-- `jobId` is a **bearer token**: anyone with it can read that run for 48 h — same
+- `jobId` is a **bearer token**: anyone with it can read that run for 48 h, the same
   exposure model as today's shareable results URL. Document in user-facing privacy notes.
 - Clearing browser data loses the local history list (accepted, per D3/D6); results
   not yet fetched by the client are lost after the 48 h server TTL (accepted).
 
 ## 12. Cost
 
-New infra is negligible — **async adds no model compute**; the R Lambda runs as much
+New infra is negligible; **async adds no model compute**, and the R Lambda runs as much
 as today. Approximate (on-demand; eu-central-1 ~a few % above us-east-1):
 
-- **Per run (new infra only):** ~$0.0003–0.0005 (orchestrator idle-wait dominates; DDB/SQS/UI-poll are sub-cent).
-- **Idle baseline:** ~$0.05–0.20 / month (mostly SQS event-source long-polling).
-- **At volume:** ~$0.5–1 / month at 1k runs; ~$3–5 / month at 10k runs. Low volume is largely covered by AWS free tiers (effectively $0).
-- The dominant cost remains the **pre-existing** R compute (~$0.001–0.002 / run at 2 GB).
+- **Per run (new infra only):** ~$0.0003 to $0.0005 (orchestrator idle-wait dominates; DDB/SQS/UI-poll are sub-cent).
+- **Idle baseline:** ~$0.05 to $0.20 / month (mostly SQS event-source long-polling).
+- **At volume:** ~$0.5 to $1 / month at 1k runs; ~$3 to $5 / month at 10k runs. Low volume is largely covered by AWS free tiers (effectively $0).
+- The dominant cost remains the **pre-existing** R compute (~$0.001 to $0.002 / run at 2 GB).
 - **Not in scope, but flagged:** keep-warm / provisioned concurrency (speed track) would
   cost ~$22 / month per always-warm 2 GB instance.
 
 ## 13. Rollout plan
 
-1. Build Phase 1 on a fresh branch, **behind `ASYNC_RUNS_ENABLED` (off)** — ships dark.
+1. Build Phase 1 on a fresh branch, **behind `ASYNC_RUNS_ENABLED` (off)**; ships dark.
 2. Open PR(s); review.
-3. **Manually apply `prod-foundation`** (IAM additions) — must precede the runtime apply.
+3. **Manually apply `prod-foundation`** (IAM additions); must precede the runtime apply.
 4. Merge with `release` label → CI applies `prod-runtime` (creates DDB/SQS/orchestrator, updates UI Lambda).
 5. Flip `ASYNC_RUNS_ENABLED` on → smoke-test (submit, navigate away, return, verify history/result).
 6. Monitor DLQ-depth alarm + CloudWatch.
-7. **Rollback:** flip the flag off — the synchronous path remains fully functional.
+7. **Rollback:** flip the flag off; the synchronous path remains fully functional.
 
 ## 14. Risks & open questions
 
-- **Orchestrator idle double-billing** while R runs — minor at 256 MB.
+- **Orchestrator idle double-billing** while R runs, minor at 256 MB.
 - **Result > 400 KB** (e.g., higher-resolution plots) → would need the S3 escape hatch (§15).
-- **Un-fetched run expires after 48 h** on a device that never synced — accepted trade-off.
-- **Concurrency cap** (~5) is a starting guess — tune from observed load/cost.
+- **Un-fetched run expires after 48 h** on a device that never synced: accepted trade-off.
+- **Concurrency cap** (~5) is a starting guess; tune from observed load/cost.
 - **R backend log verbosity** (debug-level, verbose `cli` output) is pre-existing; worth
   trimming someday to control CloudWatch ingestion, but out of scope here.
 

--- a/docs/SERVER_SIDE_API_ARCHITECTURE.md
+++ b/docs/SERVER_SIDE_API_ARCHITECTURE.md
@@ -51,7 +51,7 @@ through a Lambda Function URL.
 - The R backend is a separate **public** Lambda Function URL with authorization
   `NONE` and CORS `*`, so the browser can call it cross-origin.
 - The heavy `/run-model` analysis request is sent **directly from the browser**
-  to the R Lambda Function URL — it does not pass through the Next.js server.
+  to the R Lambda Function URL; it does not pass through the Next.js server.
 
 ## How the Browser Finds the R Backend
 
@@ -104,9 +104,9 @@ return await httpPost<ModelResponse>(`${getRApiUrl()}/run-model`, requestData, {
 The UI Lambda still hosts lightweight Next.js API routes that execute in the
 Next.js server context, e.g.:
 
-- `/api/runtime-config` — exposes the R backend URL to the browser
-- `/api/ping` — connectivity check
-- `/api/get-version-info`, `/api/system-status` — metadata
+- `/api/runtime-config`: exposes the R backend URL to the browser
+- `/api/ping`: connectivity check
+- `/api/get-version-info`, `/api/system-status`: metadata
 
 The previous `/api/run-model` proxy has been **removed**.
 
@@ -132,7 +132,7 @@ The previous `/api/run-model` proxy has been **removed**.
 
 ## Trade-offs
 
-- **Simplicity / cost:** no ALB, ECS cluster, or NAT — just two Lambdas and a
+- **Simplicity / cost:** no ALB, ECS cluster, or NAT, just two Lambdas and a
   CDN. Scales to zero when idle.
 - **CORS:** the R Lambda is public and CORS-open, so browsers can call it
   directly. There is no private-subnet isolation; protection comes from

--- a/docs/unstable-release-banner.md
+++ b/docs/unstable-release-banner.md
@@ -6,8 +6,8 @@ This document explains how to control the unstable release warning banner for th
 
 The banner is powered by two AWS Systems Manager (SSM) Parameter Store values that are created during Terraform deploys:
 
-- `/${var.project}/ui/unstable_banner_enabled` – determines whether the banner appears.
-- `/${var.project}/ui/unstable_banner_message` – text shown in the banner when it is enabled.
+- `/${var.project}/ui/unstable_banner_enabled`: determines whether the banner appears.
+- `/${var.project}/ui/unstable_banner_message`: text shown in the banner when it is enabled.
 
 Terraform seeds the parameters with safe defaults:
 

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -160,7 +160,7 @@ else
       --region "$AWS_REGION" \
       >/dev/null
   else
-    echo "❗ Skipping tagging — table does not exist."
+    echo "❗ Skipping tagging: table does not exist."
     exit 1
   fi
 fi


### PR DESCRIPTION
@
## Summary

Removes every em dash (—) and en dash (–) from the repo (94 occurrences across 27 files), restructuring each sentence rather than swapping the character. Replacements follow context: a period or semicolon for joined clauses, commas/parentheses for asides, a colon before a list or clarification, "to" for ranges.

Notable, beyond punctuation:

- `Anderson–Rubin` to `Anderson-Rubin` in two user-facing strings. The hyphen was already the convention in the other 15 occurrences, so this also fixes an inconsistency.
- Numeric ranges in `docs/ASYNC_RUNS_DESIGN.md` cost section written out with "to" (`~$0.0003 to $0.0005`) since a hyphen next to a dollar amount reads like a minus.
- Two comment blocks rewrapped to stay inside the line limit after rewording.

No logic changes. User-facing copy in `lib/text/index.ts`, `RunLoading.tsx`, `notifications.ts`, and the model page alerts is reworded but semantically identical.

## Test plan

- `npx vitest run`: 29 files, 204 tests, all passing.
- `npx tsc --noEmit`: only the pre-existing `import.meta.vitest` error in `src/tests/integration/results.test.tsx`.
- `npx eslint` on all changed TS files: no issues beyond the repo-wide CRLF `Delete ␍` noise.
- `bash -n scripts/bootstrap.sh` clean.
- The `Dockerfile.rlib` edit is a comment; the rlib image tag is hashed from `r_scripts/r-packages.txt` only (`scripts/build-r-lib.sh:11`), so this does not trigger an image rebuild.
@