### PR TITLE
perf: cap RTMA treedepth and enforce its timeout in a killable fit child

### DIFF
--- a/apps/lambda-r-backend/r_scripts/rtma_model.R
+++ b/apps/lambda-r-backend/r_scripts/rtma_model.R
@@ -22,14 +22,43 @@ RTMA_PLOT_RES <- 120
 #
 # It is not entirely free of consequences, though. On a weakly identified dataset
 # the sampler's trajectory depends on where it starts, so some seeds send it into
-# a pathologically deep tree and the fit runs for minutes instead of seconds: on
-# the e2e "precise estimates" fixture that happens for 20250101 and 2026, and on
-# the near-degenerate /v1 fixture for 42 and 8454. Unseeded runs took that gamble
-# on every call, so this is not a new failure mode, but a fixed seed makes it
-# deterministic, so this value was timed against every RTMA fixture in the e2e
-# suite (all fits under 8 seconds). Any dataset can still be unlucky, which is
-# what the wall-clock limit below is for.
+# a pathologically deep tree: on the e2e "precise estimates" fixture that happens
+# for 20250101 and 2026, and on the near-degenerate /v1 fixture for 42 and 8454.
+# Unseeded runs took that gamble on every call, so this is not a new failure
+# mode, but a fixed seed makes it deterministic, so this value was timed against
+# every RTMA fixture in the e2e suite (all fits under 8 seconds). What an unlucky
+# (dataset, seed) pair can cost is bounded by RTMA_STAN_CONTROL below, and the
+# wall-clock budget is the backstop behind that.
 RTMA_DEFAULT_SEED <- 2025L
+
+# Sampler settings for the RTMA fit, passed to phacking_meta()'s stan_control.
+#
+# This list replaces phacking's default outright rather than merging into it, so
+# adapt_delta has to be restated at phacking's own 0.98; letting it fall back to
+# Stan's 0.8 would move every number this app reports.
+#
+# max_treedepth caps one NUTS iteration at 2^12 = 4096 leapfrog steps, against
+# the 2^20 phacking asks for. Two regimes, and the cap is invisible in the first:
+#
+#   * Well identified data. No trajectory comes near either ceiling, so the draws
+#     are bit-identical to the uncapped fit. Verified per fixture in the
+#     performance report (#518, section 6) and again through this entry point on
+#     the e2e fixture, its sign-mirrored twin, and an n = 300 dataset.
+#   * Weakly identified data. The posterior grows a heavy flat shelf running out
+#     to large (mu, tau), a chain that wanders onto it saturates whatever depth
+#     it is allowed, and at depth 20 that is minutes per iteration. This is where
+#     the multi-minute RTMA grinds and the Lambda hard-kills came from. The cap
+#     does not make such a fit good; it makes it fail fast and visibly. Those
+#     runs now come back in seconds either recovered (r_hat near 1) or with r_hat
+#     far above 1 and divergent transitions, both of which the response's
+#     diagnostics block already reports (#480). Draw-dependent outputs (median,
+#     credible interval, n_eff) move within the seed-to-seed spread such datasets
+#     already have; the mode comes from a separate deterministic optimisation
+#     anchored in the posterior's core and does not move.
+#
+# Depth 10 was measured to break otherwise recoverable fits (r_hat 8 to 15), so
+# 12 is the validated floor rather than a round number.
+RTMA_STAN_CONTROL <- list(adapt_delta = 0.98, max_treedepth = 12L)
 
 # Upper bound on sampling cores: rstan runs 4 chains by default and forks at
 # most one worker per chain, so nothing above this can be used.
