### PR TITLE
style: unify page spacing behind shared shell, header, and stack classes

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -6,6 +6,13 @@
       "runtimeExecutable": "npm",
       "runtimeArgs": ["run", "ui:dev"],
       "port": 3000
+    },
+    {
+      "name": "react-ui-prod",
+      "runtimeExecutable": "npx",
+      "runtimeArgs": ["next", "start", "-p", "3001"],
+      "cwd": "apps/react-ui/client",
+      "port": 3001
     }
   ]
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -311,6 +311,25 @@ The app uses a combination of Tailwind CSS and shared style utilities for consis
 - Dark mode support via `.dark` class prefix
 - Use these for page-level layouts and major UI elements
 
+**Page Layout Primitives** (`src/styles/globals.css`):
+
+Every content page follows the same skeleton, so vertical rhythm is decided in one place rather than per page:
+
+```jsx
+<main className="content-page-container">   {/* page gutter + background */}
+  <div className="page-shell">              {/* centred column, width modifier optional */}
+    <div className="page-header">…title, description, title-row controls…</div>
+    <div className="page-stack">…cards, alert stacks, action rows…</div>
+  </div>
+</main>
+```
+
+- `.page-shell` centres the column at 56rem. Modifiers: `.page-shell-narrow` (48rem), `.page-shell-wide` (64rem), `.page-shell-full` (80rem). **Never add horizontal padding to a shell**: the gutter belongs to `.content-page-container`, and a second gutter makes that page narrower than its neighbours.
+- `.page-header` owns the gap under a page's title block (`--page-header-gap`). Put it on the wrapper, not the heading, so the gap does not shift when a description is present.
+- `.page-stack` owns the gap between top-level blocks (`--page-block-gap`) via `> * + *`. **Do not also put `mt-*`/`mb-*` on its children** - the two stack and double the gap.
+- Inside a card, use Tailwind `space-y-*` or `gap-*`, but only one mechanism per container. Mixing `gap-6` with `mb-2` on the children is how the gaps drifted apart in the first place.
+- Prefer `SectionHeading`'s `description` prop over a hand-rolled `<p>` under the heading; it carries the right typography and internal spacing.
+
 **Form Styles** (`src/styles/formStyles.ts`):
 
 - Shared constants for form elements (inputs, selects, buttons)
@@ -322,7 +341,7 @@ The app uses a combination of Tailwind CSS and shared style utilities for consis
 
 **When to use each approach**:
 
-- **Global CSS classes**: Page containers, cards, primary/secondary buttons via ActionButton component
+- **Global CSS classes**: Page containers, page shells/headers/stacks, cards, primary/secondary buttons via ActionButton component
 - **Form style constants**: All form inputs, selects, labels, and form-specific buttons
 - **Inline Tailwind**: Layout utilities (flex, grid, spacing), one-off styling exceptions
 - **Component-specific styles**: Only when truly unique to that component

