### PR TITLE
feat: compare finished runs side by side

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "react-ui",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["run", "ui:dev"],
+      "port": 3000
+    }
+  ]
+}

--- a/apps/react-ui/client/src/CONST.ts
+++ b/apps/react-ui/client/src/CONST.ts
@@ -76,6 +76,11 @@ const CONST = {
   RUNS: {
     TTL_SECONDS: 48 * 60 * 60, // 48h pickup buffer
     TTL_MS: 48 * 60 * 60 * 1000,
+    // Side-by-side comparison bounds. Two is the minimum that compares
+    // anything; three is where the columns stop being readable, since each
+    // card carries the full result summary rather than a single number.
+    COMPARE_MIN: 2,
+    COMPARE_MAX: 3,
   },
 
   MODEL_TYPES: {

--- a/apps/react-ui/client/src/components/RTMAResultsSummary.tsx
+++ b/apps/react-ui/client/src/components/RTMAResultsSummary.tsx
@@ -13,6 +13,9 @@ import {
 type RTMAResultsSummaryProps = {
   results: RTMAResults;
   showTooltips?: boolean;
+  // See the same prop on ResultsSummary: the default two-column split keys off
+  // the viewport, so pass 1 when the component itself is rendered narrow.
+  columns?: 1 | 2;
 };
 
 const formatNumber = (value: number): string =>
@@ -34,6 +37,7 @@ type Metric = {
 export default function RTMAResultsSummary({
   results,
   showTooltips = false,
+  columns = 2,
 }: RTMAResultsSummaryProps) {
   // The backend echoes the level of the equal-tailed credible intervals; runs
   // stored before it did were always fitted at the UI's fixed 0.95.
@@ -144,7 +148,13 @@ export default function RTMAResultsSummary({
           />
         </div>
       ) : null}
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+      <div
+        className={
+          columns === 1
+            ? "grid grid-cols-1 gap-4"
+            : "grid grid-cols-1 md:grid-cols-2 gap-4"
+        }
+      >
         {metrics.map((metric) => {
           const content = (
             <div>

--- a/apps/react-ui/client/src/components/ResultsSummary.tsx
+++ b/apps/react-ui/client/src/components/ResultsSummary.tsx
@@ -31,6 +31,11 @@ type ResultsSummaryProps = {
   simpleMean?: number;
   showInterpretation?: boolean;
   showExtendedResults?: boolean;
+  // Number of columns to lay the values out in. The default two-column split
+  // uses `md:`, which keys off the viewport, so it still splits when the
+  // component itself is narrow: pass 1 when rendering inside a column that is
+  // narrower than the page (the compare grid).
+  columns?: 1 | 2;
 };
 
 export default function ResultsSummary({
@@ -46,7 +51,12 @@ export default function ResultsSummary({
   simpleMean,
   showInterpretation = true,
   showExtendedResults = false,
+  columns = 2,
 }: ResultsSummaryProps) {
+  const gridClass =
+    columns === 1
+      ? "grid grid-cols-1 gap-4"
+      : "grid grid-cols-1 md:grid-cols-2 gap-4";
   const formatIntervalString = (value: string): string => {
     const trimmed = value.trim();
 
@@ -238,11 +248,21 @@ export default function ResultsSummary({
 
   // Detailed variant for modal display
   if (layout === "vertical") {
+    if (columns === 1) {
+      return (
+        <div className="space-y-2 text-sm">
+          {visibleResults.map((item, index) =>
+            renderResultItem(item, `single-${index}`),
+          )}
+        </div>
+      );
+    }
+
     const { left, right } = splitIntoColumns(visibleResults, "vertical");
 
     return (
       <div className="space-y-2 text-sm">
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <div className={gridClass}>
           <div className="space-y-2">
             {left.map((item, index) => renderResultItem(item, `left-${index}`))}
           </div>
@@ -304,7 +324,7 @@ export default function ResultsSummary({
                 />
               )}
             </div>
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div className={gridClass}>
               <div className={"space-y-4"}>
                 {left.map((item, index) => (
                   <div key={`${sectionKey}-left-${index}`}>

--- a/apps/react-ui/client/src/hooks/useReadySearchParams.ts
+++ b/apps/react-ui/client/src/hooks/useReadySearchParams.ts
@@ -1,0 +1,53 @@
+import { useEffect, useState } from "react";
+import { useSearchParams } from "next/navigation";
+
+type ReadySearchParams = {
+  params: URLSearchParams;
+  // False on the render that happens before the query string is known. Render a
+  // placeholder while it is false rather than an empty state: "no ids were
+  // given" and "the ids are not readable yet" are indistinguishable otherwise,
+  // and only one of them should tell the user to go back and pick again.
+  isReady: boolean;
+};
+
+/**
+ * Read the URL query, distinguishing "empty" from "not known yet".
+ *
+ * `useSearchParams()` is an App Router hook. In the Pages Router it is backed by
+ * the pages router, which does not know the query during the pre-hydration
+ * render of a statically optimized page, so on a direct hit or a refresh it
+ * yields an empty set for one render before filling in.
+ *
+ * The page recovers on its own, so this is not about correctness of the final
+ * render. It is about what gets painted in the meantime: without the flag, a
+ * hard load of /compare?jobIds=... paints "pick at least 2 runs" first, which
+ * is a claim about the user's selection rather than about loading, and it is
+ * wrong. `window.location.search` is authoritative as soon as the browser has
+ * the URL, so it is read once on mount to close the gap.
+ *
+ * @returns The query parameters, and whether they can be trusted yet
+ */
+export function useReadySearchParams(): ReadySearchParams {
+  const navigationParams = useSearchParams();
+  const [locationParams, setLocationParams] = useState<URLSearchParams | null>(
+    null,
+  );
+
+  useEffect(() => {
+    setLocationParams(new URLSearchParams(window.location.search));
+  }, []);
+
+  // Prefer whichever source actually has something. The router's copy wins when
+  // it is populated, so a client-side navigation that changes the query is
+  // picked up; the mount-time snapshot cannot be.
+  const hasNavigationParams =
+    navigationParams != null && Array.from(navigationParams.keys()).length > 0;
+
+  if (hasNavigationParams) {
+    return { params: navigationParams, isReady: true };
+  }
+  if (locationParams) {
+    return { params: locationParams, isReady: true };
+  }
+  return { params: new URLSearchParams(), isReady: false };
+}

--- a/apps/react-ui/client/src/hooks/useRunResults.ts
+++ b/apps/react-ui/client/src/hooks/useRunResults.ts
@@ -1,0 +1,95 @@
+import { useEffect, useState } from "react";
+import type { ModelResults, RTMAResults } from "@src/types/api";
+import { modelService } from "@api/services/modelService";
+import { getResult, putResult } from "@src/utils/runsCache";
+
+export type RunResultState =
+  | { status: "loading" }
+  | { status: "ready"; result: ModelResults | RTMAResults }
+  | { status: "unavailable"; reason: string };
+
+export type RunResultsMap = Record<string, RunResultState>;
+
+// Why this is a fetch and not a poll, unlike useRunStatus: comparison only ever
+// looks at runs that already finished, so there is nothing to wait for. A run
+// whose result is not there now will not acquire one by asking again.
+const NO_RESULT_REASON = "This run has no stored result.";
+const EXPIRED_REASON =
+  "This run is past the 48-hour server window and was not cached on this device.";
+
+/**
+ * Load the results of several runs at once, for side-by-side comparison (#457).
+ *
+ * Each job is resolved independently and in parallel: the durable IndexedDB
+ * cache first, then `GET /api/runs/{jobId}`. The cache is checked first because
+ * results are immutable once produced, so a cached copy is always as good as
+ * the server's and outlives the 48-hour server TTL. The batch `GET /api/runs`
+ * route is deliberately not used here; it returns status only, no result
+ * payload.
+ *
+ * One job failing never blocks the others: the comparison renders whatever
+ * resolved, and each missing card says why. Results that came from the server
+ * are written back to the cache, so re-opening the same comparison is offline.
+ */
+export function useRunResults(jobIds: string[]): RunResultsMap {
+  const [resultsMap, setResultsMap] = useState<RunResultsMap>({});
+  // jobIds is a fresh array on every render (parsed from the query string), so
+  // depend on its contents rather than its identity to avoid refetching in a
+  // loop.
+  const jobIdsKey = jobIds.join(",");
+
+  useEffect(() => {
+    const ids = jobIdsKey ? jobIdsKey.split(",") : [];
+    if (ids.length === 0) {
+      setResultsMap({});
+      return undefined;
+    }
+
+    let cancelled = false;
+    setResultsMap(
+      Object.fromEntries(ids.map((id) => [id, { status: "loading" }])),
+    );
+
+    const resolveOne = async (jobId: string): Promise<RunResultState> => {
+      const cached = await getResult(jobId);
+      if (cached) {
+        return { status: "ready", result: cached };
+      }
+
+      try {
+        const run = await modelService.getRun(jobId);
+        if (!run.result) {
+          return {
+            status: "unavailable",
+            reason:
+              run.status === "expired" ? EXPIRED_REASON : NO_RESULT_REASON,
+          };
+        }
+        const parsed = JSON.parse(run.result) as ModelResults | RTMAResults;
+        void putResult(jobId, parsed);
+        return { status: "ready", result: parsed };
+      } catch {
+        // A 404 here is the normal shape of an expired run: the record is gone
+        // once the server TTL passes, and the cache above already had its say.
+        return { status: "unavailable", reason: EXPIRED_REASON };
+      }
+    };
+
+    void Promise.all(
+      ids.map(async (jobId) => {
+        const state = await resolveOne(jobId);
+        if (!cancelled) {
+          // Commit each result as it lands rather than awaiting the whole set,
+          // so one slow job does not hold up the cards that are already known.
+          setResultsMap((previous) => ({ ...previous, [jobId]: state }));
+        }
+      }),
+    );
+
+    return () => {
+      cancelled = true;
+    };
+  }, [jobIdsKey]);
+
+  return resultsMap;
+}

--- a/apps/react-ui/client/src/pages/compare/index.tsx
+++ b/apps/react-ui/client/src/pages/compare/index.tsx
@@ -1,0 +1,204 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import Head from "next/head";
+import SectionHeading from "@src/components/SectionHeading";
+import { GoBackButton } from "@src/components/Buttons";
+import ActionButton from "@src/components/Buttons/ActionButton";
+import ResultsSummary from "@src/components/ResultsSummary";
+import RTMAResultsSummary from "@src/components/RTMAResultsSummary";
+import Alert from "@src/components/Alert";
+import CONST from "@src/CONST";
+import { useRunsStore, type RunEntry } from "@src/store/runsStore";
+import { useRunResults, type RunResultState } from "@src/hooks/useRunResults";
+import { useReadySearchParams } from "@src/hooks/useReadySearchParams";
+import { parseRunParameters } from "@src/utils/runParameterUtils";
+import { isRtmaResults } from "@src/utils/resultTypeUtils";
+
+// Class names are written out in full rather than composed as `grid-cols-${n}`:
+// Tailwind scans source text for literal class names, so an interpolated one is
+// never emitted into the stylesheet.
+const gridClassFor = (count: number): string => {
+  if (count >= 3) {
+    return "grid grid-cols-1 gap-4 lg:grid-cols-2 xl:grid-cols-3";
+  }
+  if (count === 2) {
+    return "grid grid-cols-1 gap-4 lg:grid-cols-2";
+  }
+  return "grid grid-cols-1 gap-4";
+};
+
+const parseJobIds = (raw: string | null): string[] => {
+  if (!raw) {
+    return [];
+  }
+  // De-duplicated: the same run twice is two identical columns, which compares
+  // nothing and would collide on the React key.
+  return Array.from(
+    new Set(
+      raw
+        .split(",")
+        .map((id) => id.trim())
+        .filter(Boolean),
+    ),
+  ).slice(0, CONST.RUNS.COMPARE_MAX);
+};
+
+type RunCardProps = {
+  jobId: string;
+  entry: RunEntry | undefined;
+  state: RunResultState | undefined;
+};
+
+function RunCard({ jobId, entry, state }: RunCardProps) {
+  const router = useRouter();
+  const parameters = parseRunParameters(entry?.parameters);
+
+  return (
+    <div className="surface-elevated flex flex-col rounded-lg border border-primary p-4">
+      <div className="mb-3 min-w-0 border-b border-primary pb-3">
+        <p
+          className="truncate font-medium"
+          title={entry?.filename ?? "Unknown dataset"}
+        >
+          {entry?.filename ?? "Unknown dataset"}
+        </p>
+        <div className="mt-1 flex flex-wrap items-center gap-2 text-sm text-gray-500 dark:text-gray-400">
+          <span className="inline-flex flex-shrink-0 items-center rounded bg-gray-100 px-1.5 py-0.5 text-xs font-medium text-gray-600 dark:bg-gray-800 dark:text-gray-300">
+            {entry?.modelType ?? parameters.modelType}
+          </span>
+          {entry ? (
+            <span>
+              {new Date(entry.submittedAt).toLocaleString()}
+              {entry.rowCount > 0 ? ` · ${entry.rowCount} rows` : ""}
+            </span>
+          ) : null}
+        </div>
+      </div>
+
+      {state?.status === "ready" ? (
+        isRtmaResults(state.result) ? (
+          // RTMAResultsSummary brings its own titled panel; the MAIVE summary
+          // does not, so it gets a matching one here. Without it the cards sit
+          // side by side with different chrome, which reads as a rendering bug
+          // rather than as two different model types.
+          <RTMAResultsSummary results={state.result} columns={1} />
+        ) : (
+          <div className="rounded-lg bg-gray-50 p-4 dark:bg-gray-700">
+            <h2 className="mb-4 text-xl font-semibold">
+              {`${parameters.modelType} Results`}
+            </h2>
+            <ResultsSummary
+              results={state.result}
+              parameters={parameters}
+              variant="simple"
+              layout="vertical"
+              columns={1}
+              showInterpretation={false}
+            />
+          </div>
+        )
+      ) : state?.status === "unavailable" ? (
+        <Alert message={state.reason} type={CONST.ALERT_TYPES.WARNING} />
+      ) : (
+        <p className="text-sm text-gray-500 dark:text-gray-400">
+          Loading results...
+        </p>
+      )}
+
+      <div className="mt-4 pt-2">
+        <ActionButton
+          variant="secondary"
+          size="sm"
+          onClick={() => {
+            const params = new URLSearchParams({ jobId });
+            if (entry?.dataId) {
+              params.set("dataId", entry.dataId);
+            }
+            if (entry?.parameters) {
+              params.set("parameters", entry.parameters);
+            }
+            router.push(`/results?${params.toString()}`);
+          }}
+        >
+          Open full results
+        </ActionButton>
+      </div>
+    </div>
+  );
+}
+
+export default function ComparePage() {
+  const { params, isReady } = useReadySearchParams();
+  const router = useRouter();
+  const jobIds = parseJobIds(params.get("jobIds"));
+  const runsList = useRunsStore((state) => state.runsList);
+  const resultsMap = useRunResults(jobIds);
+
+  const entryFor = (jobId: string): RunEntry | undefined =>
+    runsList.find((run) => run.jobId === jobId);
+
+  // Comparing runs of different model families is legitimate (that is often the
+  // point), but the cards then hold different metrics and cannot be read across,
+  // so say so rather than letting it look like a rendering fault.
+  const modelTypes = new Set(
+    jobIds.map((jobId) => entryFor(jobId)?.modelType).filter(Boolean),
+  );
+  const hasMixedModels = modelTypes.size > 1;
+
+  return (
+    <>
+      <Head>
+        <title>{`${CONST.APP_DISPLAY_NAME} - Compare Runs`}</title>
+      </Head>
+      <main className="content-page-container">
+        <div className="mx-auto w-full max-w-7xl">
+          <div className="mb-4 flex items-center justify-between">
+            <SectionHeading level="h1" text="Compare Runs" />
+            <ActionButton
+              variant="secondary"
+              size="sm"
+              onClick={() => router.push("/runs")}
+            >
+              Back to My Runs
+            </ActionButton>
+          </div>
+
+          {!isReady ? (
+            <p className="text-sm text-gray-500 dark:text-gray-400">
+              Loading...
+            </p>
+          ) : jobIds.length < CONST.RUNS.COMPARE_MIN ? (
+            <div className="card text-center">
+              <p className="mb-4 text-gray-600 dark:text-gray-300">
+                {`Pick at least ${CONST.RUNS.COMPARE_MIN} finished runs in My Runs to compare them side by side.`}
+              </p>
+              <GoBackButton href="/runs" text="My Runs" variant="simple" />
+            </div>
+          ) : (
+            <>
+              {hasMixedModels && (
+                <div className="mb-4">
+                  <Alert
+                    message="These runs use different model types, so their result cards report different quantities and do not line up row by row."
+                    type={CONST.ALERT_TYPES.INFO}
+                  />
+                </div>
+              )}
+              <div className={gridClassFor(jobIds.length)}>
+                {jobIds.map((jobId) => (
+                  <RunCard
+                    key={jobId}
+                    jobId={jobId}
+                    entry={entryFor(jobId)}
+                    state={resultsMap[jobId]}
+                  />
+                ))}
+              </div>
+            </>
+          )}
+        </div>
+      </main>
+    </>
+  );
+}

--- a/apps/react-ui/client/src/pages/results/index.tsx
+++ b/apps/react-ui/client/src/pages/results/index.tsx
@@ -22,7 +22,7 @@ import {
   deriveDataInfoFromUploadedData,
   generateDataInfo,
 } from "@utils/dataInfoUtils";
-import type { ModelParameters, ModelResults } from "@src/types";
+import type { ModelResults } from "@src/types";
 import type { RTMAResults } from "@src/types/api";
 import type { VersionInfo } from "@src/types/reproducibility";
 import CitationBox from "@src/components/CitationBox";
@@ -40,6 +40,7 @@ import {
   formatFilterSummary,
   normalizeFilterState,
 } from "@src/utils/subsampleFilterUtils";
+import { parseRunParameters } from "@src/utils/runParameterUtils";
 import {
   generateReproducibilityPackage,
   getReproducibilityPackageFilename,
@@ -98,39 +99,7 @@ export default function ResultsPage() {
     : urlRunDuration;
   const runTimestamp = jobId ? runStatus.runTimestamp : urlRunTimestamp;
 
-  let parsedParametersJson: Partial<ModelParameters> = {};
-  if (parameters) {
-    try {
-      const parsed = JSON.parse(parameters) as unknown;
-      if (parsed && typeof parsed === "object") {
-        parsedParametersJson = parsed as Partial<ModelParameters>;
-      }
-    } catch (error) {
-      console.error("Failed to parse model parameters from URL:", error);
-    }
-  }
-
-  const parsedParameters: ModelParameters = {
-    ...CONFIG.DEFAULT_MODEL_PARAMETERS,
-    ...parsedParametersJson,
-  };
-
-  if (
-    parsedParameters.shouldUseInstrumenting === false &&
-    parsedParameters.modelType !== CONST.MODEL_TYPES.WAIVE &&
-    parsedParameters.modelType !== CONST.MODEL_TYPES.RTMA
-  ) {
-    parsedParameters.modelType = CONST.MODEL_TYPES.WLS;
-  }
-
-  if (
-    parsedParameters.modelType === CONST.MODEL_TYPES.WLS ||
-    parsedParameters.modelType === CONST.MODEL_TYPES.RTMA
-  ) {
-    parsedParameters.shouldUseInstrumenting = false;
-  } else {
-    parsedParameters.shouldUseInstrumenting = true;
-  }
+  const parsedParameters = parseRunParameters(parameters);
 
   const shouldUseInstrumenting =
     parsedParameters?.shouldUseInstrumenting ?? true;

--- a/apps/react-ui/client/src/pages/runs/index.tsx
+++ b/apps/react-ui/client/src/pages/runs/index.tsx
@@ -18,6 +18,14 @@ const PENDING_STATUSES: RunStatus[] = ["queued", "running"];
 const isPending = (status: RunStatus): boolean =>
   PENDING_STATUSES.includes(status);
 
+// Statuses that can produce a result to compare. "expired" is included on
+// purpose: the server record is gone, but the durable IndexedDB cache may still
+// hold the result, and results are immutable so a cached one is never stale.
+// The compare page says so per card when there turns out to be nothing cached.
+const COMPARABLE_STATUSES: RunStatus[] = ["succeeded", "expired"];
+const isComparable = (status: RunStatus): boolean =>
+  COMPARABLE_STATUSES.includes(status);
+
 const statusLabel = (status: RunStatus): string => {
   switch (status) {
     case "queued":
@@ -58,6 +66,25 @@ export default function RunsPage() {
   const removeRun = useRunsStore((state) => state.removeRun);
   const clearRuns = useRunsStore((state) => state.clearRuns);
   const [isClearConfirmOpen, setIsClearConfirmOpen] = useState(false);
+  const [selectedJobIds, setSelectedJobIds] = useState<string[]>([]);
+
+  // Insertion order is preserved so the compare columns appear in the order the
+  // user ticked them, which is the only ordering they control.
+  const toggleSelected = (jobId: string) => {
+    setSelectedJobIds((previous) =>
+      previous.includes(jobId)
+        ? previous.filter((id) => id !== jobId)
+        : [...previous, jobId],
+    );
+  };
+
+  const selectionIsFull = selectedJobIds.length >= CONST.RUNS.COMPARE_MAX;
+  const canCompare = selectedJobIds.length >= CONST.RUNS.COMPARE_MIN;
+  const anyComparable = runsList.some((run) => isComparable(run.status));
+
+  const compareSelected = () => {
+    router.push(`/compare?jobIds=${selectedJobIds.join(",")}`);
+  };
 
   const openRun = (
     jobId: string,
@@ -100,6 +127,35 @@ export default function RunsPage() {
             </p>
           )}
 
+          {anyComparable && (
+            <div className="mb-4 flex flex-wrap items-center justify-between gap-2">
+              <p className="text-sm text-gray-500 dark:text-gray-400">
+                {selectedJobIds.length === 0
+                  ? `Select ${CONST.RUNS.COMPARE_MIN} or ${CONST.RUNS.COMPARE_MAX} finished runs to compare them side by side.`
+                  : `${selectedJobIds.length} of ${CONST.RUNS.COMPARE_MAX} selected.`}
+              </p>
+              {selectedJobIds.length > 0 && (
+                <div className="flex items-center gap-2">
+                  <button
+                    type="button"
+                    className="text-sm text-gray-400 transition-colors hover:text-gray-600 dark:hover:text-gray-200"
+                    onClick={() => setSelectedJobIds([])}
+                  >
+                    Clear selection
+                  </button>
+                  <ActionButton
+                    variant="primary"
+                    size="sm"
+                    disabled={!canCompare}
+                    onClick={compareSelected}
+                  >
+                    Compare selected
+                  </ActionButton>
+                </div>
+              )}
+            </div>
+          )}
+
           {runsList.length === 0 ? (
             <div className="card text-center">
               <p className="mb-4 text-gray-600 dark:text-gray-300">
@@ -119,18 +175,45 @@ export default function RunsPage() {
                   key={run.jobId}
                   className="surface-elevated flex items-center justify-between gap-4 rounded-lg border border-primary px-4 py-3"
                 >
-                  <div className="min-w-0">
-                    <p className="truncate font-medium" title={run.filename}>
-                      {run.filename}
-                    </p>
-                    <div className="mt-0.5 flex min-w-0 items-center gap-2 text-sm text-gray-500 dark:text-gray-400">
-                      <span className="inline-flex flex-shrink-0 items-center rounded bg-gray-100 px-1.5 py-0.5 text-xs font-medium text-gray-600 dark:bg-gray-800 dark:text-gray-300">
-                        {run.modelType}
-                      </span>
-                      <span className="truncate">
-                        {new Date(run.submittedAt).toLocaleString()}
-                        {run.rowCount > 0 ? ` · ${run.rowCount} rows` : ""}
-                      </span>
+                  {/* Tighter gap than the row's other groups: this row already
+                      truncates filenames at phone widths, and the checkbox
+                      column costs it another 28px. */}
+                  <div className="flex min-w-0 items-center gap-2">
+                    {/* Space is reserved even for rows that cannot be selected,
+                        so the filenames stay on one left edge down the list. */}
+                    {!isComparable(run.status) && anyComparable && (
+                      <span className="h-4 w-4 flex-shrink-0" aria-hidden />
+                    )}
+                    {isComparable(run.status) && (
+                      <input
+                        type="checkbox"
+                        className="h-4 w-4 flex-shrink-0 cursor-pointer accent-blue-600 disabled:cursor-not-allowed disabled:opacity-40"
+                        checked={selectedJobIds.includes(run.jobId)}
+                        disabled={
+                          selectionIsFull && !selectedJobIds.includes(run.jobId)
+                        }
+                        aria-label={`Select ${run.filename} for comparison`}
+                        title={
+                          selectionIsFull && !selectedJobIds.includes(run.jobId)
+                            ? `You can compare at most ${CONST.RUNS.COMPARE_MAX} runs at a time.`
+                            : undefined
+                        }
+                        onChange={() => toggleSelected(run.jobId)}
+                      />
+                    )}
+                    <div className="min-w-0">
+                      <p className="truncate font-medium" title={run.filename}>
+                        {run.filename}
+                      </p>
+                      <div className="mt-0.5 flex min-w-0 items-center gap-2 text-sm text-gray-500 dark:text-gray-400">
+                        <span className="inline-flex flex-shrink-0 items-center rounded bg-gray-100 px-1.5 py-0.5 text-xs font-medium text-gray-600 dark:bg-gray-800 dark:text-gray-300">
+                          {run.modelType}
+                        </span>
+                        <span className="truncate">
+                          {new Date(run.submittedAt).toLocaleString()}
+                          {run.rowCount > 0 ? ` · ${run.rowCount} rows` : ""}
+                        </span>
+                      </div>
                     </div>
                   </div>
                   <div className="flex items-center gap-3">

--- a/apps/react-ui/client/src/tests/ComparePage.test.tsx
+++ b/apps/react-ui/client/src/tests/ComparePage.test.tsx
@@ -1,0 +1,197 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import ComparePage from "@src/pages/compare";
+import { useRunsStore } from "@src/store/runsStore";
+import type { RTMAResults } from "@src/types/api";
+
+const push = vi.fn();
+let searchParams = new URLSearchParams();
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push }),
+  useSearchParams: () => searchParams,
+}));
+
+// The empty-state GoBackButton uses the Pages-Router useRouter.
+vi.mock("next/router", () => ({
+  useRouter: () => ({ push: vi.fn() }),
+}));
+
+const getResult = vi.fn();
+const putResult = vi.fn();
+vi.mock("@src/utils/runsCache", () => ({
+  getResult: (jobId: string): unknown => getResult(jobId),
+  putResult: (jobId: string, result: unknown): unknown =>
+    putResult(jobId, result),
+  deleteResult: vi.fn(),
+  clearAllResults: vi.fn(),
+}));
+
+const getRun = vi.fn();
+vi.mock("@api/services/modelService", () => ({
+  modelService: {
+    getRun: (jobId: string): unknown => getRun(jobId),
+  },
+}));
+
+const rtmaResult = (mu: number): RTMAResults => ({
+  mu,
+  muCI: [mu - 0.5, mu + 0.5],
+  tau: 1.2,
+  tauCI: [0.9, 1.6],
+  zScorePlot: "data:image/png;base64,xxx",
+  zScorePlotWidth: 600,
+  zScorePlotHeight: 400,
+  nonaffirmativeCount: 67,
+  nonaffirmativeProportion: 0.905,
+  warnings: [],
+});
+
+const addRun = (jobId: string, filename: string, modelType = "RTMA") => {
+  useRunsStore.getState().addRun({
+    jobId,
+    modelType,
+    dataId: "d1",
+    filename,
+    rowCount: 120,
+    parameters: JSON.stringify({ modelType }),
+    submittedAt: Date.now(),
+    status: "succeeded",
+  });
+};
+
+describe("ComparePage", () => {
+  beforeEach(() => {
+    useRunsStore.getState().clearRuns();
+    searchParams = new URLSearchParams();
+    push.mockReset();
+    getResult.mockReset();
+    putResult.mockReset();
+    getRun.mockReset();
+  });
+
+  it("prompts for a selection when fewer than two runs are requested", () => {
+    searchParams = new URLSearchParams({ jobIds: "job-1" });
+    getResult.mockResolvedValue(undefined);
+
+    render(<ComparePage />);
+
+    expect(screen.getByText(/pick at least 2 finished runs/i)).toBeVisible();
+  });
+
+  it("renders one card per run, reading results from the local cache", async () => {
+    addRun("job-1", "study-a.csv");
+    addRun("job-2", "study-b.csv");
+    searchParams = new URLSearchParams({ jobIds: "job-1,job-2" });
+    getResult.mockImplementation((jobId: string) =>
+      Promise.resolve(rtmaResult(jobId === "job-1" ? 5 : 9)),
+    );
+
+    render(<ComparePage />);
+
+    expect(await screen.findByText("study-a.csv")).toBeVisible();
+    expect(screen.getByText("study-b.csv")).toBeVisible();
+    // The two runs' distinct effect estimates both render, which is the whole
+    // point of the page.
+    await waitFor(() => {
+      expect(screen.getByText(/5\.000 \[4\.500, 5\.500\]/)).toBeVisible();
+      expect(screen.getByText(/9\.000 \[8\.500, 9\.500\]/)).toBeVisible();
+    });
+    // A cache hit must not go to the network.
+    expect(getRun).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the server on a cache miss and caches what it gets back", async () => {
+    addRun("job-1", "study-a.csv");
+    addRun("job-2", "study-b.csv");
+    searchParams = new URLSearchParams({ jobIds: "job-1,job-2" });
+    getResult.mockResolvedValue(undefined);
+    getRun.mockImplementation((jobId: string) =>
+      Promise.resolve({
+        status: "succeeded",
+        result: JSON.stringify(rtmaResult(jobId === "job-1" ? 5 : 9)),
+      }),
+    );
+
+    render(<ComparePage />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/5\.000 \[4\.500, 5\.500\]/)).toBeVisible();
+    });
+    expect(getRun).toHaveBeenCalledWith("job-1");
+    expect(putResult).toHaveBeenCalledWith("job-1", expect.anything());
+  });
+
+  it("explains a missing result per card instead of failing the whole page", async () => {
+    addRun("job-1", "study-a.csv");
+    addRun("job-2", "study-b.csv");
+    searchParams = new URLSearchParams({ jobIds: "job-1,job-2" });
+    getResult.mockResolvedValue(undefined);
+    getRun.mockImplementation((jobId: string) =>
+      jobId === "job-1"
+        ? Promise.resolve({
+            status: "succeeded",
+            result: JSON.stringify(rtmaResult(5)),
+          })
+        : Promise.reject(new Error("gone")),
+    );
+
+    render(<ComparePage />);
+
+    // The healthy run still renders alongside the explanation for the other.
+    await waitFor(() => {
+      expect(screen.getByText(/5\.000 \[4\.500, 5\.500\]/)).toBeVisible();
+    });
+    expect(await screen.findByText(/48-hour server window/i)).toBeVisible();
+  });
+
+  it("warns when the selected runs are of different model types", async () => {
+    addRun("job-1", "study-a.csv", "RTMA");
+    addRun("job-2", "study-b.csv", "MAIVE");
+    searchParams = new URLSearchParams({ jobIds: "job-1,job-2" });
+    getResult.mockResolvedValue(undefined);
+    getRun.mockResolvedValue({ status: "expired", result: null });
+
+    render(<ComparePage />);
+
+    expect(await screen.findByText(/different model types/i)).toBeVisible();
+  });
+
+  it("reads the ids from the URL when the router has not supplied them yet", async () => {
+    // The pre-hydration render of a hard load: useSearchParams() is empty even
+    // though the browser has the query. Falling back to window.location is what
+    // stops the page painting "pick at least 2 runs" at someone who picked two.
+    addRun("job-1", "study-a.csv");
+    addRun("job-2", "study-b.csv");
+    searchParams = new URLSearchParams();
+    window.history.replaceState({}, "", "/compare?jobIds=job-1,job-2");
+    getResult.mockResolvedValue(rtmaResult(5));
+
+    render(<ComparePage />);
+
+    expect(await screen.findByText("study-a.csv")).toBeVisible();
+    expect(screen.getByText("study-b.csv")).toBeVisible();
+    expect(
+      screen.queryByText(/pick at least 2 finished runs/i),
+    ).not.toBeInTheDocument();
+
+    window.history.replaceState({}, "", "/");
+  });
+
+  it("ignores duplicate ids and caps the comparison at three runs", async () => {
+    ["job-1", "job-2", "job-3", "job-4"].forEach((id, index) =>
+      addRun(id, `study-${index}.csv`),
+    );
+    searchParams = new URLSearchParams({
+      jobIds: "job-1,job-1,job-2,job-3,job-4",
+    });
+    getResult.mockResolvedValue(rtmaResult(5));
+
+    render(<ComparePage />);
+
+    await screen.findByText("study-0.csv");
+    expect(screen.getAllByText("study-0.csv")).toHaveLength(1);
+    // job-4 is past the cap, so its card is never rendered.
+    expect(screen.queryByText("study-3.csv")).not.toBeInTheDocument();
+  });
+});

--- a/apps/react-ui/client/src/tests/RunsPage.test.tsx
+++ b/apps/react-ui/client/src/tests/RunsPage.test.tsx
@@ -2,6 +2,13 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 import { render, screen, fireEvent, within } from "@testing-library/react";
 import RunsPage from "@src/pages/runs";
 import { useRunsStore } from "@src/store/runsStore";
+import type { RunStatus } from "@src/types/api";
+
+const push = vi.fn();
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push }),
+  useSearchParams: () => new URLSearchParams(),
+}));
 
 // The empty-state GoBackButton uses the Pages-Router useRouter (next/router),
 // which the global setup (next/navigation only) does not cover.
@@ -9,7 +16,11 @@ vi.mock("next/router", () => ({
   useRouter: () => ({ push: vi.fn() }),
 }));
 
-const addRun = (jobId: string, filename: string) => {
+const addRun = (
+  jobId: string,
+  filename: string,
+  status: RunStatus = "queued",
+) => {
   useRunsStore.getState().addRun({
     jobId,
     modelType: "MAIVE",
@@ -18,13 +29,21 @@ const addRun = (jobId: string, filename: string) => {
     rowCount: 120,
     parameters: "{}",
     submittedAt: Date.now(),
-    status: "queued",
+    status,
   });
 };
+
+const selectRun = (filename: string) =>
+  fireEvent.click(
+    screen.getByRole("checkbox", {
+      name: `Select ${filename} for comparison`,
+    }),
+  );
 
 describe("RunsPage", () => {
   beforeEach(() => {
     useRunsStore.getState().clearRuns();
+    push.mockReset();
   });
 
   it("shows the dataset filename and the device-local note", () => {
@@ -57,5 +76,88 @@ describe("RunsPage", () => {
     // Confirming inside the dialog clears the list.
     fireEvent.click(within(dialog).getByRole("button", { name: "Clear all" }));
     expect(useRunsStore.getState().runsList).toHaveLength(0);
+  });
+
+  describe("comparison selection", () => {
+    it("offers a checkbox only for runs that can have a result", () => {
+      addRun("job-1", "done.csv", "succeeded");
+      addRun("job-2", "waiting.csv", "queued");
+      addRun("job-3", "broken.csv", "failed");
+      // Expired runs stay selectable: the result may still be cached locally.
+      addRun("job-4", "old.csv", "expired");
+      render(<RunsPage />);
+
+      expect(screen.getAllByRole("checkbox")).toHaveLength(2);
+      expect(
+        screen.getByRole("checkbox", { name: /Select done\.csv/ }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("checkbox", { name: /Select old\.csv/ }),
+      ).toBeInTheDocument();
+    });
+
+    it("hides the selection prompt when nothing is comparable", () => {
+      addRun("job-1", "waiting.csv", "queued");
+      render(<RunsPage />);
+
+      expect(screen.queryByRole("checkbox")).not.toBeInTheDocument();
+      expect(screen.queryByText(/side by side/i)).not.toBeInTheDocument();
+    });
+
+    it("needs two runs before comparing is allowed", () => {
+      addRun("job-1", "a.csv", "succeeded");
+      addRun("job-2", "b.csv", "succeeded");
+      render(<RunsPage />);
+
+      selectRun("a.csv");
+      const compare = screen.getByRole("button", { name: "Compare selected" });
+      expect(compare).toBeDisabled();
+
+      selectRun("b.csv");
+      expect(compare).toBeEnabled();
+    });
+
+    it("navigates to the compare page with the selected ids in tick order", () => {
+      addRun("job-1", "a.csv", "succeeded");
+      addRun("job-2", "b.csv", "succeeded");
+      render(<RunsPage />);
+
+      selectRun("b.csv");
+      selectRun("a.csv");
+      fireEvent.click(screen.getByRole("button", { name: "Compare selected" }));
+
+      expect(push).toHaveBeenCalledWith("/compare?jobIds=job-2,job-1");
+    });
+
+    it("stops the selection at three runs", () => {
+      ["a", "b", "c", "d"].forEach((name) =>
+        addRun(`job-${name}`, `${name}.csv`, "succeeded"),
+      );
+      render(<RunsPage />);
+
+      selectRun("a.csv");
+      selectRun("b.csv");
+      selectRun("c.csv");
+
+      const fourth = screen.getByRole("checkbox", { name: /Select d\.csv/ });
+      expect(fourth).toBeDisabled();
+      // Already-selected boxes stay clickable, so a choice can be swapped out.
+      expect(
+        screen.getByRole("checkbox", { name: /Select a\.csv/ }),
+      ).toBeEnabled();
+    });
+
+    it("clears the selection on request", () => {
+      addRun("job-1", "a.csv", "succeeded");
+      render(<RunsPage />);
+
+      selectRun("a.csv");
+      expect(screen.getByText(/1 of 3 selected/)).toBeInTheDocument();
+
+      fireEvent.click(screen.getByRole("button", { name: "Clear selection" }));
+      expect(
+        screen.getByRole("checkbox", { name: /Select a\.csv/ }),
+      ).not.toBeChecked();
+    });
   });
 });

--- a/apps/react-ui/client/src/tests/runParameterUtils.test.ts
+++ b/apps/react-ui/client/src/tests/runParameterUtils.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { parseRunParameters } from "@src/utils/runParameterUtils";
+import { isRtmaResults } from "@src/utils/resultTypeUtils";
+import type { ModelResults, RTMAResults } from "@src/types/api";
+import CONFIG from "@src/CONFIG";
+
+describe("parseRunParameters", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("falls back to the defaults when there is nothing stored", () => {
+    const parsed = parseRunParameters(null);
+    expect(parsed.modelType).toBe(CONFIG.DEFAULT_MODEL_PARAMETERS.modelType);
+    // Asserted as a literal rather than recomputed from the default, so the
+    // test cannot agree with a broken derivation by making the same mistake.
+    expect(parsed.shouldUseInstrumenting).toBe(true);
+  });
+
+  it("keeps stored values that are not derived", () => {
+    const parsed = parseRunParameters(
+      JSON.stringify({ modelType: "MAIVE", winsorize: 2 }),
+    );
+    expect(parsed.modelType).toBe("MAIVE");
+    expect(parsed.winsorize).toBe(2);
+  });
+
+  it("reads a non-instrumented run back as WLS", () => {
+    // This is how a WLS run is recorded: the model type in the stored object is
+    // whatever was selected before instrumenting was switched off.
+    const parsed = parseRunParameters(
+      JSON.stringify({ modelType: "MAIVE", shouldUseInstrumenting: false }),
+    );
+    expect(parsed.modelType).toBe("WLS");
+    expect(parsed.shouldUseInstrumenting).toBe(false);
+  });
+
+  it("leaves WAIVE and RTMA alone when instrumenting is off", () => {
+    expect(
+      parseRunParameters(
+        JSON.stringify({ modelType: "WAIVE", shouldUseInstrumenting: false }),
+      ).modelType,
+    ).toBe("WAIVE");
+    expect(
+      parseRunParameters(
+        JSON.stringify({ modelType: "RTMA", shouldUseInstrumenting: false }),
+      ).modelType,
+    ).toBe("RTMA");
+  });
+
+  it("derives the instrumenting flag rather than trusting it", () => {
+    // A stored `true` on RTMA is incoherent; the model type wins.
+    expect(
+      parseRunParameters(
+        JSON.stringify({ modelType: "RTMA", shouldUseInstrumenting: true }),
+      ).shouldUseInstrumenting,
+    ).toBe(false);
+    expect(
+      parseRunParameters(JSON.stringify({ modelType: "MAIVE" }))
+        .shouldUseInstrumenting,
+    ).toBe(true);
+  });
+
+  it("returns defaults instead of throwing on malformed JSON", () => {
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    expect(parseRunParameters("{not json").modelType).toBe(
+      CONFIG.DEFAULT_MODEL_PARAMETERS.modelType,
+    );
+  });
+});
+
+describe("isRtmaResults", () => {
+  it("identifies each result shape by its own fields", () => {
+    const rtma = { mu: 1, muCI: [0.5, 1.5] } as unknown as RTMAResults;
+    const maive = {
+      effectEstimate: 1,
+      standardError: 0.1,
+    } as unknown as ModelResults;
+
+    expect(isRtmaResults(rtma)).toBe(true);
+    expect(isRtmaResults(maive)).toBe(false);
+  });
+});

--- a/apps/react-ui/client/src/utils/resultTypeUtils.ts
+++ b/apps/react-ui/client/src/utils/resultTypeUtils.ts
@@ -1,0 +1,18 @@
+import type { ModelResults, RTMAResults } from "@src/types/api";
+
+/**
+ * Tell an RTMA result from a MAIVE/WAIVE/WLS one by its shape.
+ *
+ * The results page picks the renderer from the requested `modelType`, which it
+ * always has to hand. The compare page may not: a run whose entry has been
+ * removed from the local list still has a cached result and a jobId in the URL,
+ * and guessing its model type wrong renders the wrong summary. The payload
+ * itself is unambiguous, so read that instead: only RTMA reports `muCI`, and
+ * only the others report `effectEstimate`.
+ *
+ * @param results A parsed run result of either shape
+ * @returns True when the result came from an RTMA fit
+ */
+export const isRtmaResults = (
+  results: ModelResults | RTMAResults,
+): results is RTMAResults => "muCI" in results && results.muCI != null;

--- a/apps/react-ui/client/src/utils/runParameterUtils.ts
+++ b/apps/react-ui/client/src/utils/runParameterUtils.ts
@@ -1,0 +1,55 @@
+import type { ModelParameters } from "@src/types";
+import CONFIG from "@src/CONFIG";
+import CONST from "@src/CONST";
+
+/**
+ * Rebuild a full `ModelParameters` from the JSON string a run carries around
+ * (the results page reads it from the URL, the runs list stores it per entry).
+ *
+ * `shouldUseInstrumenting` is not stored independently of `modelType`: it is
+ * derived, because the two would otherwise be able to disagree. A stored
+ * `shouldUseInstrumenting: false` on a non-WAIVE, non-RTMA run is how a WLS run
+ * is recorded, so it is read back as WLS rather than as the model type that
+ * happens to sit in the object.
+ *
+ * Unparseable input falls back to the defaults rather than throwing, so one bad
+ * entry cannot take down a page that renders several runs at once.
+ *
+ * @param parameters JSON-stringified parameters, or null when absent
+ * @returns Fully populated parameters with the instrumenting flag derived
+ */
+export const parseRunParameters = (
+  parameters: string | null | undefined,
+): ModelParameters => {
+  let parsedJson: Partial<ModelParameters> = {};
+  if (parameters) {
+    try {
+      const parsed = JSON.parse(parameters) as unknown;
+      if (parsed && typeof parsed === "object") {
+        parsedJson = parsed as Partial<ModelParameters>;
+      }
+    } catch (error) {
+      console.error("Failed to parse model parameters:", error);
+    }
+  }
+
+  const resolved: ModelParameters = {
+    ...CONFIG.DEFAULT_MODEL_PARAMETERS,
+    ...parsedJson,
+  };
+
+  if (
+    resolved.shouldUseInstrumenting === false &&
+    resolved.modelType !== CONST.MODEL_TYPES.WAIVE &&
+    resolved.modelType !== CONST.MODEL_TYPES.RTMA
+  ) {
+    resolved.modelType = CONST.MODEL_TYPES.WLS;
+  }
+
+  resolved.shouldUseInstrumenting = !(
+    resolved.modelType === CONST.MODEL_TYPES.WLS ||
+    resolved.modelType === CONST.MODEL_TYPES.RTMA
+  );
+
+  return resolved;
+};


### PR DESCRIPTION
Closes #457. Follows the approach sketched in the issue: tick finished runs in
My Runs, land on `/compare?jobIds=a,b`, cards rendered from the existing summary
components, IndexedDB first.

## Selecting

Checkboxes appear only on runs that can have a result. `expired` counts as one:
the server record is gone after 48 hours, but the durable cache may still hold
it, and results are immutable so a cached copy is never stale. If it turns out
nothing was cached, the card says so rather than the run being unselectable on a
guess.

Two to three runs. Three is where the columns stop being readable, since each
card carries a whole result summary rather than one number. Ticking order is
preserved, because it is the only column ordering the user controls.

## Comparing

Each job resolves independently and in parallel, cache first, then
`GET /api/runs/{jobId}`. The batch `GET /api/runs` route is **not** used despite
the issue suggesting it: it returns status only, no result payload. Anything
fetched from the server is written back to the cache, so reopening the same
comparison works offline.

One job failing never blocks the others. Cards commit as they land rather than
waiting for the whole set, and a card with no result explains which case it hit.

Mixed model types are allowed, since comparing a MAIVE run against an RTMA run is
often the point, but the page says plainly that the cards then report different
quantities and cannot be read across.

## Two things the reuse needed

**The summary components split into two columns on `md:`**, which keys off the
viewport, not the component. Rendered inside a compare column they still split,
at a third of the width. Both now take an optional `columns` prop; the default is
unchanged, so nothing else moves. The compare page passes 1, which is what makes
the metrics line up row-for-row across cards.

**`RTMAResultsSummary` brings its own titled panel and `ResultsSummary` does
not**, so the two card types sat side by side with different chrome, reading as a
rendering fault rather than as two model types. The compare page gives the
non-RTMA summary a matching panel.

## Incidental

`parseRunParameters` is extracted from the results page rather than copied. It
holds the non-obvious bit: `shouldUseInstrumenting` is *derived* from
`modelType`, not trusted, because a stored `false` on a non-WAIVE/RTMA run is how
a WLS run is recorded. Two copies of that could disagree. The results page now
calls it, so this is a net deletion there.

`isRtmaResults` picks the renderer from the payload shape instead of the stored
model type. The results page can use the model type because it always has it;
compare may not, since a run whose list entry was removed still has a cached
result and a jobId in the URL.

`.claude/launch.json` is included so `npm run ui:dev` is discoverable to tooling.
Unrelated to the feature; drop it if you would rather not have it tracked.

## Verification

224 vitest tests pass, 13 of them new: 7 covering the compare page (cache hit,
server fallback with write-back, per-card failure isolation, the mixed-model
notice, dedup and the cap, the hard-load path) and 6 covering the extracted
parameter parsing. Lint and typecheck clean.

Driven in a real browser, not only jsdom: two RTMA runs read across correctly
(5.171 vs 4.402), a three-card RTMA + MAIVE + expired mix renders each case,
mobile stacks with no horizontal overflow, and a hard load of a `/compare` link
works.

Two things that came out of looking at it rather than testing it:

- The My Runs row already truncated filenames at phone widths (~107px of 375 for
  the name), and the checkbox column costs another 28px. Tightened that group's
  gap to claw some back. The row wants a proper narrow-width layout, but that is
  its own change.
- Rows without a checkbox lost their left alignment, so the space is reserved.

One correction worth recording, since I got it wrong out loud mid-session: I
briefly concluded that hard-loading `/results?jobId=...` was broken app-wide.
That was a wedged dev server returning 503s for its chunks, so nothing hydrated.
On a healthy server the results page is fine and always was. No pre-existing bug.

What survives from that is smaller and real: on a hard load the pre-hydration
render has no query, so `/compare` painted "pick at least 2 runs" for one frame
at someone who had picked two. `useReadySearchParams` separates "empty" from "not
known yet" and paints a neutral placeholder instead. The page recovered on its
own either way; this is about not flashing a false claim about the user's
selection.

No screenshots committed: the browser tooling here returns images to me rather
than writing files, so I could not produce `docs/screenshots/pr-N-*.png` in the
usual convention.