@@ -56,6 +85,233 @@ RTMA_MAX_SAMPLING_CORES <- 4L
 rtma_sampling_cores <- function() {
   n <- suppressWarnings(as.integer(Sys.getenv("RTMA_SAMPLING_CORES")))
   if (length(n) != 1 || is.na(n) || n < 1) 1L else n
+}
+
+#' Snapshot the machine's pid -> parent pid table
+#'
+#' Read from /proc on Linux (the Lambda image, where `ps` is not installed) and
+#' from ps everywhere else (macOS, where local dev and the e2e suite run).
+#' Processes that exit between the listing and the read are dropped rather than
+#' reported with a missing parent.
+#'
+#' @return list(pid = <integer>, ppid = <integer>), or NULL if neither source
+#'   could be read
+rtma_process_table <- function() {
+  tryCatch(
+    {
+      if (dir.exists("/proc")) {
+        pids <- as.integer(list.files("/proc", pattern = "^[0-9]+$"))
+        ppids <- vapply(pids, function(pid) {
+          # /proc/<pid>/stat is one line: pid (comm) state ppid ... The command
+          # name can contain spaces and parentheses, so parse from the last
+          # closing parenthesis, after which the fields are fixed-width.
+          stat <- tryCatch(
+            readLines(file.path("/proc", pid, "stat"), warn = FALSE),
+            error = function(e) character(0)
+          )
+          if (length(stat) != 1) {
+            return(NA_integer_)
+          }
+          fields <- strsplit(sub("^.*\\)\\s*", "", stat), " ", fixed = TRUE)[[1]]
+          suppressWarnings(as.integer(fields[2]))
+        }, integer(1))
+      } else {
+        lines <- suppressWarnings(
+          system2("ps", c("-Ao", "pid=,ppid="), stdout = TRUE, stderr = FALSE)
+        )
+        fields <- strsplit(trimws(lines), "[[:space:]]+")
+        fields <- fields[lengths(fields) == 2]
+        pids <- suppressWarnings(as.integer(vapply(fields, `[[`, "", 1)))
+        ppids <- suppressWarnings(as.integer(vapply(fields, `[[`, "", 2)))
+      }
+      complete <- !is.na(pids) & !is.na(ppids)
+      list(pid = pids[complete], ppid = ppids[complete])
+    },
+    error = function(e) NULL
+  )
+}
+
+#' Transitive descendants of a process within a table snapshot
+#'
+#' @param pid Root process id
+#' @param table Snapshot from rtma_process_table(), or NULL
+#' @return Integer vector of descendant pids, possibly empty
+rtma_descendants <- function(pid, table) {
+  pid <- as.integer(pid)
+  if (is.null(table) || length(table$pid) == 0) {
+    return(integer(0))
+  }
+  found <- integer(0)
+  frontier <- pid
+  repeat {
+    children <- setdiff(table$pid[table$ppid %in% frontier], c(found, pid))
+    if (length(children) == 0) {
+      return(found)
+    }
+    found <- c(found, children)
+    frontier <- children
+  }
+}
+
+#' Kill a fit child together with every Stan worker it forked
+#'
+#' Killing the child alone is not enough. With mc.cores > 1 it forks a worker
+#' per chain, SIGKILL skips R's mc.cleanup, and an orphaned worker mid-grind
+#' keeps burning the container's CPU with nothing left to stop it. So the
+#' workers go first, while their parent is still alive: the ppid links that
+#' identify them disappear the moment the child dies and the kernel reparents
+#' its orphans to init.
+#'
+#' The scan repeats so that a worker forked between one scan and its kill is
+#' still caught. Workers already killed stay visible as zombies of the live
+#' child, so the loop terminates on the set of pids already signalled rather
+#' than on liveness. In practice rstan forks once, at the start of sampling,
+#' and the second scan finds nothing new.
+#'
+#' @param pid Process id of the fit child
+#' @return Integer vector of the worker pids signalled, invisibly
+rtma_kill_fit_tree <- function(pid) {
+  pid <- as.integer(pid)
+  signalled <- integer(0)
+  for (attempt in seq_len(3L)) {
+    workers <- setdiff(rtma_descendants(pid, rtma_process_table()), signalled)
+    if (length(workers) == 0) {
+      break
+    }
+    for (worker in workers) {
+      tools::pskill(worker, tools::SIGKILL)
+    }
+    signalled <- c(signalled, workers)
+    Sys.sleep(0.05)
+  }
+  tools::pskill(pid, tools::SIGKILL)
+  invisible(signalled)
+}
+
+#' Run the RTMA fit under a wall-clock budget that is actually enforced
+#'
+#' setTimeLimit cannot do this job. R checks elapsed-time limits only at R-level
+#' interrupt points, and a grinding Stan chain does not return to R until it
+#' finishes; with forked chains the parent blocks in the worker-collect loop
+#' instead, which is no better. Measured overshoot was minutes past a 15 second
+#' budget in both configurations (#518, section 4), which on Lambda means the
+#' documented timeout error never arrives and the request dies as an opaque hard
+#' kill at the function timeout.
+#'
+#' So on unix the fit runs in a forked child this process can kill: poll for its
+#' result, and at the deadline kill the child and its Stan workers. Where R
+#' cannot fork the fit runs in-process under setTimeLimit, which is best-effort
+#' for the same reason as before; that path is dev-only (Windows).
+#'
+#' Failures are returned rather than thrown so that the caller owns every
+#' user-facing message, and so that a timeout cannot be confused with a fit
+#' error that happens to arrive near the deadline.
+#'
+#' @param fit_call Zero-argument function that runs the fit. Whatever it
+#'   returns is handed back untouched, so it can carry the fit plus anything
+#'   that does not cross a process boundary on its own (see rtma_fit_call in
+#'   run_rtma_model, which collects the fit's warnings).
+#' @param timeout_sec Wall-clock budget in seconds
+#' @return One of list(status = "ok", value = <fit_call's value>),
+#'   list(status = "timeout"), list(status = "error", message = <string>), or
+#'   list(status = "died") when the child vanished without either
+run_rtma_fit_bounded <- function(fit_call, timeout_sec) {
+  if (.Platform$OS.type != "unix") {
+    return(run_rtma_fit_in_process(fit_call, timeout_sec))
+  }
+
+  job <- parallel::mcparallel(fit_call())
+  collected <- NULL
+  # The child must not outlive this call on any exit path: the deadline, an
+  # error raised below, or an interrupt delivered to the serving process.
+  on.exit(
+    if (is.null(collected)) {
+      rtma_kill_fit_tree(job$pid)
+      # Reap the corpse rather than leave a zombie for the life of the
+      # container. mccollect warns that the job returned no result, which is
+      # exactly what a killed child looks like and carries no information.
+      suppressWarnings(try(
+        parallel::mccollect(job, wait = FALSE, timeout = 1),
+        silent = TRUE
+      ))
+    },
+    add = TRUE
+  )
+
+  deadline <- Sys.time() + timeout_sec
+  repeat {
+    remaining <- as.numeric(difftime(deadline, Sys.time(), units = "secs"))
+    if (remaining <= 0) {
+      break
+    }
+    # Sliced so the deadline is honoured to about a quarter second however long
+    # the fit runs. Each slice blocks in select(), so this is not a spin.
+    collected <- parallel::mccollect(
+      job,
+      wait = FALSE,
+      timeout = min(0.25, remaining)
+    )
+    if (!is.null(collected)) {
+      break
+    }
+  }
+
+  if (is.null(collected)) {
+    return(list(status = "timeout"))
+  }
+
+  result <- collected[[1]]
+  if (inherits(result, "try-error")) {
+    # The child's own error, forwarded by mccollect. Report the message
+    # phacking wrote rather than mccollect's wrapper text.
+    condition <- attr(result, "condition")
+    return(list(
+      status = "error",
+      message = if (is.null(condition)) {
+        trimws(as.character(result))
+      } else {
+        conditionMessage(condition)
+      }
+    ))
+  }
+  if (is.null(result)) {
+    # Gone without a result and without an error: killed from outside this
+    # request, in practice by the kernel's OOM killer.
+    return(list(status = "died"))
+  }
+  list(status = "ok", value = result)
+}
+
+#' Run the RTMA fit in this process under a best-effort time limit
+#'
+#' The fallback for platforms that cannot fork. setTimeLimit only fires at
+#' R-level interrupt points, so the budget holds for everything except the one
+#' case it is there for; it is kept because a loose bound beats none, and
+#' because no deployed environment takes this path.
+#'
+#' @param fit_call Zero-argument function that runs the fit
+#' @param timeout_sec Wall-clock budget in seconds
+#' @return The same outcome list as run_rtma_fit_bounded()
+run_rtma_fit_in_process <- function(fit_call, timeout_sec) {
+  started <- Sys.time()
+  setTimeLimit(elapsed = timeout_sec, transient = TRUE)
+  on.exit(setTimeLimit(), add = TRUE)
+  tryCatch(
+    list(status = "ok", value = fit_call()),
+    error = function(e) {
+      setTimeLimit() # clear so error reporting is not itself interrupted
+      elapsed <- as.numeric(difftime(Sys.time(), started, units = "secs"))
+      err_message <- conditionMessage(e)
+      # The interrupt fires inside phacking, which re-throws it as an opaque
+      # message, so elapsed time is the more reliable of the two tests.
+      if (elapsed >= timeout_sec * 0.95 ||
+        grepl("elapsed time limit", err_message, fixed = TRUE)) {
+        list(status = "timeout")
+      } else {
+        list(status = "error", message = err_message)
+      }
+    }
+  )
 }
 
 #' Render a z-score density plot and return it as a base64-encoded PNG data URI
