### PR TITLE
Release: compare runs side by side + RTMA parallel chains

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -438,7 +438,7 @@ R_API_URL=https://<r-lambda-id>.lambda-url.<region>.on.aws
 
 ## Deployment Notes
 
-- **Release workflow**: PRs to `release` branch trigger `release.yml` GitHub Actions
+- **Release workflow**: there is no `release` branch. `release.yml` triggers on any PR merged into `master` that carries the `release` label; the merge itself starts the build and deploy
 - **Version bumping**: Add `v-build`, `v-patch`, `v-minor`, or `v-major` labels
 - **Automation**: Use `npm run release` to open release PR, `npm run mergePR` to merge
 - **Infrastructure**: Defer to maintainer for `cloud:*` and `images:*` commands


### PR DESCRIPTION
## Summary

Ships two undeployed commits from master:

- 28e8ddd7 feat: compare finished runs side by side (#457, #516)
- 61fc1f5d perf: run RTMA stan chains in parallel and raise the R lambda to 2 vCPU (#483, #515)

Plus a doc correction to CLAUDE.md's Deployment Notes (the release process
description was wrong: there is no `release` branch).

## Test plan

- CI on this PR (lint, unit tests, R e2e) must be green before merge.
- After merge, watch release.yml through the deploy job.
- Post-deploy: verify R Lambda memory_size=3538 and RTMA_SAMPLING_CORES=2, then
  time RTMA runs at k=100/500/2000 against the live endpoint and report on #483.