### PR TITLE
docs: correct the quarterly-release automation description

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -442,7 +442,7 @@ R_API_URL=https://<r-lambda-id>.lambda-url.<region>.on.aws
 - **Version bumping**: Add `v-build`, `v-patch`, `v-minor`, or `v-major` labels
 - **Automation**: Use `npm run release` to open release PR, `npm run mergePR` to merge
 - **Infrastructure**: Defer to maintainer for `cloud:*` and `images:*` commands
-- **Quarterly releases**: Automated releases on Jan 1, Apr 1, Jul 1, Oct 1
+- **Quarterly releases**: `quarterly-release.yml` opens a version-bump PR on Jan 1, Apr 1, Jul 1, Oct 1. It only bumps `package.json`; it never applies the `release` label, so merging it does not deploy anything on its own
 
 ## Common Issues
 


### PR DESCRIPTION
## Summary

`quarterly-release.yml` only bumps `package.json` and opens a PR; it never applies the
`release` label, so merging its PR alone deploys nothing. CLAUDE.md described it as
"Automated releases," which overstates what actually happens.

Related: closed #442 (a 4+ month stale quarterly PR that wouldn't have deployed anything
even if merged), and re-enabled the `quarterly-release.yml` schedule, which GitHub had
auto-disabled for inactivity since the Apr 1 run (no Jul 1 run happened).

## Test plan

Docs only, no code change. No deploy needed.