@@ -237,7 +493,18 @@ run_rtma_model <- function(data, parameters, include_plot = TRUE) {
   cores <- min(cores, RTMA_MAX_SAMPLING_CORES)
   # Wall-clock budget kept below the Lambda function timeout so a degenerate
   # dataset returns a clear error instead of being hard-killed mid-request.
-  timeout_sec <- if (!is.null(params$timeoutSeconds)) as.numeric(params$timeoutSeconds) else 480
+  # Validated like cores above, and for the same reason: the legacy route hands
+  # parameters through unfiltered, so this is caller-settable there, and
+  # run_rtma_fit_bounded() needs a real positive number to compute a deadline.
+  timeout_sec <- if (!is.null(params$timeoutSeconds)) {
+    suppressWarnings(as.numeric(params$timeoutSeconds))
+  } else {
+    480
+  }
+  # is.finite() rejects NA, NaN and Inf in one test.
+  if (length(timeout_sec) != 1 || !is.finite(timeout_sec) || timeout_sec <= 0) {
+    cli::cli_abort("The timeoutSeconds parameter must be a positive number.")
+  }
   # Sampler seed; see RTMA_DEFAULT_SEED above for why it must be pinned.
   seed <- if (!is.null(params$seed)) {
     suppressWarnings(as.integer(params$seed))
@@ -258,39 +525,32 @@ run_rtma_model <- function(data, parameters, include_plot = TRUE) {
     "timeout_sec: {timeout_sec}"
   ))
 
-  # Run RTMA via phacking package, bounded by a wall-clock limit. Pathological
-  # datasets can make the sampler's tree depth explode to effectively unbounded
-  # runtimes; the limit converts that into a clean failure instead of a hang.
-  # The time-limit interrupt fires inside phacking, which re-throws it as an
-  # opaque message, so timeout is detected by elapsed time rather than message.
-  #
-  # phacking_meta() also signals conditions the caller must see, above all
-  # "Favored direction is opposite of the pooled estimate.", which means the fit
-  # truncated nothing and the returned mu is effectively uncorrected. tryCatch
-  # only handles errors, so warnings are collected here and returned in the
-  # response instead of being dropped on the floor.
-  rtma_warnings <- character(0)
-  start_time <- Sys.time()
-
   # rstan takes its chain count from mc.cores, so set it here rather than
   # passing parallelize = TRUE: that flag makes phacking call
   # `options(mc.cores = parallel::detectCores())`, which reads the host's core
-  # count instead of the Lambda's allocation. Restored afterwards so a request
-  # cannot leave the option changed for the next one in the same container.
+  # count instead of the Lambda's allocation. The fit child inherits the option
+  # across the fork. Restored afterwards so a request cannot leave the option
+  # changed for the next one in the same container.
   previous_mc_cores <- getOption("mc.cores")
   on.exit(options(mc.cores = previous_mc_cores), add = TRUE)
   options(mc.cores = cores)
 
-  setTimeLimit(elapsed = timeout_sec, transient = TRUE)
-  rtma_res <- tryCatch(
-    withCallingHandlers(
+  # phacking_meta() signals conditions the caller must see, above all "Favored
+  # direction is opposite of the pooled estimate.", which means the fit
+  # truncated nothing and the returned mu is effectively uncorrected. They are
+  # collected next to the fit rather than left to propagate: warnings do not
+  # cross a process boundary, and this closure runs in the fit child.
+  rtma_fit_call <- function() {
+    fit_warnings <- character(0)
+    fit <- withCallingHandlers(
       {
         # Seeded here rather than at the top of the function: nothing between
         # this line and phacking_meta() touches the RNG, so this is exactly the
-        # state the sampler starts from. The seed also fixes rstan's own seed,
-        # which it draws from this RNG, so each chain's stream is determined by
-        # its chain id alone; running the chains on 1 core or 4 gives
-        # bit-identical draws (verified in #483).
+        # state the sampler starts from, in the child as much as in-process.
+        # The seed also fixes rstan's own seed, which it draws from this RNG,
+        # so each chain's stream is determined by its chain id alone; running
+        # the chains on 1 core or 4 gives bit-identical draws (verified in
+        # #483).
         set.seed(seed)
         phacking::phacking_meta(
           yi = yi,
@@ -298,30 +558,45 @@ run_rtma_model <- function(data, parameters, include_plot = TRUE) {
           favor_positive = favor_positive,
           alpha_select = alpha_select,
           ci_level = ci_level,
+          stan_control = RTMA_STAN_CONTROL,
           parallelize = FALSE
         )
       },
       warning = function(w) {
-        rtma_warnings <<- c(rtma_warnings, conditionMessage(w))
+        fit_warnings <<- c(fit_warnings, conditionMessage(w))
         invokeRestart("muffleWarning")
       }
-    ),
-    error = function(e) {
-      setTimeLimit() # clear so error reporting is not itself interrupted
-      elapsed <- as.numeric(difftime(Sys.time(), start_time, units = "secs"))
-      err_message <- conditionMessage(e)
-      if (elapsed >= timeout_sec * 0.95 ||
-        grepl("elapsed time limit", err_message, fixed = TRUE)) {
-        cli::cli_abort(c(
-          "RTMA timed out after {timeout_sec} seconds.",
-          "i" = "The run exceeded its time budget before finishing; this does not necessarily mean it diverged. Try winsorizing outliers or reducing the number of estimates."
-        ))
-      }
-      cli::cli_alert_danger(paste("RTMA error:", err_message))
-      cli::cli_abort(paste("RTMA analysis failed:", err_message))
-    }
+    )
+    list(fit = fit, warnings = fit_warnings)
+  }
+
+  # Pathological datasets can make the sampler's tree depth explode.
+  # RTMA_STAN_CONTROL bounds how expensive a single iteration can get;
+  # run_rtma_fit_bounded() bounds the fit as a whole, and unlike the
+  # setTimeLimit guard it replaces, it can actually stop a running chain.
+  fit_outcome <- run_rtma_fit_bounded(rtma_fit_call, timeout_sec)
+  fit_result <- switch(fit_outcome$status,
+    ok = fit_outcome$value,
+    timeout = cli::cli_abort(c(
+      "RTMA timed out after {timeout_sec} seconds.",
+      "i" = "The run exceeded its time budget before finishing; this does not necessarily mean it diverged. Try winsorizing outliers or reducing the number of estimates."
+    )),
+    died = cli::cli_abort(c(
+      "The RTMA fit stopped before returning a result.",
+      "i" = "The fit process was killed from outside the request, which usually means the container ran out of memory. Try reducing the number of estimates."
+    )),
+    error = {
+      # "{err_message}" rather than paste(): an error text containing braces
+      # would otherwise be re-interpolated by cli and take down the report of
+      # the very error it describes.
+      err_message <- fit_outcome$message
+      cli::cli_alert_danger("RTMA error: {err_message}")
+      cli::cli_abort("RTMA analysis failed: {err_message}")
+    },
+    cli::cli_abort("Unrecognized RTMA fit outcome: {fit_outcome$status}")
   )
-  setTimeLimit() # clear the limit for the rest of the request (plot, response)
+  rtma_res <- fit_result$fit
+  rtma_warnings <- fit_result$warnings
 
   cli::cli_h2("RTMA results structure:")
   cli::cli_code(capture.output(str(rtma_res, max.level = 2)))

--- a/apps/lambda-r-backend/r_scripts/tests/e2e/run_e2e_tests.R
+++ b/apps/lambda-r-backend/r_scripts/tests/e2e/run_e2e_tests.R
@@ -40,6 +40,7 @@ source(file.path(script_dir, "scenarios/edge_cases_test.R"))
 source(file.path(script_dir, "scenarios/basic_rtma_test.R"))
 source(file.path(script_dir, "scenarios/rtma_direction_test.R"))
 source(file.path(script_dir, "scenarios/rtma_seed_test.R"))
+source(file.path(script_dir, "scenarios/rtma_timeout_test.R"))
 source(file.path(script_dir, "scenarios/api_v1_test.R"))
 
 # Define available test scenarios
@@ -115,6 +116,11 @@ AVAILABLE_SCENARIOS <- list(
     name = "RTMA Seed Reproducibility Test",
     description = "Test that identical input and seed reproduce identical RTMA results",
     function_name = "test_rtma_seed"
+  ),
+  "rtma-timeout" = list(
+    name = "RTMA Timeout Test",
+    description = "Test that the RTMA wall-clock budget is enforced and the server survives it",
+    function_name = "test_rtma_timeout"
   ),
 
   # Public /v1 API scenarios
@@ -388,7 +394,7 @@ run_all_scenarios <- function(api_url = NULL, verbose = TRUE) {
   }
   test_count <- test_count + 1
 
-  # The two scenarios below run last: between them they fit seven more RTMA
+  # The three scenarios below run last: between them they fit eight more RTMA
   # models, and every extra fit in this long-lived process makes the rstan
   # sampler more likely to wedge on a later one. Keeping them at the end leaves
   # every other scenario with the same process state it had before they existed.
@@ -411,6 +417,20 @@ run_all_scenarios <- function(api_url = NULL, verbose = TRUE) {
     cat("   ✓ RTMA favored direction test passed\n")
   } else {
     cat("   ✗ RTMA favored direction test failed:", rtma_direction_result$error, "\n")
+  }
+  test_count <- test_count + 1
+
+  # Last of all: this one kills a fit mid-sample, so anything that ran after it
+  # would be reporting on a process that has just had a child torn out from
+  # under it. That the server survives is the scenario's own final assertion.
+  cat("\n10. Running RTMA timeout test...\n")
+  rtma_timeout_result <- test_rtma_timeout()
+  all_results$rtma_timeout <- rtma_timeout_result
+  if (rtma_timeout_result$status == "PASS") {
+    passed_count <- passed_count + 1
+    cat("   ✓ RTMA timeout test passed\n")
+  } else {
+    cat("   ✗ RTMA timeout test failed:", rtma_timeout_result$error, "\n")
   }
   test_count <- test_count + 1
 

--- a/apps/lambda-r-backend/r_scripts/tests/e2e/scenarios/rtma_timeout_test.R
+++ b/apps/lambda-r-backend/r_scripts/tests/e2e/scenarios/rtma_timeout_test.R
@@ -1,0 +1,173 @@
+# RTMA Timeout Test Scenario
+#
+# run_rtma_model() promises that a fit exceeding params$timeoutSeconds comes
+# back as "RTMA timed out after N seconds." rather than running until the
+# platform kills the process. setTimeLimit could not keep that promise: R
+# checks elapsed-time limits only at R-level interrupt points, which a running
+# Stan chain never crosses (#518, section 4), so the error arrived, if at all,
+# only once the fit it was supposed to interrupt had finished. The fit now runs
+# in a forked child the handler kills at the deadline, Stan workers included.
+#
+# What this scenario pins down, end to end through the server:
+#   * an impossible budget produces the documented error, and produces it
+#     sooner than the same request takes to succeed. That comparison is the
+#     assertion that would have failed before the fork: the old code could only
+#     report the timeout after the full fit, so the "timed out" response was
+#     always the slower of the two.
+#   * the same server then serves a normal fit, so killing a child mid-sample
+#     leaves no wreckage behind (orphaned workers competing for the container's
+#     CPU, broken parallel bookkeeping).
+#   * a budget that is not a positive number is rejected as a bad parameter
+#     instead of producing a deadline nothing can satisfy.
+
+# Budget for the request that must time out. Well under the fastest possible
+# fit on this fixture (sampling alone takes seconds), so a timeout is the only
+# correct outcome, and it is what the response message is asserted to name.
+RTMA_TIMEOUT_BUDGET_SEC <- 0.2
+
+# Absolute ceiling on how late the timeout response may arrive. The deadline is
+# enforced to about a quarter second, but the request also pays HTTP, JSON and
+# fork overhead, and CI machines are slow; the sharp assertion is the
+# comparison against the successful fit, not this bound.
+RTMA_TIMEOUT_MAX_RESPONSE_SEC <- 30
+
+#' Fail with a message unless a condition holds
+#' @param condition Condition that must be TRUE
+#' @param message Failure message
+expect_rtma_timeout <- function(condition, message) {
+  if (!isTRUE(condition)) {
+    stop(message)
+  }
+}
+
+#' Build RTMA parameter JSON for the timeout scenario
+#' @param timeout_seconds Wall-clock budget to request, or NULL for the default
+#' @return JSON string of parameters
+rtma_timeout_params <- function(timeout_seconds = NULL) {
+  params <- list(
+    modelType = "RTMA",
+    favorPositive = TRUE,
+    alphaSelect = 0.05,
+    ciLevel = 0.95,
+    winsorize = 0
+  )
+  if (!is.null(timeout_seconds)) {
+    params$timeoutSeconds <- timeout_seconds
+  }
+  params_to_json(params)
+}
+
+#' POST /run-rtma and report how long the response took to arrive
+#' @param data_json JSON string of the dataset
+#' @param timeout_seconds Wall-clock budget to request, or NULL for the default
+#' @return list(response = <parsed body>, elapsed = <seconds>)
+time_rtma_request <- function(data_json, timeout_seconds = NULL) {
+  started <- Sys.time()
+  response <- test_run_rtma(data_json, rtma_timeout_params(timeout_seconds))
+  list(
+    response = response,
+    elapsed = as.numeric(difftime(Sys.time(), started, units = "secs"))
+  )
+}
+
+#' Test that the RTMA wall-clock budget is enforced
+#' @return Test results
+test_rtma_timeout <- function() {
+  test_name <- "RTMA Timeout Test"
+
+  tryCatch(
+    {
+      data_json <- df_to_json(generate_rtma_test_data())
+
+      cat(sprintf(
+        "  requesting a fit with a %s second budget...\n",
+        RTMA_TIMEOUT_BUDGET_SEC
+      ))
+      timed_out <- time_rtma_request(data_json, RTMA_TIMEOUT_BUDGET_SEC)
+
+      # The legacy route reports handler errors as a 200 with an error flag.
+      expect_rtma_timeout(
+        isTRUE(timed_out$response$error),
+        sprintf(
+          "a %s second budget should time the fit out, but the request returned results",
+          RTMA_TIMEOUT_BUDGET_SEC
+        )
+      )
+      expect_rtma_timeout(
+        grepl(
+          sprintf("RTMA timed out after %s seconds", RTMA_TIMEOUT_BUDGET_SEC),
+          timed_out$response$message,
+          fixed = TRUE
+        ),
+        paste(
+          "timeout error should carry the documented message, got:",
+          timed_out$response$message
+        )
+      )
+      expect_rtma_timeout(
+        timed_out$elapsed <= RTMA_TIMEOUT_MAX_RESPONSE_SEC,
+        sprintf(
+          "timeout response took %.1f s to arrive; the budget is not being enforced",
+          timed_out$elapsed
+        )
+      )
+      cat(sprintf("  timed out in %.1f s\n", timed_out$elapsed))
+
+      # Same server, same data, no budget: it must still fit, and it must take
+      # longer than the request that gave up on it.
+      cat("  running a normal fit on the same server afterwards...\n")
+      normal <- time_rtma_request(data_json)
+      expect_rtma_timeout(
+        !is.null(normal$response$data) && is.numeric(normal$response$data$mu),
+        "a normal fit after a timed-out one should still succeed"
+      )
+      expect_rtma_timeout(
+        timed_out$elapsed < normal$elapsed,
+        sprintf(
+          paste(
+            "the timed-out request took %.1f s and the fit it gave up on took %.1f s;",
+            "the deadline is not interrupting the fit"
+          ),
+          timed_out$elapsed,
+          normal$elapsed
+        )
+      )
+      cat(sprintf("  normal fit succeeded in %.1f s\n", normal$elapsed))
+
+      # A budget that cannot produce a deadline is a bad request, not a fit
+      # that runs forever. No fit starts, so this costs nothing.
+      cat("  checking that a non-positive budget is rejected...\n")
+      rejected <- time_rtma_request(data_json, 0)
+      expect_rtma_timeout(
+        isTRUE(rejected$response$error) &&
+          grepl("timeoutSeconds", rejected$response$message, fixed = TRUE),
+        paste(
+          "a zero budget should be rejected as an invalid parameter, got:",
+          rejected$response$message
+        )
+      )
+
+      log_test_result(
+        test_name, "PASS",
+        sprintf(
+          "Budget enforced in %.1fs against a %.1fs fit; server healthy afterwards",
+          timed_out$elapsed,
+          normal$elapsed
+        )
+      )
+
+      return(list(
+        status = "PASS",
+        test_name = test_name
+      ))
+    },
+    error = function(e) {
+      log_test_result(test_name, "FAIL", e$message)
+      return(list(
+        status = "FAIL",
+        test_name = test_name,
+        error = e$message
+      ))
+    }
+  )
+}


### PR DESCRIPTION
Implements R1 and R2 from the research report in #518. Supersedes #520, which
did the same two things; this is a rewrite, not an increment (see the end for
what changed).

**R1: cap Stan's max_treedepth at 12.** phacking asks for depth 20, which lets a
chain that wanders onto a weakly identified posterior's shelf spend 2^20
leapfrog steps on a single iteration. Depth 12 costs nothing on data where no
trajectory gets near either ceiling (bit-identical draws) and turns the
pathological cases into fast, visibly diagnosed failures instead of opaque
multi-minute grinds. `stan_control` replaces phacking's default list outright
rather than merging into it, so `adapt_delta` is restated at phacking's own 0.98.

**R2: enforce the wall-clock budget from a process that can act on it.**
`setTimeLimit` cannot interrupt a running Stan chain: R checks elapsed limits
only at R-level interrupt points, which a chain never reaches until it finishes,
serial or forked. The fit now runs in a `parallel::mcparallel` child that the
handler polls and kills at the deadline, Stan workers included, raising the
"RTMA timed out after N seconds" error the API already documented. Windows keeps
the in-process `setTimeLimit` path, since it cannot fork.

They ship together because they are one failure: a grinding chain never returns
control to R. The cap alone still leaves a bad dataset unbounded; the budget
alone was never enforced.

## Verification

Everything below was measured on this branch against `master`, through
`run_rtma_model` and through the running server.

**Bit-identity on well identified data.** A/B against master on identical JSON,
comparing all 16 response fields including warnings and diagnostics: identical
on the e2e RTMA fixture, its sign-mirrored twin (the direction warning still
ships correctly from inside the fit child), n = 300, and the app's Felts demo
dataset.

**The cap on a grinding pair.** The e2e "precise estimates" fixture
(k_nonaffirm = 4) with seed 20250101: master was still running at 15m34s and had
to be killed; capped, the same fit returns in 45s with r_hat 3.15 and 6
divergent transitions, which the diagnostics block (#480) already surfaces. The
cap does not make a bad fit good, it makes it fail fast and visibly.

**The budget, forced.** n = 300 on 4 cores with `timeoutSeconds = 2`: the
documented error fires, and a normal 4-core fit immediately afterwards in the
same session is bit-identical to a clean 1-core fit, so the kill leaves nothing
damaged behind.

**The supervisor itself**, exercised on cheap fake fits (17 checks, all passing):
the ok, error, died and timeout outcomes; a child's error message crossing the
fork verbatim, braces included; a fit child with two workers of its own killed
whole at the deadline, with no survivors, no zombies and no stragglers; and the
in-process fallback's three outcomes.

**e2e suite**: 17/17 with the new scenario wired into the `all` sweep, not just
into the registry. The server process had zero children left after the run.

**Cost**: the fork plus shipping the fit back through the pipe adds roughly half
a second per request (2.49s to 3.08s on the 40-row fixture, 16.72s to 17.25s at
n = 300, measured on an otherwise idle machine). That is the price of a budget
that can actually be enforced.

## What is different from #520

- **Failures are returned, not thrown.** The supervisor reports
  `ok`/`timeout`/`error`/`died` and `run_rtma_model` maps those to messages, so
  every user-facing string stays in one place and no classed condition has to be
  smuggled past a sibling `tryCatch` handler.
- **The kill ordering is fixed.** #520 killed the tree and then rescanned for
  survivors, but a rescan after the child dies finds nothing: orphans have been
  reparented to init and are no longer reachable by a ppid walk. Here the workers
  are killed first, while their parent is still alive to identify them, and the
  loop terminates on the set already signalled (killed workers linger as zombies
  of the live child) rather than on liveness, which also drops #520's five
  pointless passes over a zombie.
- **The child cannot outlive the call.** Cleanup hangs off `on.exit`, so an error
  raised in the handler or an interrupt delivered to the server kills the fit
  too, not only a timeout.
- **A `died` outcome**, distinct from a timeout: a child that vanishes without a
  result was killed from outside the request (in practice the OOM killer), which
  is not fixable by shrinking the runtime and should not be reported as if it
  were.
- **cli interpolation is safe**: an upstream error message containing braces used
  to take down the report of the error it described.
- **The scenario runs in CI.** #520 registered `rtma-timeout` but left it out of
  `run_all_scenarios`, which is the fixed sequence `all` actually runs, so it
  would never have run again after that PR. It is now step 10 of the sweep.
- **The scenario asserts something the old code would have failed.** A wall-clock
  ceiling alone is weak: it compares the timed-out request against the same fit
  succeeding (0.3s against 2.4s), which under `setTimeLimit` could only ever have
  come back slower, and it also covers rejection of a non-positive budget.
- **`timeoutSeconds` is validated** like `cores` above it: the legacy route hands
  parameters through unfiltered.