--- a/apps/react-ui/client/src/pages/_app.tsx
+++ b/apps/react-ui/client/src/pages/_app.tsx
@@ -21,7 +21,9 @@ export default function App({ Component, pageProps }: AppProps) {
       <RunsWatcher />
       <div className="flex flex-col min-h-screen">
         {!isHomePage && <Header />}
-        <main className="flex-1 flex-col">
+        {/* `flex` is load-bearing: without it `flex-col` is inert and the page
+            container's `flex: 1` has no flex parent to grow into. */}
+        <main className="flex flex-1 flex-col">
           <Component {...pageProps} />
         </main>
         <Footer />

--- a/apps/react-ui/client/src/pages/about.tsx
+++ b/apps/react-ui/client/src/pages/about.tsx
@@ -21,7 +21,7 @@ export default function AboutPage() {
         />
       </Head>
       <main className="content-page-container">
-        <div className="max-w-5xl w-full px-2 sm:px-0">
+        <div className="page-shell page-shell-wide">
           <GoBackButton href="/" text="Back to Home" />
 
           <div className="card p-6 sm:p-8 space-y-8">

--- a/apps/react-ui/client/src/pages/api-docs.tsx
+++ b/apps/react-ui/client/src/pages/api-docs.tsx
@@ -100,7 +100,7 @@ export default function ApiDocsPage() {
         />
       </Head>
       <main className="content-page-container">
-        <div className="max-w-5xl w-full px-2 sm:px-0">
+        <div className="page-shell page-shell-wide">
           <GoBackButton href="/" text="Back to Home" />
 
           <div className="card p-6 sm:p-8 space-y-10">

--- a/apps/react-ui/client/src/pages/compare/index.tsx
+++ b/apps/react-ui/client/src/pages/compare/index.tsx
@@ -152,8 +152,8 @@ export default function ComparePage() {
         <title>{`${CONST.APP_DISPLAY_NAME} - Compare Runs`}</title>
       </Head>
       <main className="content-page-container">
-        <div className="mx-auto w-full max-w-7xl">
-          <div className="mb-4 flex items-center justify-between">
+        <div className="page-shell page-shell-full">
+          <div className="page-header flex items-center justify-between gap-4">
             <SectionHeading level="h1" text="Compare Runs" />
             <ActionButton
               variant="secondary"

--- a/apps/react-ui/client/src/pages/demo.tsx
+++ b/apps/react-ui/client/src/pages/demo.tsx
@@ -77,9 +77,11 @@ export default function DemoPage() {
       </Head>
 
       <main className="content-page-container">
+        {/* No horizontal padding here: `content-page-container` already
+            provides the page gutter. */}
         <div
-          className={`flex w-full flex-1 justify-center px-4 ${
-            isLoading ? "items-start pt-16 pb-12" : "items-center py-12"
+          className={`flex w-full flex-1 justify-center ${
+            isLoading ? "items-start pt-16" : "items-center"
           }`}
         >
           {hasError ? (

--- a/apps/react-ui/client/src/pages/index.tsx
+++ b/apps/react-ui/client/src/pages/index.tsx
@@ -99,7 +99,7 @@ export default function Home() {
         <title>{`${CONST.APP_DISPLAY_NAME} - Welcome`}</title>
       </Head>
       <main className="home-page-container">
-        <div className="max-w-4xl text-center animate-fade-in px-3 sm:px-0">
+        <div className="page-shell text-center animate-fade-in">
           <h1 className="text-4xl sm:text-5xl font-bold mb-6 text-primary tracking-tight">
             {TEXT.home.title}
           </h1>

--- a/apps/react-ui/client/src/pages/model/index.tsx
+++ b/apps/react-ui/client/src/pages/model/index.tsx
@@ -1003,7 +1003,7 @@ export default function ModelPage() {
             <SectionHeading
               level="h1"
               text="No data selected"
-              className="mb-4"
+              className="page-header"
             />
             <GoBackButton
               href="/upload"
@@ -1012,7 +1012,7 @@ export default function ModelPage() {
             />
           </div>
         ) : (
-          <div className="max-w-4xl w-full">
+          <div className="page-shell">
             <GoBackButton
               href={`/validation?dataId=${dataId}`}
               text="Back to Validation"
@@ -1027,9 +1027,11 @@ export default function ModelPage() {
                   showWarmupHint={showWarmupHint}
                 />
               ) : (
-                <div className="bg-white dark:bg-gray-800 p-8 rounded-xl shadow-lg border border-gray-100 dark:border-gray-700 transition-all duration-500 opacity-100 scale-100">
+                <div className="bg-white dark:bg-gray-800 p-6 sm:p-8 rounded-xl shadow-lg border border-gray-100 dark:border-gray-700 transition-all duration-500 opacity-100 scale-100">
+                  {/* `gap-6` owns every gap in this column; children must not
+                      add margins of their own on top of it. */}
                   <div className="flex flex-col gap-6">
-                    <div className="flex items-center mb-2">
+                    <div className="flex items-center gap-4">
                       <div className="flex-grow">
                         <SectionHeading level="h1" text="Model Parameters" />
                       </div>
@@ -1037,12 +1039,10 @@ export default function ModelPage() {
                         <HelpButton modalComponent={ParametersHelpModal} />
                       )}
                     </div>
-                    <div className="mb-2">
-                      <p className="text-gray-700 dark:text-gray-300">
-                        Please select the model type and parameters you would
-                        like to use.
-                      </p>
-                    </div>
+                    <p className="text-gray-700 dark:text-gray-300">
+                      Please select the model type and parameters you would like
+                      to use.
+                    </p>
                     <div className="space-y-6">
                       <OptionSection
                         config={modelOptionsConfig.basic}

--- a/apps/react-ui/client/src/pages/results/index.tsx
+++ b/apps/react-ui/client/src/pages/results/index.tsx
@@ -256,7 +256,11 @@ export default function ResultsPage() {
     if (runExpired) {
       body = (
         <div className="text-center">
-          <SectionHeading level="h1" text="Run expired" className="mb-4" />
+          <SectionHeading
+            level="h1"
+            text="Run expired"
+            className="page-header"
+          />
           <p className="mb-6 text-gray-600 dark:text-gray-300">
             Results are only kept for 48 hours after a run is submitted, so this
             run is no longer available. Please run the analysis again.
@@ -272,7 +276,11 @@ export default function ResultsPage() {
     } else if (runFailed) {
       body = (
         <div className="text-center">
-          <SectionHeading level="h1" text="Run failed" className="mb-4" />
+          <SectionHeading
+            level="h1"
+            text="Run failed"
+            className="page-header"
+          />
           <p className="mb-6 text-gray-600 dark:text-gray-300">
             {runStatus.errorMessage ??
               "The analysis did not complete. Please try again."}
@@ -310,7 +318,7 @@ export default function ResultsPage() {
             <SectionHeading
               level="h1"
               text="No results available"
-              className="mb-4"
+              className="page-header"
             />
             <GoBackButton
               href="/upload"
@@ -493,17 +501,20 @@ export default function ResultsPage() {
         <title>{`${CONST.APP_DISPLAY_NAME} - Results`}</title>
       </Head>
       <main className="content-page-container">
-        <div className="max-w-4xl w-full space-y-8 px-2 sm:px-0">
-          <div className="bg-white dark:bg-gray-800 p-6 sm:p-8 rounded-xl shadow-lg border border-gray-100 dark:border-gray-700 mb-8">
+        <div className="page-shell page-stack">
+          <div className="bg-white dark:bg-gray-800 p-6 sm:p-8 rounded-xl shadow-lg border border-gray-100 dark:border-gray-700">
             {allRunsLink && <div className="mb-4">{allRunsLink}</div>}
-            <SectionHeading level="h1" text="Model Results" className="mb-6" />
+            <SectionHeading
+              level="h1"
+              text="Model Results"
+              className="page-header"
+            />
 
             <div className="space-y-6">
               {isWaiveModel && (
                 <Alert
                   message={TEXT.waive.cautionNote}
                   type={CONST.ALERT_TYPES.WARNING}
-                  className="mt-0"
                 />
               )}
               {activeFilterSummary ? (
@@ -658,7 +669,7 @@ export default function ResultsPage() {
             />
           )}
 
-          <div className="flex flex-col gap-6 mt-8 lg:flex-row">
+          <div className="flex flex-col gap-6 lg:flex-row">
             {/* Left Column - Current Run Actions */}
             <div className="flex flex-col gap-4 flex-1">
               <div className="flex items-center gap-2 mb-2">

--- a/apps/react-ui/client/src/pages/runs/index.tsx
+++ b/apps/react-ui/client/src/pages/runs/index.tsx
@@ -107,9 +107,17 @@ export default function RunsPage() {
         <title>{`${CONST.APP_DISPLAY_NAME} - My Runs`}</title>
       </Head>
       <main className="content-page-container">
-        <div className="mx-auto w-full max-w-3xl">
-          <div className="mb-1 flex items-center justify-between">
-            <SectionHeading level="h1" text="My Runs" />
+        <div className="page-shell page-shell-narrow">
+          <div className="page-header flex items-start justify-between gap-4">
+            <SectionHeading
+              level="h1"
+              text="My Runs"
+              description={
+                runsList.length > 0
+                  ? "Runs are saved on this device only."
+                  : undefined
+              }
+            />
             {runsList.length > 0 && (
               <ActionButton
                 variant="secondary"
@@ -120,12 +128,6 @@ export default function RunsPage() {
               </ActionButton>
             )}
           </div>
-
-          {runsList.length > 0 && (
-            <p className="mb-4 text-sm text-gray-500 dark:text-gray-400">
-              Runs are saved on this device only.
-            </p>
-          )}
 
           {anyComparable && (
             <div className="mb-4 flex flex-wrap items-center justify-between gap-2">

--- a/apps/react-ui/client/src/pages/upload/index.tsx
+++ b/apps/react-ui/client/src/pages/upload/index.tsx
@@ -153,13 +153,13 @@ export default function UploadPage() {
         <title>{`${CONST.APP_DISPLAY_NAME} - Upload Data`}</title>
       </Head>
       <main className="content-page-container">
-        <div className="max-w-4xl w-full px-2 sm:px-0">
+        <div className="page-shell">
           <GoBackButton href="/" text="Back to Home" />
           <div className="card p-6 sm:p-8">
             <SectionHeading
               level="h1"
               text={TEXT.upload.title}
-              className="mb-6"
+              className="page-header"
             />
             <div className="mb-6">
               <p className="text-secondary mb-2">{TEXT.upload.description}</p>

--- a/apps/react-ui/client/src/pages/validation/index.tsx
+++ b/apps/react-ui/client/src/pages/validation/index.tsx
@@ -1010,192 +1010,195 @@ export default function ValidationPage() {
         <title>{`${CONST.APP_DISPLAY_NAME} - Validation`}</title>
       </Head>
       <main className="content-page-container">
-        <div className="max-w-4xl w-full px-2 sm:px-0">
+        <div className="page-shell">
           <GoBackButton href={backLink} text="Back to Upload" />
 
-          <div className="card p-6 sm:p-8 space-y-4">
-            <SectionHeading level="h1" text={TEXT.validation.title} />
-            <p className="text-secondary">{TEXT.validation.description}</p>
-            <p className="text-muted text-sm">{TEXT.validation.helperText}</p>
-          </div>
-
-          {loading ? (
-            <div className="card p-6 sm:p-8 mt-6 text-center">
-              <p className="text-secondary">{TEXT.validation.loading}</p>
+          <div className="page-stack">
+            <div className="card p-6 sm:p-8 space-y-4">
+              <SectionHeading level="h1" text={TEXT.validation.title} />
+              <p className="text-secondary">{TEXT.validation.description}</p>
+              <p className="text-muted text-sm">{TEXT.validation.helperText}</p>
             </div>
-          ) : !uploadedData ? (
-            <div className="card p-6 sm:p-8 mt-6 space-y-4 text-center">
-              <SectionHeading
-                level="h2"
-                text={TEXT.validation.missingDataTitle}
-              />
-              <p className="text-secondary">
-                {TEXT.validation.missingDataMessage}
-              </p>
-              <ActionButton
-                onClick={() => {
-                  router.push("/upload");
-                }}
-                variant="primary"
-                className="mx-auto w-full sm:w-auto"
-              >
-                Back to Upload
-              </ActionButton>
-            </div>
-          ) : (
-            <div className="space-y-6 mt-6">
-              <div className="card p-6 sm:p-8 space-y-6">
-                <div>
-                  <SectionHeading
-                    level="h2"
-                    text={TEXT.mapping.title}
-                    icon={<FaTable />}
-                    description={TEXT.mapping.description}
-                    className="mb-2"
-                  />
-                  <p className="text-muted text-sm">
-                    {TEXT.mapping.helperText}
-                  </p>
-                </div>
 
-                {autoMappingApplied && (
-                  <div className="rounded-lg border border-blue-200 dark:border-blue-800 bg-blue-50 dark:bg-blue-900/20 p-4 text-sm text-blue-900 dark:text-blue-100">
-                    {TEXT.mapping.autoMappingNotice}
-                  </div>
-                )}
-
-                <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                  {(
-                    Object.keys(TEXT.mapping.fieldLabels) as Array<
-                      keyof typeof TEXT.mapping.fieldLabels
-                    >
-                  ).map((fieldKey) => {
-                    const label = TEXT.mapping.fieldLabels[fieldKey];
-                    const isRequired = REQUIRED_FIELDS.includes(
-                      fieldKey as keyof ColumnMapping,
-                    );
-
-                    return (
-                      <div key={fieldKey} className="flex flex-col">
-                        <label className="text-sm font-medium text-secondary mb-2">
-                          {label}
-                          {isRequired ? (
-                            <span className="text-red-500">*</span>
-                          ) : null}
-                        </label>
-                        <select
-                          className="rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900/40 text-gray-900 dark:text-gray-100 p-2 focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/40"
-                          value={mapping[fieldKey as keyof MappingState] ?? ""}
-                          onChange={(event) =>
-                            handleMappingChange(
-                              fieldKey as keyof MappingState,
-                              event.target.value,
-                            )
-                          }
-                        >
-                          <option value="">
-                            {isRequired ? "Select a column" : "Leave unmapped"}
-                          </option>
-                          {availableColumns.map((column) => (
-                            <option
-                              key={column}
-                              value={column}
-                              disabled={
-                                mapping[fieldKey as keyof MappingState] !==
-                                  column && usedColumns.has(column)
-                              }
-                            >
-                              {column}
-                            </option>
-                          ))}
-                        </select>
-                      </div>
-                    );
-                  })}
-                </div>
-
-                {CONFIG.SHOULD_SHOW_RAW_DATA_PREVIEW && (
-                  <DataPreview
-                    title={TEXT.mapping.rawPreviewTitle}
-                    headers={availableColumns}
-                    rows={rawPreviewRows}
-                  />
-                )}
-
-                <div className="space-y-4">
-                  <DataPreview
-                    title={TEXT.mapping.mappedPreviewTitle}
-                    description={TEXT.mapping.mappedPreviewDescription}
-                    headers={mappedPreviewHeaders}
-                    rows={mappedPreviewRows}
-                    emptyMessage={TEXT.mapping.validationIncomplete}
-                  />
-                  {normalizedData.length > 0 &&
-                    CONFIG.SHOULD_SHOW_DF_ROWS_INFO && (
-                      <RowInfoComponent
-                        rowCount={normalizedData.length}
-                        showFirstRows={normalizedData.length > 5}
-                        rowCountToShow={5}
-                      />
-                    )}
-                </div>
+            {loading ? (
+              <div className="card p-6 sm:p-8 text-center">
+                <p className="text-secondary">{TEXT.validation.loading}</p>
               </div>
+            ) : !uploadedData ? (
+              <div className="card p-6 sm:p-8 space-y-4 text-center">
+                <SectionHeading
+                  level="h2"
+                  text={TEXT.validation.missingDataTitle}
+                />
+                <p className="text-secondary">
+                  {TEXT.validation.missingDataMessage}
+                </p>
+                <ActionButton
+                  onClick={() => {
+                    router.push("/upload");
+                  }}
+                  variant="primary"
+                  className="mx-auto w-full sm:w-auto"
+                >
+                  Back to Upload
+                </ActionButton>
+              </div>
+            ) : (
+              <div className="page-stack">
+                <div className="card p-6 sm:p-8 space-y-6">
+                  <div>
+                    <SectionHeading
+                      level="h2"
+                      text={TEXT.mapping.title}
+                      icon={<FaTable />}
+                      description={TEXT.mapping.description}
+                      className="mb-2"
+                    />
+                    <p className="text-muted text-sm">
+                      {TEXT.mapping.helperText}
+                    </p>
+                  </div>
 
-              <SubsampleFilterCard
-                isEnabled={isFilterEnabled}
-                onToggle={handleFilterToggle}
-                columns={availableColumns}
-                rootGroup={filterGroup}
-                onRootGroupChange={setFilterGroup}
-                matchedRowCount={filterEvaluation.displayMatchedRowCount}
-                totalRowCount={filterEvaluation.totalRowCount}
-                statusMessage={filterEvaluation.statusMessage}
-              />
+                  {autoMappingApplied && (
+                    <div className="rounded-lg border border-blue-200 dark:border-blue-800 bg-blue-50 dark:bg-blue-900/20 p-4 text-sm text-blue-900 dark:text-blue-100">
+                      {TEXT.mapping.autoMappingNotice}
+                    </div>
+                  )}
 
-              <div className="card p-6 sm:p-8 space-y-4">
-                <div>
+                  <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                    {(
+                      Object.keys(TEXT.mapping.fieldLabels) as Array<
+                        keyof typeof TEXT.mapping.fieldLabels
+                      >
+                    ).map((fieldKey) => {
+                      const label = TEXT.mapping.fieldLabels[fieldKey];
+                      const isRequired = REQUIRED_FIELDS.includes(
+                        fieldKey as keyof ColumnMapping,
+                      );
+
+                      return (
+                        <div key={fieldKey} className="flex flex-col">
+                          <label className="text-sm font-medium text-secondary mb-2">
+                            {label}
+                            {isRequired ? (
+                              <span className="text-red-500">*</span>
+                            ) : null}
+                          </label>
+                          <select
+                            className="rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900/40 text-gray-900 dark:text-gray-100 p-2 focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/40"
+                            value={
+                              mapping[fieldKey as keyof MappingState] ?? ""
+                            }
+                            onChange={(event) =>
+                              handleMappingChange(
+                                fieldKey as keyof MappingState,
+                                event.target.value,
+                              )
+                            }
+                          >
+                            <option value="">
+                              {isRequired
+                                ? "Select a column"
+                                : "Leave unmapped"}
+                            </option>
+                            {availableColumns.map((column) => (
+                              <option
+                                key={column}
+                                value={column}
+                                disabled={
+                                  mapping[fieldKey as keyof MappingState] !==
+                                    column && usedColumns.has(column)
+                                }
+                              >
+                                {column}
+                              </option>
+                            ))}
+                          </select>
+                        </div>
+                      );
+                    })}
+                  </div>
+
+                  {CONFIG.SHOULD_SHOW_RAW_DATA_PREVIEW && (
+                    <DataPreview
+                      title={TEXT.mapping.rawPreviewTitle}
+                      headers={availableColumns}
+                      rows={rawPreviewRows}
+                    />
+                  )}
+
+                  <div className="space-y-4">
+                    <DataPreview
+                      title={TEXT.mapping.mappedPreviewTitle}
+                      description={TEXT.mapping.mappedPreviewDescription}
+                      headers={mappedPreviewHeaders}
+                      rows={mappedPreviewRows}
+                      emptyMessage={TEXT.mapping.validationIncomplete}
+                    />
+                    {normalizedData.length > 0 &&
+                      CONFIG.SHOULD_SHOW_DF_ROWS_INFO && (
+                        <RowInfoComponent
+                          rowCount={normalizedData.length}
+                          showFirstRows={normalizedData.length > 5}
+                          rowCountToShow={5}
+                        />
+                      )}
+                  </div>
+                </div>
+
+                <SubsampleFilterCard
+                  isEnabled={isFilterEnabled}
+                  onToggle={handleFilterToggle}
+                  columns={availableColumns}
+                  rootGroup={filterGroup}
+                  onRootGroupChange={setFilterGroup}
+                  matchedRowCount={filterEvaluation.displayMatchedRowCount}
+                  totalRowCount={filterEvaluation.totalRowCount}
+                  statusMessage={filterEvaluation.statusMessage}
+                />
+
+                <div className="card p-6 sm:p-8 space-y-6">
                   <SectionHeading
                     level="h2"
                     text={TEXT.validation.resultsTitle}
                     icon={<FaCheckCircle />}
                     description={TEXT.validation.resultsDescription}
-                    className="mb-2"
                   />
+
+                  {!mappingComplete || !validationResult ? (
+                    <Alert
+                      type={CONST.ALERT_TYPES.INFO}
+                      message={TEXT.mapping.validationIncomplete}
+                    />
+                  ) : (
+                    <div className="space-y-3">
+                      {validationResult.messages.map((item, index) => (
+                        <Alert
+                          key={`${item.type}-${index}`}
+                          type={item.type}
+                          message={item.message}
+                        />
+                      ))}
+                    </div>
+                  )}
+
+                  <ActionButton
+                    ref={continueButtonRef}
+                    onClick={handleContinue}
+                    variant="primary"
+                    className="w-full"
+                    disabled={
+                      !validationResult?.isValid ||
+                      (filterEvaluation.hasActiveFilter &&
+                        filterEvaluation.hasNoMatches)
+                    }
+                  >
+                    {TEXT.validation.continueButton}
+                  </ActionButton>
                 </div>
-
-                {!mappingComplete || !validationResult ? (
-                  <Alert
-                    type={CONST.ALERT_TYPES.INFO}
-                    message={TEXT.mapping.validationIncomplete}
-                  />
-                ) : (
-                  <div className="space-y-3">
-                    {validationResult.messages.map((item, index) => (
-                      <Alert
-                        key={`${item.type}-${index}`}
-                        type={item.type}
-                        message={item.message}
-                      />
-                    ))}
-                  </div>
-                )}
-
-                <ActionButton
-                  ref={continueButtonRef}
-                  onClick={handleContinue}
-                  variant="primary"
-                  className="w-full"
-                  disabled={
-                    !validationResult?.isValid ||
-                    (filterEvaluation.hasActiveFilter &&
-                      filterEvaluation.hasNoMatches)
-                  }
-                >
-                  {TEXT.validation.continueButton}
-                </ActionButton>
               </div>
-            </div>
-          )}
+            )}
+          </div>
         </div>
       </main>
     </>

--- a/apps/react-ui/client/src/styles/globals.css
+++ b/apps/react-ui/client/src/styles/globals.css
@@ -488,6 +488,11 @@ body {
 		@apply page-container-light dark:page-container-dark;
 		padding: var(--spacing-xl) var(--spacing-md);
 		justify-content: center; /* Override the default flex-start */
+		/* The landing hero deliberately claims the whole viewport (there is no
+		   header on this page), so the footer starts below the fold and only
+		   appears once the visitor scrolls. Content pages do the opposite and
+		   size to their content - see .page-container-base. */
+		min-height: 100vh;
 	}
 
 	.content-page-container {

--- a/apps/react-ui/client/src/styles/globals.css
+++ b/apps/react-ui/client/src/styles/globals.css
@@ -51,13 +51,26 @@
 		color var(--transition-normal), background-color var(--transition-normal),
 		border-color var(--transition-normal), box-shadow var(--transition-normal);
 
-	/* Spacing */
+	/* Spacing scale. Lines up with Tailwind's: xs=1, sm=2, md=4, lg=6, xl=8,
+	   2xl=12, so var(--spacing-lg) and mb-6 are the same 1.5rem. */
 	--spacing-xs: 0.25rem;
 	--spacing-sm: 0.5rem;
 	--spacing-md: 1rem;
 	--spacing-lg: 1.5rem;
 	--spacing-xl: 2rem;
 	--spacing-2xl: 3rem;
+
+	/* Page rhythm, consumed by .page-header and .page-stack below. The gap under
+	   a page title and the gap between top-level page blocks are decided here
+	   once, not re-picked per page. */
+	--page-header-gap: var(--spacing-lg);
+	--page-block-gap: var(--spacing-xl);
+
+	/* Page shell widths */
+	--page-width-narrow: 48rem;
+	--page-width-default: 56rem;
+	--page-width-wide: 64rem;
+	--page-width-full: 80rem;
 
 	/* Border radius */
 	--radius-sm: 0.375rem;
@@ -438,7 +451,11 @@ body {
 
 	/* Page container abstractions */
 	.page-container-base {
-		min-height: 100vh;
+		/* Fills the space `main` hands down (the viewport minus header and
+		   footer). A fixed 100vh here overflowed every page by exactly the
+		   header + footer height, so even short pages scrolled. */
+		flex: 1;
+		min-height: 0;
 		display: flex;
 		flex-direction: column;
 		align-items: center;
@@ -467,31 +484,67 @@ body {
 	}
 
 	/* Common page layouts */
-        .home-page-container {
-                @apply page-container-light dark:page-container-dark;
-                padding: var(--spacing-xl) var(--spacing-md);
-                justify-content: center; /* Override the default flex-start */
-        }
+	.home-page-container {
+		@apply page-container-light dark:page-container-dark;
+		padding: var(--spacing-xl) var(--spacing-md);
+		justify-content: center; /* Override the default flex-start */
+	}
 
-        .content-page-container {
-                @apply page-container-base;
-                flex: 1;
-                padding: var(--spacing-xl) var(--spacing-md);
-                background-image: linear-gradient(to bottom, #fff, #f9fafb, #f3f4f6);
-        }
+	.content-page-container {
+		@apply page-container-base;
+		padding: var(--spacing-xl) var(--spacing-md);
+		background-image: linear-gradient(to bottom, #fff, #f9fafb, #f3f4f6);
+	}
 
-        @media (min-width: 768px) {
-                .home-page-container {
-                        padding: var(--spacing-2xl) var(--spacing-lg);
-                }
+	@media (min-width: 768px) {
+		.home-page-container {
+			padding: var(--spacing-2xl) var(--spacing-lg);
+		}
 
-                .content-page-container {
-                        padding: var(--spacing-2xl);
-                }
-        }
+		.content-page-container {
+			padding: var(--spacing-2xl);
+		}
+	}
 
 	.dark .content-page-container {
 		background-image: linear-gradient(to bottom, #111827, #1f2937, #111827);
+	}
+
+	/* Page shell: the centred column a content page puts everything in. The
+	   horizontal gutter belongs to .content-page-container, so a shell must not
+	   add padding of its own - that is what left some pages 8px narrower than
+	   others on phones. */
+	.page-shell {
+		width: 100%;
+		margin-left: auto;
+		margin-right: auto;
+		max-width: var(--page-width-default);
+	}
+
+	.page-shell-narrow {
+		max-width: var(--page-width-narrow);
+	}
+
+	.page-shell-wide {
+		max-width: var(--page-width-wide);
+	}
+
+	.page-shell-full {
+		max-width: var(--page-width-full);
+	}
+
+	/* Space under a page's title block: the heading, its description, and any
+	   controls on the title row. Goes on the wrapper rather than the heading, so
+	   the gap stays the same whether or not a description is rendered. */
+	.page-header {
+		margin-bottom: var(--page-header-gap);
+	}
+
+	/* Rhythm between a page's top-level blocks: cards, alert stacks, action
+	   rows. Use this instead of margins on the blocks themselves, which used to
+	   stack with the parent's own spacing and double the gap. */
+	.page-stack > * + * {
+		margin-top: var(--page-block-gap);
 	}
 
 	/* Animation classes */


### PR DESCRIPTION
## What prompted this

The `My Runs` heading had almost no space under it (`mb-1`, 4px). That turned out to be one symptom of a broader issue: there was no defined vertical rhythm for pages, so each page invented its own.

## What was wrong

Audited every page. Four classes of problem:

**1. No shared rule for the gap under a page title.** Values in use: `mb-1` (runs), `mb-4` (compare), `mb-6` (upload, results), `space-y-4` (validation), nothing at all (model).

**2. Every page hand-rolled its shell.** `max-w-3xl` / `4xl` / `5xl` / `7xl`, sometimes with `mx-auto`, sometimes relying on the container's `align-items: center`. Five pages added `px-2 sm:px-0` on top of the gutter `.content-page-container` already provides, making them 8px narrower than their neighbours on phones.

**3. Competing spacing mechanisms stacking up.**
- Results: parent `space-y-8` + `mb-8` on the card + `mt-8` on the actions row, three declarations fighting over one gap.
- Model: `flex flex-col gap-6` with `mb-2` on two of the children.
- Validation: `<div>` wrapping a single `SectionHeading` purely so a `mb-2` would land inside the parent's `space-y-4`.
- Results also carried an `Alert className="mt-0"` cancelling a margin `Alert` does not have.

**4. Every page scrolled, even empty ones.** `.page-container-base` had `min-height: 100vh` while `main` in `_app.tsx` was `flex-1 flex-col` without `flex`, so `flex-col` was inert and the container's `flex: 1` had no flex parent. Every page was viewport-height *plus* header *plus* footer. On a 720px viewport the empty My Runs page was 936px tall: a scrollbar and ~200px of dead space under the content.

## What changed

Added page-layout primitives to `globals.css`, driven by two tokens (`--page-header-gap`, `--page-block-gap`):

- `.page-shell` (+ `-narrow` / `-wide` / `-full`) - centred column, no gutter of its own
- `.page-header` - the gap under a title block, on the wrapper so it does not move when a description appears
- `.page-stack` - `> * + *` rhythm between top-level blocks, replacing per-child margins

Then converted all nine content pages plus home to them, and fixed the individual defects above. Runs now uses `SectionHeading`'s `description` prop instead of a separate `<p>`, so the title and its subtitle read as one block.

Documented the skeleton in CLAUDE.md, including the two rules that would have prevented most of this: never add padding to a shell, never mix a stack/gap with margins on its children.

## Verification

- `npm run lint` clean, 224/224 tests pass, prettier clean
- Walked upload → validation → model in the browser, plus runs, compare, about, api-docs, home
- Measured after the change: 24px under every page title, uniform 32px between top-level blocks (validation went from `24 / 32 / 64` to `32 / 32 / 32`), shell gutter 16px on mobile and 48px on desktop on every page
- Home and short pages no longer scroll: home is exactly 720px in a 720px viewport, down from 862px+

Purely presentational; no behaviour or copy changes.