### PR TITLE
perf: run RTMA stan chains in parallel and raise the R lambda to 2 vCPU

### DIFF
--- a/apps/lambda-r-backend/r_scripts/api_v1.R
+++ b/apps/lambda-r-backend/r_scripts/api_v1.R
@@ -485,7 +485,7 @@ api_v1_default_maive_parameters <- function(parameters) {
 
 #' Apply RTMA parameter defaults per design D6
 #'
-#' The internal parallelize/timeoutSeconds knobs are deliberately not exposed;
+#' The internal cores/timeoutSeconds knobs are deliberately not exposed;
 #' run_rtma_model falls back to its own safe defaults for them. `seed` is not in
 #' that category: those two only affect how the fit is executed, while the seed
 #' determines the numbers that come back, so a caller who wants to re-run a

--- a/apps/lambda-r-backend/r_scripts/rtma_model.R
+++ b/apps/lambda-r-backend/r_scripts/rtma_model.R
@@ -31,6 +31,33 @@ RTMA_PLOT_RES <- 120
 # what the wall-clock limit below is for.
 RTMA_DEFAULT_SEED <- 2025L
 
+# Upper bound on sampling cores: rstan runs 4 chains by default and forks at
+# most one worker per chain, so nothing above this can be used.
+RTMA_MAX_SAMPLING_CORES <- 4L
+
+#' Number of cores to sample RTMA's Stan chains on
+#'
+#' rstan reads `getOption("mc.cores")` to decide how many of its 4 chains to run
+#' at once, and on Linux (and macOS) it forks with `mclapply`, so the overhead is
+#' sub-second. Sampling is ~95% of RTMA wall time, so this is the single largest
+#' lever on how long a request takes (#483).
+#'
+#' The count is read from the environment rather than detected, for two reasons.
+#' `parallel::detectCores()` reports the host's cores, not the Lambda's
+#' allocation, so it over-subscribes and the chains thrash. And the number of
+#' cores a Lambda gets is a function of its memory size (~1 vCPU per 1769 MB),
+#' which lives in terraform, not here: `RTMA_SAMPLING_CORES` is set alongside
+#' `memory_size` in prod-runtime/lambda.tf so the two cannot drift apart.
+#'
+#' Defaults to 1 (serial) when unset, so local runs and the e2e suite behave as
+#' they did before.
+#'
+#' @return A positive integer core count
+rtma_sampling_cores <- function() {
+  n <- suppressWarnings(as.integer(Sys.getenv("RTMA_SAMPLING_CORES")))
+  if (length(n) != 1 || is.na(n) || n < 1) 1L else n
+}
+
 #' Render a z-score density plot and return it as a base64-encoded PNG data URI
 #'
 #' phacking::z_density() has no favor_positive argument: it always draws the
@@ -190,9 +217,24 @@ run_rtma_model <- function(data, parameters, include_plot = TRUE) {
   favor_positive <- if (!is.null(params$favorPositive)) isTRUE(params$favorPositive) else TRUE
   alpha_select <- if (!is.null(params$alphaSelect)) as.numeric(params$alphaSelect) else 0.05
   ci_level <- if (!is.null(params$ciLevel)) as.numeric(params$ciLevel) else 0.95
-  # Default FALSE: parallel chains add fork overhead with no speedup, and thrash
-  # on the Lambda's sub-1-vCPU allocation. Benchmarks showed no gain even on 8 cores.
-  parallelize <- if (!is.null(params$parallelize)) isTRUE(params$parallelize) else FALSE
+  # Cores to sample on; see rtma_sampling_cores() above. Overridable per request
+  # so a benchmark can compare core counts without redeploying, but not exposed
+  # through the public /v1 API (see api_v1.R).
+  cores <- if (!is.null(params$cores)) {
+    suppressWarnings(as.integer(params$cores))
+  } else {
+    rtma_sampling_cores()
+  }
+  if (length(cores) != 1 || is.na(cores) || cores < 1) {
+    cli::cli_abort("The cores parameter must be a positive integer.")
+  }
+  # The legacy /run-rtma route (index.R) hands `parameters` to this function
+  # unfiltered, and it is publicly reachable, so `cores` is caller-settable
+  # there. rstan already forks only min(chains, cores) workers, so a large
+  # value cannot fork-bomb, but clamping here means that guarantee does not
+  # depend on an rstan implementation detail. RTMA_MAX_SAMPLING_CORES is the
+  # chain count: more cores than chains buys nothing.
+  cores <- min(cores, RTMA_MAX_SAMPLING_CORES)
   # Wall-clock budget kept below the Lambda function timeout so a degenerate
   # dataset returns a clear error instead of being hard-killed mid-request.
   timeout_sec <- if (!is.null(params$timeoutSeconds)) as.numeric(params$timeoutSeconds) else 480
@@ -212,7 +254,7 @@ run_rtma_model <- function(data, parameters, include_plot = TRUE) {
     "alpha_select: {alpha_select}",
     "ci_level: {ci_level}",
     "seed: {seed}",
-    "parallelize: {parallelize}",
+    "cores: {cores}",
     "timeout_sec: {timeout_sec}"
   ))
 
@@ -229,13 +271,26 @@ run_rtma_model <- function(data, parameters, include_plot = TRUE) {
   # response instead of being dropped on the floor.
   rtma_warnings <- character(0)
   start_time <- Sys.time()
+
+  # rstan takes its chain count from mc.cores, so set it here rather than
+  # passing parallelize = TRUE: that flag makes phacking call
+  # `options(mc.cores = parallel::detectCores())`, which reads the host's core
+  # count instead of the Lambda's allocation. Restored afterwards so a request
+  # cannot leave the option changed for the next one in the same container.
+  previous_mc_cores <- getOption("mc.cores")
+  on.exit(options(mc.cores = previous_mc_cores), add = TRUE)
+  options(mc.cores = cores)
+
   setTimeLimit(elapsed = timeout_sec, transient = TRUE)
   rtma_res <- tryCatch(
     withCallingHandlers(
       {
         # Seeded here rather than at the top of the function: nothing between
         # this line and phacking_meta() touches the RNG, so this is exactly the
-        # state the sampler starts from.
+        # state the sampler starts from. The seed also fixes rstan's own seed,
+        # which it draws from this RNG, so each chain's stream is determined by
+        # its chain id alone; running the chains on 1 core or 4 gives
+        # bit-identical draws (verified in #483).
         set.seed(seed)
         phacking::phacking_meta(
           yi = yi,
@@ -243,7 +298,7 @@ run_rtma_model <- function(data, parameters, include_plot = TRUE) {
           favor_positive = favor_positive,
           alpha_select = alpha_select,
           ci_level = ci_level,
-          parallelize = parallelize
+          parallelize = FALSE
         )
       },
       warning = function(w) {

--- a/apps/lambda-r-backend/r_scripts/tests/e2e/scenarios/rtma_seed_test.R
+++ b/apps/lambda-r-backend/r_scripts/tests/e2e/scenarios/rtma_seed_test.R
@@ -8,6 +8,13 @@
 #
 # The check that matters is bit-identity, not "close enough": a tolerance would
 # pass just as happily with the seed removed again.
+#
+# The same fingerprint also covers core-count invariance (#483). RTMA now runs
+# its Stan chains across however many cores the Lambda's memory size buys, and
+# that is only safe because a seeded fit gives the same draws whether the chains
+# run one at a time or all at once. If that ever stops holding, the reported
+# numbers would depend on the deployed memory size, which is the failure this
+# guards against.
 
 # Keep in sync with RTMA_DEFAULT_SEED in rtma_model.R. Asserted end to end so a
 # request that sets no seed still runs pinned, rather than silently drifting
@@ -25,10 +32,11 @@ expect_rtma_seed <- function(condition, message) {
   }
 }
 
-#' Build RTMA parameter JSON, optionally pinning the seed
+#' Build RTMA parameter JSON, optionally pinning the seed and core count
 #' @param seed Seed to request, or NULL to leave it to the backend default
+#' @param cores Sampling cores to request, or NULL for the backend default
 #' @return JSON string of parameters
-rtma_seed_params <- function(seed = NULL) {
+rtma_seed_params <- function(seed = NULL, cores = NULL) {
   params <- list(
     modelType = "RTMA",
     favorPositive = TRUE,
@@ -38,6 +46,9 @@ rtma_seed_params <- function(seed = NULL) {
   )
   if (!is.null(seed)) {
     params$seed <- seed
+  }
+  if (!is.null(cores)) {
+    params$cores <- cores
   }
   params_to_json(params)
 }
@@ -76,10 +87,11 @@ rtma_seed_differences <- function(left, right) {
 #' @param df Data frame of estimates
 #' @param seed Seed to request, or NULL for the backend default
 #' @param label Label used in progress output and failure messages
+#' @param cores Sampling cores to request, or NULL for the backend default
 #' @return Parsed results object
-run_rtma_seed_case <- function(df, seed, label) {
+run_rtma_seed_case <- function(df, seed, label, cores = NULL) {
   cat(sprintf("  %s...\n", label))
-  response <- test_run_rtma(df_to_json(df), rtma_seed_params(seed))
+  response <- test_run_rtma(df_to_json(df), rtma_seed_params(seed, cores))
 
   expect_rtma_seed(
     is.list(response) && !is.null(response$data),
@@ -182,6 +194,39 @@ check_rtma_seed_v1 <- function(df, expected) {
   invisible(TRUE)
 }
 
+#' Check that the core count changes only the speed, never the numbers (#483)
+#'
+#' Requests the same fit on 1 core and on 4 and compares the full fingerprint.
+#' 4 rather than 2 so the assertion holds at the largest core count the backend
+#' will ever use, whatever memory size it is deployed at; the value is clamped
+#' to the chain count, so a host with fewer cores oversubscribes briefly rather
+#' than changing the result.
+#'
+#' @param df Data frame of estimates
+#' @return TRUE invisibly
+check_rtma_cores_invariance <- function(df) {
+  serial <- run_rtma_seed_case(
+    df, RTMA_TEST_SEED, "same seed on 1 core", cores = 1
+  )
+  parallel <- run_rtma_seed_case(
+    df, RTMA_TEST_SEED, "same seed on 4 cores", cores = 4
+  )
+
+  differences <- rtma_seed_differences(
+    rtma_seed_fingerprint(serial),
+    rtma_seed_fingerprint(parallel)
+  )
+  expect_rtma_seed(
+    length(differences) == 0,
+    paste(
+      "Running the chains in parallel must not move the numbers;",
+      "1 core and 4 cores differ in", paste(differences, collapse = " | ")
+    )
+  )
+
+  invisible(TRUE)
+}
+
 #' Test that RTMA runs are reproducible under a pinned seed
 #' @return Test results
 test_rtma_seed <- function() {
@@ -226,10 +271,14 @@ test_rtma_seed <- function() {
       )
 
       check_rtma_seed_v1(test_data, rtma_seed_fingerprint(first))
+      check_rtma_cores_invariance(test_data)
 
       log_test_result(
         test_name, "PASS",
-        "Identical input and seed reproduce identical RTMA results"
+        paste(
+          "Identical input and seed reproduce identical RTMA results,",
+          "on any core count"
+        )
       )
 
       return(list(

--- a/docs/ASYNC_RUNS_DESIGN.md
+++ b/docs/ASYNC_RUNS_DESIGN.md
@@ -49,7 +49,7 @@ This aligns with the direction agreed in #441 ("async/background runs now").
     Lambda Web Adapter, `timeout=30s`, fronted by **Cloudflare** (~100 s origin cap).
   - **R backend Lambda** (`terraform/stacks/prod-runtime/lambda.tf`): R Plumber via
     Lambda Web Adapter, Function URL (auth NONE, CORS `*`), `timeout=600s`,
-    `memory_size=2048`. Routes in `apps/lambda-r-backend/r_scripts/index.R`.
+    `memory_size=3538` (2 vCPU). Routes in `apps/lambda-r-backend/r_scripts/index.R`.
 - **The browser calls the R Function URL directly** for runs
   (`apps/react-ui/client/src/api/services/modelService.ts` → `${getRApiUrl()}/run-model|/run-rtma`),
   triggered in `apps/react-ui/client/src/pages/model/index.tsx`.
@@ -197,9 +197,11 @@ as today. Approximate (on-demand; eu-central-1 ~a few % above us-east-1):
 - **Per run (new infra only):** ~$0.0003 to $0.0005 (orchestrator idle-wait dominates; DDB/SQS/UI-poll are sub-cent).
 - **Idle baseline:** ~$0.05 to $0.20 / month (mostly SQS event-source long-polling).
 - **At volume:** ~$0.5 to $1 / month at 1k runs; ~$3 to $5 / month at 10k runs. Low volume is largely covered by AWS free tiers (effectively $0).
-- The dominant cost remains the **pre-existing** R compute (~$0.001 to $0.002 / run at 2 GB).
+- The dominant cost remains the **pre-existing** R compute (~$0.001 to $0.002 / run). The
+  move to 3538 MB (#483) left this range alone: RTMA runs roughly twice as fast at 1.73x
+  the memory rate, so GB-s per run went slightly down, not up.
 - **Not in scope, but flagged:** keep-warm / provisioned concurrency (speed track) would
-  cost ~$22 / month per always-warm 2 GB instance.
+  cost ~$38 / month per always-warm 3.5 GB instance.
 
 ## 13. Rollout plan
 
@@ -223,5 +225,5 @@ as today. Approximate (on-demand; eu-central-1 ~a few % above us-east-1):
 ## 15. Out of scope / future
 
 - **S3 escape hatch** for >256 KB inputs and/or >400 KB results (deferred; sync path covers large inputs for now).
-- **Speed track:** cold-start mitigation (keep-warm / provisioned concurrency; check SnapStart eligibility) and a high-memory `parallelize=TRUE` re-benchmark for the slow tail.
+- **Speed track:** cold-start mitigation (keep-warm / provisioned concurrency; check SnapStart eligibility). The high-memory parallel-chain re-benchmark is done: the R backend now runs at 3538 MB (2 vCPU) and forks its Stan chains across both (#483).
 - **Accounts / cross-device history**, **email/SNS notifications**, **SSE/WebSocket push**.

--- a/docs/COST_CONTROLS.md
+++ b/docs/COST_CONTROLS.md
@@ -13,14 +13,14 @@ See also `PUBLIC_API_DESIGN.md` §7 (the original abuse/cost analysis) and
 The R backend is reachable directly at its raw `*.on.aws` Function URL (the
 browser is handed that URL via `/api/runtime-config`), so Cloudflare's edge rate
 limit is a speed bump, not a wall: an attacker can hit Lambda directly. One
-request can occupy a 2 GB Lambda for up to 600 s. The controls below bound what
+request can occupy a 3.5 GB Lambda for up to 600 s. The controls below bound what
 that adds up to.
 
 ## The layers
 
 | Layer | Where | What it bounds |
 |---|---|---|
-| Reserved concurrency = 10 (R backend) | `prod-runtime/variables.tf` (`lambda_r_backend_reserved_concurrency`) | Concurrent R executions, regardless of entry path. Excess gets `429`. Bounds the *rate* of spend (~$0.12/hr per slot). |
+| Reserved concurrency = 10 (R backend) | `prod-runtime/variables.tf` (`lambda_r_backend_reserved_concurrency`) | Concurrent R executions, regardless of entry path. Excess gets `429`. Bounds the *rate* of spend (~$0.21/hr per slot). |
 | Reserved concurrency = 30 (UI) | `prod-runtime/variables.tf` (`ui_lambda_reserved_concurrency`) | UI Lambda spend and its share of the account concurrency pool. |
 | Async fan-out = 5 | `prod-runtime/orchestrator_lambda.tf` (`maximum_concurrency`) | Concurrent async runs; kept below the R cap so async never starves sync. |
 | Max dataset rows = 50,000 | R `api_v1.R` / `index.R` (`MAX_INPUT_ROWS`), UI `datasetValidation.ts` (`MAX_ROWS`) | Per-request work; caps payload-driven CPU/output amplification on every HTTP route including the raw legacy path. |
@@ -30,8 +30,16 @@ that adds up to.
 | Alarm notifications (errors/throttles/duration/DLQ) | `prod-runtime/monitoring.tf` + the alarms | Human awareness; previously these alarms notified no one. |
 
 Reserved concurrency bounds the *rate* of spend but not the *total*: 10 slots
-pinned at 2 GB around the clock is still ~$860/month. The circuit breaker is what
-turns the rate limit into an enforced ceiling.
+pinned at 3.5 GB around the clock is still ~$1,490/month. The circuit breaker is
+what turns the rate limit into an enforced ceiling.
+
+That ceiling rose by ~73% when the R backend went from 2048 MB to 3538 MB to get
+a second vCPU for RTMA's Stan chains (#483). Nothing needed retuning: the breaker
+trips on sustained *throttling*, not on a dollar figure, so it enforces the same
+concurrency ceiling at any memory size, and the $10 budget notification simply
+arrives sooner. The number that rose is the worst case, where an attacker pins
+every slot for the full 600 s. Ordinary runs got *cheaper*, because RTMA now
+finishes in roughly half the time at 1.73x the memory rate.
 
 ## The cost circuit breaker
 

--- a/docs/PUBLIC_API_DESIGN.md
+++ b/docs/PUBLIC_API_DESIGN.md
@@ -232,12 +232,12 @@ plus `funnelPlot`/`funnelPlotWidth`/`funnelPlotHeight` only with
 
 Same envelope; parameters (all optional): `favorPositive` (default `true`),
 `alphaSelect` (`0.05`), `ciLevel` (`0.95`), `winsorize` (`0`), `seed` (`2025`).
-The internal `parallelize` / `timeoutSeconds` knobs are **not**
+The internal `cores` / `timeoutSeconds` knobs are **not**
 exposed. Response: `mu`, `muCI`, `tau`, `tauCI`, `seed`,
 `nonaffirmativeCount`, `nonaffirmativeProportion`, `warnings` (+ `zScorePlot*`
 with `?include=plot`).
 
-`seed` is exposed where `parallelize` / `timeoutSeconds` are not, because those
+`seed` is exposed where `cores` / `timeoutSeconds` are not, because those
 two only change how the fit is executed while the seed changes the numbers that
 come back: `phacking_meta()` takes no seed, so an unseeded fit returns a
 different credible interval on every call for identical input (#479). The
@@ -313,7 +313,7 @@ Layered, in order of load-bearing-ness:
 
 1. **Reserved concurrency = 10 on the R Lambda** (D2; Terraform). Hard ceiling
    on concurrent compute regardless of entry path. Worst-case sustained abuse
-   ≈ 10 × 2 GB × 100% duty cycle ≈ low tens of $/day, alarmed well before that.
+   ≈ 10 × 3.5 GB × 100% duty cycle ≈ $50/day, alarmed well before that.
    The orchestrator's `maximum_concurrency=5` fits inside it, so async can
    never starve sync entirely (and vice versa is acceptable: sync overflow
    `429`s, and the UI already has the async path).
@@ -428,9 +428,9 @@ until Phase 3.
   eventual fix.
 - **Concurrency cap = 10 is a guess.** It now also throttles UI sync traffic
   at the margin; previously it was deliberately unreserved. Watch the throttle
-  alarm; tune. Each unit of concurrency is worth roughly **$0.12/hour
-  (~$86/month)** of worst-case exposure at 2 GB, so the cap is effectively the
-  ceiling on an anonymous abuse bill: ~$29/day at 10, ~$58/day at 20. Note the
+  alarm; tune. Each unit of concurrency is worth roughly **$0.21/hour
+  (~$149/month)** of worst-case exposure at 3.5 GB, so the cap is effectively the
+  ceiling on an anonymous abuse bill: ~$50/day at 10, ~$100/day at 20. Note the
   cap is **global, not per-caller**: anonymous access means there is no
   per-user quota, and the edge rule limits request *rate*, not concurrency, so
   one heavy caller can occupy all of it.

--- a/terraform/stacks/prod-runtime/circuit_breaker.tf
+++ b/terraform/stacks/prod-runtime/circuit_breaker.tf
@@ -1,8 +1,8 @@
 # Cost circuit breaker (docs/COST_CONTROLS.md).
 #
 # The reserved-concurrency cap on the R backend bounds the *rate* of spend but
-# not the monthly total: 10 concurrent 2 GB executions pinned around the clock
-# is still ~$860/month. This is the free automatic backstop that enforces a
+# not the monthly total: 10 concurrent 3.5 GB executions pinned around the clock
+# is still ~$1,490/month. This is the free automatic backstop that enforces a
 # ceiling. When the backend throttles continuously for
 # var.cost_circuit_breaker_throttle_periods 5-minute periods (demand exceeding
 # the cap for ~30 minutes straight, a strong abuse signal with near-zero

--- a/terraform/stacks/prod-runtime/lambda.tf
+++ b/terraform/stacks/prod-runtime/lambda.tf
@@ -35,10 +35,11 @@ resource "aws_lambda_function" "r_backend" {
   package_type = "Image"
   image_uri    = "${data.aws_ecr_repository.lambda_r_backend.repository_url}:${var.image_tag}"
 
-  # To set environment variables, use the following:
-  # environment {
-  #   variables = {}
-  # }
+  environment {
+    variables = {
+      RTMA_SAMPLING_CORES = tostring(local.lambda_r_backend_vcpus)
+    }
+  }
 
   tags = {
     Project = var.project

--- a/terraform/stacks/prod-runtime/locals.tf
+++ b/terraform/stacks/prod-runtime/locals.tf
@@ -4,5 +4,12 @@ locals {
   lambda_r_backend_function_name = "${var.project}-${var.lambda_r_backend_function_base_name}"
 
   lambda_r_backend_log_group_name = data.aws_cloudwatch_log_group.lambda_r_backend_logs.name
+
+  # Lambda allocates ~1 vCPU per 1769 MB. RTMA forks its Stan chains, so the R
+  # process has to be told how many cores it actually got: detecting them from
+  # inside the sandbox reports the host, not the allocation. Deriving the count
+  # from memory_size here is what keeps the two from drifting apart when the
+  # memory size is next tuned (#483).
+  lambda_r_backend_vcpus = max(1, floor(var.lambda_r_backend_memory_size / 1769))
 }
 

--- a/terraform/stacks/prod-runtime/variables.tf
+++ b/terraform/stacks/prod-runtime/variables.tf
@@ -59,9 +59,16 @@ variable "lambda_r_backend_function_base_name" {
 variable "lambda_r_backend_memory_size" {
   type        = number
   description = "Memory size in MB for the Lambda R backend function"
-  # 2048 MB ~= 1.15 vCPU. RTMA (phacking) sampling is single-threaded and
-  # CPU-bound, so a faster single core matters more than extra cores.
-  default = 2048
+  # 3538 MB = 2 x 1769, so exactly 2 vCPUs. RTMA's Stan sampling is ~95% of its
+  # wall time and rstan forks its 4 chains across whatever mc.cores says, so a
+  # second core roughly halves it (#483). The old 2048 MB was ~1.15 vCPU, which
+  # cannot overlap chains at all whatever mc.cores is set to.
+  #
+  # This is not a straight cost increase: a run that takes half as long at 1.73x
+  # the memory rate is cheaper in GB-s than it was. Raising this further only
+  # helps in steps of 1769 MB, and locals.tf derives the core count from it, so
+  # a value between steps buys memory that RTMA cannot use.
+  default = 3538
 }
 
 variable "lambda_r_backend_timeout" {


### PR DESCRIPTION
Closes the remaining half of #483. The preload (`1d4f12f2`) and the plot gating
(`5c1fcf72`) already landed; this is the parallel-chain lever, which the issue
identified as by far the largest one and which #479 (`61e1c309`) unblocked.

## What was wrong

Two things had to change together, and either alone is a no-op.

**The R side asked for the wrong number of cores.** `parallelize = TRUE` makes
phacking run `options(mc.cores = parallel::detectCores())`, and `detectCores()`
reads the *host*, not the Lambda's allocation. The default was therefore
`FALSE`, with a comment recording that parallel chains showed "no speedup even
on 8 cores".

**The Lambda could not have run them anyway.** Lambda grants ~1 vCPU per
1769 MB, so 2048 MB is ~1.15 vCPU. rstan forks one worker per chain; with 1.15
vCPU they interleave rather than overlap, whatever `mc.cores` says.

## What changed

`rtma_model.R` takes the core count from `RTMA_SAMPLING_CORES` instead of
detecting it, sets `mc.cores` itself, and restores the previous value with
`on.exit` so one request cannot leave the option changed for the next one in a
warm container. `parallelize` is now hardcoded `FALSE`; the knob it replaced was
internal, and `/v1` builds an explicit parameter allowlist, so nothing public
changes shape.

Terraform derives the count from `memory_size / 1769` in `locals.tf` and passes
it in as an environment variable, and `memory_size` goes 2048 to 3538 MB (exactly
2 x 1769). Deriving it is the point: the memory size and the core count live in
different files and different images, and this is what stops them drifting apart
the next time either is tuned.

## Verification

**The numbers do not move.** This is the claim the whole change rests on, so it
is asserted as bit-identity rather than a tolerance. Across 1, 2 and 4 cores,
`identical()` holds on the reported statistics *and* on the raw unpermuted Stan
draws, over 12 fits (k=100 once per core count, k=200 three times per core
count). rstan draws its own seed from the global RNG, which `run_rtma_model()`
pins immediately before the fit, so each chain's stream is fixed by its chain id
alone and the split across workers cannot reach it.

That invariant now has a regression test: `rtma_seed_test.R` runs the same fit on
1 core and on 4 through the real endpoint and compares the full fingerprint. It
lives in the seed scenario because it is the same property, and it would fail if
the reported numbers ever started depending on the deployed memory size.

**The chains genuinely overlap.** Confirmed both by timing and directly: the
sampling process forks one child per core, visible in `ps` during a run.

**The timeout guard survives forking.** `setTimeLimit(elapsed=)` is set in the
parent, and it was not obvious it would still fire once the work moved into
`mclapply` children. Checked explicitly: a 2 s budget on a fit that needs far
longer still aborts at 2 s.

Also verified: the environment variable is read, a junk or empty value falls back
to serial, `cores = 0` is rejected, and `mc.cores` is restored afterwards. Full
e2e suite passes (15/15). `terraform fmt` clean. `lintr` reports 8 issues, all
pre-existing and none on a changed line.

## About the speedup numbers

Measured on a workstation, not on Lambda, so treat the ratios as evidence that
the mechanism works and the absolute times as meaningless. macOS forks for
`mclapply` exactly as Linux does, which is the part of the issue's argument that
needed testing.

| | serial | 2 cores | 4 cores |
|---|---|---|---|
| k=100 | 7.9 s | 3.3 s (2.4x) | 2.0 s (3.9x) |
| k=200, best of 3 | 10.1 s | 6.2 s (1.65x) | 3.8 s (2.7x) |

This host turned out to be a poor benchmark machine and I am reporting that
rather than the first numbers I got. An early k=500 pass produced 25.5 / 46.8 /
81.6 s, i.e. parallel looking *slower*, purely because background load climbed
through the run; a later repeat of the same serial config took 131 s against its
own 25.5 s. The table above is from interleaved rounds with the per-config
minimum, which is the closest available estimate of uncontended time. Contention
can only ever make the parallel case look worse, so the 1.65x is a floor, not a
point estimate. The bracket 1.65x to 2.4x is consistent with the issue's
predicted "sampling / ~2".

A real measurement belongs on the deployed image. Since results are bit-identical
the comparison there can also be exact rather than statistical.

## Cost: the worst case rises 73%, deliberately

Worth being explicit, since this repo has a `COST_CONTROLS.md` for a reason. At
3.5 GB, 10 concurrency slots pinned around the clock is ~$1,490/month rather than
~$860. Nothing needed retuning: the circuit breaker trips on sustained
*throttling*, not on a dollar figure, so it enforces the same ceiling at any
memory size, and the $10 budget notification just arrives sooner. The figure that
rose is the deliberate-abuse worst case, where every slot is held for the full
600 s.

Ordinary runs get *cheaper*. The run shortens by more than the memory rate rises,
so GB-s per run goes down. Documentation updated in `COST_CONTROLS.md`,
`PUBLIC_API_DESIGN.md`, `ASYNC_RUNS_DESIGN.md` and the `circuit_breaker.tf`
comment, all of which stated the old figures.

## One thing this exposed

The legacy `/run-rtma` route passes `parameters` to `run_rtma_model()`
unfiltered, and it is publicly reachable, so `cores` is caller-settable there.
rstan already forks only `min(chains, cores)` workers, so a large value cannot
fork-bomb, but the value is now clamped to the chain count so that guarantee does
not rest on an rstan implementation detail.

## Merge order

Independent of #514: no shared files except `PUBLIC_API_DESIGN.md`, where the two
sets of hunks are ~100 lines apart and merge cleanly. Either can land first.
Deploying this one needs a terraform apply for the memory change and a new image
for the R change; the R change alone is inert at 2048 MB, and the memory change
alone is inert without it, so applying them out of order is safe in either
direction, just not useful until both are in.
