### PR TITLE
test: stop e2e parameter-combination flake from bootstrap request timeout

### DIFF
--- a/apps/lambda-r-backend/r_scripts/tests/e2e/README.md
+++ b/apps/lambda-r-backend/r_scripts/tests/e2e/README.md
@@ -211,6 +211,8 @@ Each successful API call should return:
 
 4. **Port Conflicts**: If port 8787 is in use, start the API on a different port and use `--api-url`
 
+5. **Slow Requests Timing Out**: Requests default to a 30 second budget (`E2E_API_TIMEOUT`, in seconds). Most model fits answer in well under a second, but `standardErrorTreatment = "bootstrap"` refits the model 500 times and takes roughly 20 seconds, so scenarios exercising it set their own longer per-request timeout. Raise `E2E_API_TIMEOUT` rather than lowering it if a slow machine starts reporting timeouts.
+
 ### Debug Mode
 
 To run tests with more detailed output, modify the `verbose` parameter:

--- a/apps/lambda-r-backend/r_scripts/tests/e2e/run_e2e_tests.R
+++ b/apps/lambda-r-backend/r_scripts/tests/e2e/run_e2e_tests.R
@@ -311,7 +311,7 @@ run_all_scenarios <- function(api_url = NULL, verbose = TRUE) {
     passed_count <- passed_count + 1
     cat("   ✓ Parameter combinations test passed\n")
   } else {
-    cat("   ✗ Parameter combinations test failed\n")
+    cat("   ✗ Parameter combinations test failed:", param_result$error, "\n")
   }
   test_count <- test_count + 1
 

--- a/apps/lambda-r-backend/r_scripts/tests/e2e/scenarios/basic_maive_test.R
+++ b/apps/lambda-r-backend/r_scripts/tests/e2e/scenarios/basic_maive_test.R
@@ -63,15 +63,78 @@ test_basic_maive <- function() {
   )
 }
 
