### PR TITLE
build: update the MAIVE version to v0.2.5

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ env:
   TF_VERSION: 1.12.0
   TG_VERSION: 0.62.1
   PROJECT_NAME: maive
-  MAIVE_TAG: v0.2.2
+  MAIVE_TAG: v0.2.5
   R_VERSION: 4.4.1
 
 jobs:

--- a/apps/react-ui/client/package.json
+++ b/apps/react-ui/client/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "client",
 	"version": "0.7.2-0",
-	"maiveTag": "v0.2.2",
+	"maiveTag": "v0.2.5",
 	"private": true,
 	"type": "commonjs",
 	"scripts": {


### PR DESCRIPTION
Bumps the pinned MAIVE R package from `v0.2.2` to `v0.2.5`, picking up three releases of fixes.

## What the UI gains

| Version | Change |
| --- | --- |
| 0.2.3 | Warnings for weak instruments |
| 0.2.4 | easymeta.org link fixes |
| 0.2.5 | `maive()` and `waive()` return unrounded estimates |

The 0.2.5 fix is the one that matters here. Estimates were previously rounded to 3 decimals before being returned, which distorted the downstream z-ratios, p-values and confidence intervals shown in the UI, and could zero out small standard errors entirely.

## Changes

Both pins the `set-maive-tag` script maintains:

- `.github/workflows/release.yml` (`env.MAIVE_TAG`): used by CI to build the R library image
- `apps/react-ui/client/package.json` (`maiveTag`): displayed in the UI, and the fallback when the `MAIVE_TAG` env var isn't set

Applied by hand rather than via `npm run set-maive-tag v0.2.5`, because that script needs `jq` and it isn't installed on this machine. The resulting diff is identical to what the script produces, and the tag was verified to exist at `PetrCala/MAIVE@c220d1c`.

## Deploy note

`get-rlib-hash.sh` folds `MAIVE_TAG` into the R library layer hash, so merging rebuilds that layer rather than reusing the cached `v0.2.2` image.

## Context

MAIVE 0.2.5 is separately submitted to CRAN and awaiting review. This bump does not depend on that: the lambda installs from the GitHub tag via `pak::pkg_install('PetrCala/MAIVE@${MAIVE_TAG}')`, not from CRAN.