+#' Assert that a parameter combination actually took effect
+#'
+#' The generic assert_* helpers only check that the response is shaped like a
+#' MAIVE result, so every combination below would pass them even if the server
+#' ignored the parameters entirely. These checks tie each case to the switch it
+#' is there to exercise. They are safe to assert on: generate_test_data() is
+#' seeded and MAIVE seeds its own bootstrap, so the same input always produces
+#' the same output here.
+#'
+#' @param test_case One entry of the parameter-combination list
+#' @param data The `data` field of the API response
+assert_parameter_case <- function(test_case, data) {
+  params <- test_case$params
+
+  # Instrumenting is what produces a first stage; without it the server reports
+  # no F-statistic and omits the first-stage block.
+  f_statistic <- unlist(data$firstStageFStatistic)
+  first_stage_mode <- unlist(data$firstStage$mode)
+  if (isTRUE(params$shouldUseInstrumenting)) {
+    if (!is.numeric(f_statistic) || length(f_statistic) != 1 || !is.finite(f_statistic)) {
+      stop(sprintf(
+        "expected a finite first-stage F-statistic with instrumenting on, got '%s'",
+        paste(format(f_statistic), collapse = ", ")
+      ))
+    }
+    if (!identical(first_stage_mode, "levels")) {
+      stop(sprintf(
+        "expected a levels first stage, got '%s'",
+        paste(format(first_stage_mode), collapse = ", ")
+      ))
+    }
+  } else if (is.numeric(f_statistic)) {
+    stop("did not expect a first-stage F-statistic with instrumenting off")
+  }
+
+  # Only the bootstrap SE treatment returns bootstrapped standard errors; the
+  # clustered treatments leave the field as the string "NA".
+  boot_se <- unlist(data$bootSE)
+  if (identical(params$standardErrorTreatment, "bootstrap")) {
+    if (!is.numeric(boot_se) || length(boot_se) == 0 || any(!is.finite(boot_se))) {
+      stop(sprintf(
+        "expected finite bootstrapped standard errors, got '%s'",
+        paste(format(boot_se), collapse = ", ")
+      ))
+    }
+  } else if (is.numeric(boot_se)) {
+    stop(sprintf(
+      "did not expect bootstrapped standard errors with standardErrorTreatment '%s'",
+      params$standardErrorTreatment
+    ))
+  }
+}
+
 #' Test MAIVE with different parameter combinations
 #' @return Test results
 test_parameter_combinations <- function() {
   test_name <- "Parameter Combinations Test"
 
+  # The wild-cluster bootstrap refits the model 500 times, which takes roughly
+  # 20 seconds on the seeded 60-observation fixture and longer once the server
+  # has warmed up inside a full sweep. That sits close enough to the 30s default
+  # client timeout that the case used to fail intermittently under `--scenario
+  # all` while passing on its own, with no reason reported. Give the bootstrap
+  # path a budget matched to the work it asks for, so anything past it is a real
+  # hang rather than a slow machine.
+  bootstrap_timeout <- max(API_TIMEOUT, 180)
+
   # Test different parameter combinations
   test_cases <- list(
     list(
       name = "PET method",
+      timeout = API_TIMEOUT,
       params = list(
         modelType = "MAIVE",
         includeStudyDummies = TRUE,
@@ -87,6 +150,7 @@ test_parameter_combinations <- function() {
     ),
     list(
       name = "PEESE method",
+      timeout = API_TIMEOUT,
       params = list(
         modelType = "MAIVE",
         includeStudyDummies = FALSE,
@@ -102,6 +166,7 @@ test_parameter_combinations <- function() {
     ),
     list(
       name = "EK method",
+      timeout = bootstrap_timeout,
       params = list(
         modelType = "MAIVE",
         includeStudyDummies = TRUE,
@@ -120,11 +185,13 @@ test_parameter_combinations <- function() {
   results <- list()
 
   for (test_case in test_cases) {
-    tryCatch(
-      {
-        cat(sprintf("Testing %s...\n", test_case$name))
+    cat(sprintf("Testing %s...\n", test_case$name))
 
-        # Generate test data
+    started_at <- Sys.time()
+    outcome <- tryCatch(
+      {
+        # generate_test_data() reseeds on every call, so all three cases run
+        # against the same pinned fixture.
         test_data <- generate_test_data(n_studies = 20, include_study_id = TRUE)
 
         # Convert to JSON
@@ -132,39 +199,56 @@ test_parameter_combinations <- function() {
         params_json <- params_to_json(test_case$params)
 
         # Call API
-        response <- test_run_model(file_data_json, params_json)
+        response <- test_run_model(file_data_json, params_json, timeout = test_case$timeout)
 
         # Validate response
         assert_response_structure(response)
         assert_maive_results(response)
+        assert_parameter_case(test_case, response$data)
 
-        results[[test_case$name]] <- list(
-          status = "PASS",
-          results = response$data
-        )
+        list(status = "PASS", results = response$data)
       },
-      error = function(e) {
-        results[[test_case$name]] <<- list(
-          status = "FAIL",
-          error = e$message
-        )
-      }
+      error = function(e) list(status = "FAIL", error = conditionMessage(e))
     )
+
+    # Report the elapsed time for every case: the bootstrap case is slow enough
+    # that a creeping runtime is the first sign this test is heading back
+    # towards its timeout.
+    outcome$elapsed_seconds <- as.numeric(difftime(Sys.time(), started_at, units = "secs"))
+    cat(sprintf("  %s: %s (%.1fs)\n", test_case$name, outcome$status, outcome$elapsed_seconds))
+    if (outcome$status == "FAIL") {
+      cat(sprintf("    %s\n", outcome$error))
+    }
+
+    results[[test_case$name]] <- outcome
   }
 
   # Check overall results
-  passed_tests <- sum(sapply(results, function(x) x$status == "PASS"))
+  failed_cases <- names(results)[vapply(results, function(x) x$status == "FAIL", logical(1))]
   total_tests <- length(results)
 
-  if (passed_tests == total_tests) {
+  if (length(failed_cases) == 0) {
     log_test_result(test_name, "PASS", sprintf("All %d parameter combinations passed", total_tests))
+    failure_detail <- NULL
   } else {
-    log_test_result(test_name, "FAIL", sprintf("%d/%d parameter combinations failed", total_tests - passed_tests, total_tests))
+    failure_detail <- paste(
+      vapply(
+        failed_cases,
+        function(name) sprintf("%s: %s", name, results[[name]]$error),
+        character(1)
+      ),
+      collapse = "; "
+    )
+    log_test_result(test_name, "FAIL", sprintf(
+      "%d/%d parameter combinations failed (%s)",
+      length(failed_cases), total_tests, failure_detail
+    ))
   }
 
   return(list(
-    status = ifelse(passed_tests == total_tests, "PASS", "FAIL"),
+    status = if (length(failed_cases) == 0) "PASS" else "FAIL",
     test_name = test_name,
+    error = failure_detail,
     results = results
   ))
 }


### PR DESCRIPTION
## What was flaky

The `parameters` e2e scenario (`test_parameter_combinations`) reported FAIL in a full `--scenario all` sweep, then passed on its own immediately afterwards.

The cause is not statistical. `generate_test_data()` is seeded, and MAIVE seeds its own wild-cluster bootstrap, so all three cases return byte-identical payloads on repeated calls (verified with `identical()` on two calls per case).

What fails is the HTTP client giving up. The "EK method" case is the only one using `standardErrorTreatment = "bootstrap"`, which refits the model 500 times over the 60-observation fixture with 21 regressors. Measured wall-clock for that one request, across runs against a locally hosted server:

```
16.3  16.4  16.5  17.1  17.4  17.6  18.6  21.2  23.1  23.5  40.0  47.3   seconds
```

`API_TIMEOUT` defaults to 30s. The 40.0s and 47.3s samples both came from sweeps run against a server already warmed by an earlier sweep, which is the process-state dependence that made this look intermittent.

Reproduced deterministically with `E2E_API_TIMEOUT=15`: `1/3 parameter combinations failed`, with a blank reason. The blank reason was a second defect: the aggregate result carried no `error` field, so the runner printed `failed:` with nothing after it and discarded the per-case message.

Unrelated: the "Publication bias p-value is high" warning in the same output is a plain `warning()` in `publication_bias_test.R`, deferred by R to the end of the script, so it prints at the end of every sweep including passing ones.

## Changes

- Per-case request timeout. The bootstrap case gets `max(API_TIMEOUT, 180)`; the other two keep the default. A slow machine now reports a slow test rather than a failed one, while a genuine hang still trips.
- New `assert_parameter_case()` so each case checks the switch it exists to exercise rather than only response shape: instrumenting on implies a finite first-stage F and a `levels` first stage, off implies neither; `standardErrorTreatment = "bootstrap"` implies finite bootstrapped SEs, the clustered treatments imply none. All deterministic on the pinned fixture; each branch was negative-tested.
- Failures name the case and its error, in the log line and in the returned `error` field. Per-case elapsed seconds are reported so a creeping runtime is visible before it becomes a failure again.
- Replaced the `<<-` in the error handler with a plain `tryCatch` return value.
- Runner prints the parameter-combination failure reason.
- Troubleshooting note in the e2e README about `E2E_API_TIMEOUT` and the bootstrap path.

## Verification

Six consecutive full sweeps against one long-lived local server, all 17/17. EK case timings across those six: 17.4, 40.0, 23.1, 17.6, 47.3, 21.2 seconds. Two of six crossed the old 30s ceiling, so the previous code would have failed roughly a third of full sweeps.

`lintr::lint()` reports no lints, and `styler` leaves the changed file unchanged (styled against a scratch copy, not in place).
